### PR TITLE
fix(windows): zip extraction fails when primary download server is down

### DIFF
--- a/js/src/download.ts
+++ b/js/src/download.ts
@@ -89,8 +89,8 @@ export async function ensureBinary(): Promise<string> {
   if (!fs.existsSync(downloadedPath)) {
     throw new Error(
       `Download completed but binary not found at expected path: ${downloadedPath}. ` +
-        `This may indicate a packaging issue. Please report at ` +
-        `https://github.com/CloakHQ/cloakbrowser/issues`
+      `This may indicate a packaging issue. Please report at ` +
+      `https://github.com/CloakHQ/cloakbrowser/issues`
     );
   }
 
@@ -276,6 +276,9 @@ async function downloadFile(url: string, dest: string): Promise<void> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
 
+  // Create file stream early so we can ensure cleanup on error
+  const fileStream = createWriteStream(dest);
+
   try {
     const response = await fetch(url, {
       signal: controller.signal,
@@ -294,7 +297,6 @@ async function downloadFile(url: string, dest: string): Promise<void> {
     let downloaded = 0;
     let lastLoggedPct = -1;
 
-    const fileStream = createWriteStream(dest);
     const reader = response.body.getReader();
 
     // Stream chunks to file with progress logging
@@ -318,18 +320,31 @@ async function downloadFile(url: string, dest: string): Promise<void> {
       }
     }
 
-    // Wait for file stream to finish
+    // Wait for file stream to fully close (not just finish)
     await new Promise<void>((resolve, reject) => {
-      fileStream.end(() => resolve());
+      fileStream.end();
+      fileStream.on("close", () => resolve());
       fileStream.on("error", reject);
     });
 
     const sizeMB = Math.floor(fs.statSync(dest).size / (1024 * 1024));
     console.log(`[cloakbrowser] Download complete: ${sizeMB} MB`);
+  } catch (err) {
+    // Ensure file stream is destroyed on error to release the handle
+    if (!fileStream.destroyed) {
+      await new Promise<void>((resolve) => {
+        fileStream.destroy();
+        fileStream.on("close", () => resolve());
+        // Safety timeout in case close never fires
+        setTimeout(resolve, 2000);
+      });
+    }
+    throw err;
   } finally {
     clearTimeout(timeout);
   }
 }
+
 
 async function extractArchive(
   archivePath: string,
@@ -387,12 +402,16 @@ async function extractTar(archivePath: string, destDir: string): Promise<void> {
 }
 
 async function extractZip(archivePath: string, destDir: string): Promise<void> {
-  const { execFileSync } = await import("node:child_process");
-  // Use system unzip — available on Windows (PowerShell), macOS, and Linux
+  // Brief delay to ensure OS fully releases file handles (Windows)
+  await new Promise(resolve => setTimeout(resolve, 500));
+
   if (process.platform === "win32") {
+    // PowerShell 5.1's Expand-Archive uses .NET FileStream which can conflict
+    // with recently-closed Node.js file handles. Use ZipFile API directly.
     execFileSync("powershell", [
       "-NoProfile", "-Command",
-      `Expand-Archive -Path '${archivePath}' -DestinationPath '${destDir}' -Force`,
+      `Add-Type -AssemblyName System.IO.Compression.FileSystem; ` +
+      `[System.IO.Compression.ZipFile]::ExtractToDirectory('${archivePath}', '${destDir}')`,
     ], { timeout: 120_000 });
   } else {
     execFileSync("unzip", ["-o", archivePath, "-d", destDir], { timeout: 120_000 });
@@ -520,7 +539,7 @@ export async function checkWrapperUpdate(): Promise<void> {
     if (data.version && versionNewer(data.version, WRAPPER_VERSION)) {
       console.warn(
         `[cloakbrowser] Update available: ${WRAPPER_VERSION} → ${data.version}. ` +
-          `Run: npm install cloakbrowser@latest`
+        `Run: npm install cloakbrowser@latest`
       );
     }
   } catch {
@@ -567,10 +586,10 @@ async function checkAndDownloadUpdate(): Promise<void> {
 function maybeTriggerUpdateCheck(): void {
   // Wrapper update: once per process, not rate-limited
   if (!wrapperUpdateChecked) {
-    checkWrapperUpdate().catch(() => {});
+    checkWrapperUpdate().catch(() => { });
   }
 
   // Binary update: rate-limited to once per hour
   if (!shouldCheckForUpdate()) return;
-  checkAndDownloadUpdate().catch(() => {});
+  checkAndDownloadUpdate().catch(() => { });
 }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Problem</h2>
<p>On Windows, <code>ensureBinary()</code> consistently fails with <strong>“file in use by another process”</strong> when extracting the downloaded Chromium zip. This happens every time the primary download server (<code>cloakbrowser.dev</code>) is unavailable and the fallback to GitHub Releases is triggered.</p>
<p>The error appears as:</p>
<pre><code>The process cannot access the file
'C:\Users\...\.cloakbrowser\_download_xxx.zip'
because it is being used by another process.
</code></pre>
<p>This makes CloakBrowser <strong>completely unusable on first install</strong> for any Windows user when the primary CDN is down — which currently happens consistently (<code>terminated</code> error on every attempt).</p>
<h2>Root cause</h2>
<p>The bug is in <code>downloadFile()</code> inside <code>downloadAndExtract()</code>. Here is the exact sequence:</p>
<p><strong>Step 1</strong> — <code>downloadFile(primaryUrl, tmpPath)</code> is called:</p>
<ul>
<li><code>createWriteStream(tmpPath)</code> opens a file handle (handle #1)</li>
<li><code>fetch(primaryUrl)</code> starts but the server is down</li>
<li>The fetch throws <code>terminated</code></li>
<li>The function exits via the thrown error</li>
<li><strong><code>fileStream</code> is never closed or destroyed — handle #1 is leaked</strong></li>
</ul>
<p><strong>Step 2</strong> — <code>downloadFile(fallbackUrl, tmpPath)</code> is called on the same <code>tmpPath</code>:</p>
<ul>
<li><code>createWriteStream(tmpPath)</code> opens a NEW file handle (handle #2) on the same file</li>
<li><code>fetch(fallbackUrl)</code> succeeds, 526 MB downloaded</li>
<li><code>fileStream.end(() =&gt; resolve())</code> is called — handle #2 is closed</li>
<li>Download completes successfully</li>
</ul>
<p><strong>Step 3</strong> — <code>extractArchive(tmpPath, ...)</code> is called:</p>
<ul>
<li><code>extractZip()</code> spawns PowerShell to extract the zip</li>
<li>PowerShell tries to open the file but <strong>handle #1 from Step 1 is still open</strong></li>
<li>Windows returns <code>ERROR_SHARING_VIOLATION</code></li>
<li>Extraction fails, <code>chromium-145.0.7632.109.2</code> directory is empty</li>
<li><code>ensureBinary()</code> throws “binary not found”</li>
</ul>
<p><strong>Visual flow:</strong></p>
<pre><code>downloadFile(primaryUrl, tmpPath)
  └─ createWriteStream(tmpPath)    → handle #1 OPENED
  └─ fetch(primaryUrl)             → FAILS (terminated)
  └─ throw                         → handle #1 NEVER CLOSED ← BUG

downloadFile(fallbackUrl, tmpPath)
  └─ createWriteStream(tmpPath)    → handle #2 OPENED
  └─ fetch(fallbackUrl)            → OK (526 MB)
  └─ fileStream.end(callback)      → handle #2 CLOSED

extractZip(tmpPath, destDir)
  └─ PowerShell opens tmpPath      → BLOCKED by handle #1
  └─ ERROR_SHARING_VIOLATION       → EXTRACTION FAILS
</code></pre>
<h2>Additional issue</h2>
<p>Even when the primary server works (no fallback), there is a secondary problem: <code>downloadFile()</code> waits for the <code>finish</code> event via <code>fileStream.end(() =&gt; resolve())</code>. On Windows, <code>finish</code> fires before the OS fully releases the file handle. The <code>close</code> event is the correct signal that the file descriptor is freed.</p>
<h2>Fix</h2>
<p>Two changes in <code>downloadFile()</code>:</p>
<p><strong>1. Destroy fileStream on error (fixes the primary bug):</strong><br>
The <code>createWriteStream</code> is now created before the try block, and the catch handler calls <code>fileStream.destroy()</code> followed by waiting for the <code>close</code> event. This guarantees the OS handle is released even when the download fails.</p>
<p><strong>2. Wait for <code>close</code> instead of <code>finish</code> on success (fixes secondary issue):</strong><br>
Changed from <code>fileStream.end(() =&gt; resolve())</code> (listens for <code>finish</code>) to <code>fileStream.end()</code> + <code>fileStream.on("close", () =&gt; resolve())</code>. The <code>close</code> event fires after the file descriptor is fully released by the OS.</p>
<p><strong>3. Safety delay in <code>extractZip()</code> (defense in depth):</strong><br>
Added a 500ms delay before extraction and switched from <code>Expand-Archive</code> to <code>ZipFile.ExtractToDirectory</code> for more predictable behavior on PowerShell 5.1.</p>
<h2>Reproduction</h2>
<p>Save as <code>test-repro.mjs</code> and run with <code>node test-repro.mjs</code> on Windows:</p>
<pre><code class="language-js">import fs from 'node:fs';
import { createWriteStream } from 'node:fs';
import { execSync } from 'node:child_process';
import path from 'node:path';

const dir = path.join(process.env.USERPROFILE, '.cloakbrowser');
fs.mkdirSync(dir, { recursive: true });
const zip = path.join(dir, '_download_repro.zip');
const dest = path.join(dir, 'repro-extract');
const GITHUB_URL = 'https://github.com/CloakHQ/cloakbrowser/releases/download/chromium-v145.0.7632.109.2/cloakbrowser-windows-x64.zip';
const DEAD_URL = 'https://cloakbrowser.dev/chromium-v145.0.7632.109.2/cloakbrowser-windows-x64.zip';

async function downloadFile(url, filepath) {
  const fileStream = createWriteStream(filepath);
  const resp = await fetch(url, { redirect: 'follow' });
  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
  const reader = resp.body.getReader();
  while (true) {
    const { done, value } = await reader.read();
    if (done) break;
    fileStream.write(value);
  }
  await new Promise((res, rej) =&gt; { fileStream.end(() =&gt; res()); fileStream.on('error', rej); });
}

console.log('Step 1: Primary download (will fail)...');
try { await downloadFile(DEAD_URL, zip); }
catch (e) { console.log('  Failed:', e.message); }

console.log('Step 2: Fallback download (same file path)...');
await downloadFile(GITHUB_URL, zip);
console.log('  Done:', Math.round(fs.statSync(zip).size / 1024 / 1024), 'MB');

console.log('Step 3: Extract...');
if (fs.existsSync(dest)) fs.rmSync(dest, { recursive: true, force: true });
fs.mkdirSync(dest, { recursive: true });
try {
  execSync(`powershell -NoProfile -Command "Expand-Archive -Path '${zip}' -DestinationPath '${dest}' -Force"`, { timeout: 120000 });
  console.log('  Result: SUCCESS');
} catch {
  console.log('  Result: FAILED — file locked by leaked handle from Step 1');
}

if (fs.existsSync(dest)) fs.rmSync(dest, { recursive: true, force: true });
try { fs.unlinkSync(zip); } catch {}
</code></pre>
<p>Expected output on current version:</p>
<pre><code>Step 1: Primary download (will fail)...
  Failed: terminated
Step 2: Fallback download (same file path)...
  Done: 526 MB
Step 3: Extract...
  Result: FAILED — file locked by leaked handle from Step 1
</code></pre>
<h2>Actual test logs</h2>
<p><strong>Original <code>ensureBinary()</code> from npm — FAIL (ran 3 times, failed every time):</strong></p>
<pre><code>PS&gt; node -e "import('cloakbrowser').then(m =&gt; m.ensureBinary()).then(p =&gt; console.log('PASS:', p)).catch(e =&gt; console.log('FAIL:', e.message.substring(0, 300)))"

[cloakbrowser] Stealth Chromium 145.0.7632.109.2 not found. Downloading for windows-x64...
[cloakbrowser] Downloading from https://cloakbrowser.dev/chromium-v145.0.7632.109.2/cloakbrowser-windows-x64.zip
[cloakbrowser] Primary download failed (terminated), trying GitHub Releases...
[cloakbrowser] Downloading from https://github.com/CloakHQ/cloakbrowser/releases/download/chromium-v145.0.7632.109.2/cloakbrowser-windows-x64.zip
[cloakbrowser] Download progress: 9% (47/526 MB)
...
[cloakbrowser] Download progress: 99% (521/526 MB)
[cloakbrowser] Download complete: 526 MB
[cloakbrowser] Checksum verified: SHA-256 OK
[cloakbrowser] Extracting to C:\Users\krivc\.cloakbrowser\chromium-145.0.7632.109.2
FAIL: Command failed: powershell ... "The process cannot access the file
'C:\Users\krivc\.cloakbrowser\_download_1772619170783.zip'
because it is being used by another process."
</code></pre>
<p><strong>Isolated handle leak proof (test-lock5.mjs):</strong></p>
<pre><code>Step 1: Primary download (cloakbrowser.dev — will likely fail)...
  Primary: FAILED — terminated
Step 2: Fallback download (GitHub)...
  Downloaded: 526 MB
Step 3: Expand-Archive...
  Expand-Archive: SUCCESS (with error output — forced through lock)
Step 4: ZipFile API...
  ZipFile: FAILED — file locked!
</code></pre>
<p><strong>Fixed <code>ensureBinary()</code> from local fork — PASS:</strong></p>
<pre><code>PS&gt; node -e "import('./dist/download.js').then(m =&gt; m.ensureBinary()).then(p =&gt; console.log('PASS:', p))"

[cloakbrowser] Stealth Chromium 145.0.7632.109.2 not found. Downloading for windows-x64...
[cloakbrowser] Downloading from https://cloakbrowser.dev/chromium-v145.0.7632.109.2/cloakbrowser-windows-x64.zip
[cloakbrowser] Primary download failed (terminated), trying GitHub Releases...
[cloakbrowser] Downloading from https://github.com/CloakHQ/cloakbrowser/releases/download/chromium-v145.0.7632.109.2/cloakbrowser-windows-x64.zip
[cloakbrowser] Download progress: 9% (47/526 MB)
...
[cloakbrowser] Download progress: 99% (521/526 MB)
[cloakbrowser] Download complete: 526 MB
[cloakbrowser] Checksum verified: SHA-256 OK
[cloakbrowser] Extracting to C:\Users\krivc\.cloakbrowser\chromium-145.0.7632.109.2
[cloakbrowser] Binary ready: C:\Users\krivc\.cloakbrowser\chromium-145.0.7632.109.2\chrome.exe
PASS: C:\Users\krivc\.cloakbrowser\chromium-145.0.7632.109.2\chrome.exe
</code></pre>
<h2>Test results</h2>

Scenario | Before | After
-- | -- | --
ensureBinary() — primary down, fallback, extract | FAIL (file locked) | PASS
ensureBinary() — primary works, extract | PASS | PASS
Direct downloadFile() + extract (no fallback) | PASS | PASS


<h2>Environment</h2>
<ul>
<li>Windows 11 x64</li>
<li>Node.js 18.20.4</li>
<li>PowerShell 5.1</li>
<li>cloakbrowser 0.3.4</li>
</ul>
</body></html><!--EndFragment-->
</body>
</html>