### PR TITLE
fix(python): reduce download connect timeout to 10s, read to 60s for …

### DIFF
--- a/cloakbrowser/download.py
+++ b/cloakbrowser/download.py
@@ -44,7 +44,7 @@ from .config import (
 logger = logging.getLogger("cloakbrowser")
 
 # Timeout for download (large binary, allow 10 min)
-DOWNLOAD_TIMEOUT = 600.0
+DOWNLOAD_TIMEOUT = httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=10.0)
 
 # Auto-update check interval (1 hour)
 UPDATE_CHECK_INTERVAL = 3600


### PR DESCRIPTION
## Problem

When the primary download server (cloakbrowser.dev) is unreachable, `httpx.stream()` waits the full `DOWNLOAD_TIMEOUT` (600 seconds / 10 minutes) before falling back to GitHub Releases. First-time users on any platform sit staring at a frozen terminal for 10+ minutes.

## Root cause

`DOWNLOAD_TIMEOUT = 600.0` is a single float, which httpx applies to **all** phases equally — connect, read, write, pool. A dead server that accepts the TCP connection but never sends data holds the stream open for the full 600s on the read phase.

## Fix

Replace the single float with granular timeouts:

```python
DOWNLOAD_TIMEOUT = httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=10.0)
```

- **connect=10s** — fail fast if server doesn't accept connection
- **read=60s** — if server connects but sends no data, fail after 60s (not 600s)
- **write/pool=10s** — reasonable defaults

Note: `read=60s` is conservative on purpose — slower connections downloading the 526 MB binary won't be interrupted since the read timer resets with each received chunk. This could be reduced further (e.g. `read=30s`) if needed.

## Before / After

| Scenario | Before | After |
|---|---|---|
| Primary down → fallback → complete | ~692s (11.5 min) | ~170s (2.8 min) |
| Primary works → complete | ~90s | ~90s (unchanged) |

Tested on Windows 11, Python 3.10, cloakbrowser 0.3.8.

## Note

The JS wrapper had a related issue (PR #23 — file handle leak causing extraction failure). The Python wrapper doesn't have the file handle bug (context manager `with open()` closes correctly), but the timeout makes first-run UX equally bad when the primary server is down.
