### PR TITLE
fix: ensure pw.stop() runs even if browser.close() raises or is cancelled

### DIFF
--- a/cloakbrowser/browser.py
+++ b/cloakbrowser/browser.py
@@ -120,8 +120,10 @@ def launch(
     _original_close = browser.close
 
     def _close_with_cleanup() -> None:
-        _original_close()
-        pw.stop()
+        try:
+            _original_close()
+        finally:
+            pw.stop()
 
     browser.close = _close_with_cleanup
 
@@ -203,8 +205,10 @@ async def launch_async(  # noqa: C901
     _original_close = browser.close
 
     async def _close_with_cleanup() -> None:
-        await _original_close()
-        await pw.stop()
+        try:
+            await _original_close()
+        finally:
+            await pw.stop()
 
     browser.close = _close_with_cleanup
 
@@ -314,8 +318,10 @@ def launch_persistent_context(
     _original_close = context.close
 
     def _close_with_cleanup() -> None:
-        _original_close()
-        pw.stop()
+        try:
+            _original_close()
+        finally:
+            pw.stop()
 
     context.close = _close_with_cleanup
 
@@ -427,8 +433,10 @@ async def launch_persistent_context_async(
     _original_close = context.close
 
     async def _close_with_cleanup() -> None:
-        await _original_close()
-        await pw.stop()
+        try:
+            await _original_close()
+        finally:
+            await pw.stop()
 
     context.close = _close_with_cleanup
 
@@ -514,8 +522,10 @@ def launch_context(
     _original_ctx_close = context.close
 
     def _close_context_with_cleanup() -> None:
-        _original_ctx_close()
-        browser.close()
+        try:
+            _original_ctx_close()
+        finally:
+            browser.close()
 
     context.close = _close_context_with_cleanup
 


### PR DESCRIPTION
Greetings from https://github.com/dgtlmoon/changedetection.io <3

**Problem - Session cleanups can be improved**

All four launch functions patch browser.close() / context.close() to also call pw.stop(), which is the right approach. However the patched functions have no error handling:

```
  async def _close_with_cleanup() -> None:
      await _original_close()   # if this raises or is CancelledError...
      await pw.stop()           # ...this line is never reached
```

This means the Playwright Node.js subprocess can be left running if:

- The Chromium process hangs and the caller uses asyncio.wait_for(browser.close(), timeout=N)  the timeout cancels the coroutine with CancelledError before pw.stop() runs
- _original_close() raises any exception (renderer crash, already-closed browser, etc.)

The result is an orphaned playwright Node process, open DevTools sockets, and /tmp/playwright-* profile directories that are only cleaned up when that process eventually dies on its own.

**Fix**

Wrap each patched cleanup function in try/finally so pw.stop() is guaranteed to run regardless of what _original_close() does:

```
  # Before
  async def _close_with_cleanup() -> None:
      await _original_close()
      await pw.stop()

  # After
  async def _close_with_cleanup() -> None:
      try:
          await _original_close()
      finally:
          await pw.stop()
```

Same one-line change applies to the sync variants (launch, launch_persistent_context, launch_persistent_context_async, launch_context).

Why this matters in practice

Callers that defensively wrap browser.close() with a timeout — which is the correct thing to do for a hung page — currently get a resource leak as a side-effect of doing the right thing:

```
  # Caller does the right thing...
  try:
      await asyncio.wait_for(browser.close(), timeout=5.0)
  except asyncio.TimeoutError:
      pass
  # ...but pw.stop() was never called, playwright process stays alive
```
After this fix, pw.stop() runs in all cases.
