### PR TITLE
feat: add types to `options` argument

### DIFF
--- a/js/src/human-puppeteer/index.ts
+++ b/js/src/human-puppeteer/index.ts
@@ -336,10 +336,11 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
     clickCount?: number;
     count?: number;
     delay?: number;
+    human_config?: Partial<HumanConfig>;
     timeout?: number;
   })) => {
     await ensureCursorInit();
-    const callCfg = mergeConfig(cfg, options);
+    const callCfg = mergeConfig(cfg, options?.human_config ?? options);
     if (callCfg.idle_between_actions) {
       await humanIdle(raw, cursor.x, cursor.y, callCfg);
     }
@@ -365,9 +366,9 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // ==== hover ====
-  const humanHoverFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number })) => {
+  const humanHoverFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await ensureCursorInit();
-    const callCfg = mergeConfig(cfg, options);
+    const callCfg = mergeConfig(cfg, options?.human_config ?? options);
     if (callCfg.idle_between_actions) {
       await humanIdle(raw, cursor.x, cursor.y, callCfg);
     }
@@ -383,9 +384,10 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   // ==== type ====
   const humanTypeFn = async (selector: string, text: string, options?: Partial<HumanConfig> & ({
     delay?: number;
+    human_config?: Partial<HumanConfig>;
     timeout?: number;
   })) => {
-    const callCfg = mergeConfig(cfg, options);
+    const callCfg = mergeConfig(cfg, options?.human_config ?? options);
     await sleep(randRange(callCfg.field_switch_delay));
     await humanClickFn(selector, options);
     await sleep(rand(100, 250));
@@ -408,7 +410,7 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // ==== tap ====
-  const humanTapFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number })) => {
+  const humanTapFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await humanClickFn(selector, options);
   };
 
@@ -674,8 +676,9 @@ function patchSingleElementHandle(
     clickCount?: number;
     count?: number;
     delay?: number;
+    human_config?: Partial<HumanConfig>;
   })) => {
-    const callCfg = mergeConfig(cfg, options);
+    const callCfg = mergeConfig(cfg, options?.human_config ?? options);
     const info = await moveToElement(callCfg);
     if (!info) return origElClick(options);
 
@@ -698,8 +701,8 @@ function patchSingleElementHandle(
   };
 
   // --- el.type() ---
-  (el as any).type = async (text: string, options?: Partial<HumanConfig> & ({ delay?: number })) => {
-    const callCfg = mergeConfig(cfg, options);
+  (el as any).type = async (text: string, options?: Partial<HumanConfig> & ({ delay?: number; human_config?: Partial<HumanConfig> })) => {
+    const callCfg = mergeConfig(cfg, options?.human_config ?? options);
     const info = await moveToElement(callCfg);
     if (!info) return origElType(text, options);
     await humanClick(raw, info.isInp, callCfg);
@@ -715,8 +718,8 @@ function patchSingleElementHandle(
   // page.click(). Only patched when the underlying ElementHandle exposes
   // ``scrollIntoView`` (Puppeteer v22+).
   if (origElScrollIntoView) {
-    (el as any).scrollIntoView = async (options?: Partial<HumanConfig>) => {
-      const callCfg = mergeConfig(cfg, options);
+    (el as any).scrollIntoView = async (options?: Partial<HumanConfig> & { human_config?: Partial<HumanConfig> }) => {
+      const callCfg = mergeConfig(cfg, options?.human_config ?? options);
       await (page as any)._ensureCursorInit();
       try {
         const { cursorX, cursorY } = await humanScrollIntoView(
@@ -872,17 +875,19 @@ function patchSingleFrame(
     clickCount?: number;
     count?: number;
     delay?: number;
+    human_config?: Partial<HumanConfig>;
     timeout?: number;
   })) => {
     await (page as any).click(selector, options);
   };
 
-  (frame as any).hover = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number })) => {
+  (frame as any).hover = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await (page as any).hover(selector, options);
   };
 
   (frame as any).type = async (selector: string, text: string, options?: Partial<HumanConfig> & ({
     delay?: number;
+    human_config?: Partial<HumanConfig>;
     timeout?: number;
   })) => {
     await (page as any).type(selector, text, options);
@@ -898,7 +903,7 @@ function patchSingleFrame(
     await (page as any).focus(selector);
   };
 
-  (frame as any).tap = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number })) => {
+  (frame as any).tap = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await (page as any).click(selector, options);
   };
 

--- a/js/src/human-puppeteer/index.ts
+++ b/js/src/human-puppeteer/index.ts
@@ -319,7 +319,11 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   }
 
   // ==== goto ====
-  const humanGoto = async (url: string, options?: any) => {
+  const humanGoto = async (url: string, options?: {
+    referer?: string;
+    timeout?: number;
+    waitUntil?: 'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2';
+  }) => {
     const response = await originals.goto(url, options);
     stealth.invalidate();
     patchFrames(page, cfg, cursor, raw, rawKb, originals, stealth);
@@ -327,11 +331,17 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // ==== click (with clickCount support for dblclick) ====
-  const humanClickFn = async (selector: string, options?: any) => {
+  const humanClickFn = async (selector: string, options?: Partial<HumanConfig> & ({
+    button?: 'left' | 'right' | 'middle' | 'back' | 'forward';
+    clickCount?: number;
+    count?: number;
+    delay?: number;
+    timeout?: number;
+  })) => {
     await ensureCursorInit();
-    const callCfg = mergeConfig(cfg, options?.human_config);
+    const callCfg = mergeConfig(cfg, options);
     if (callCfg.idle_between_actions) {
-      await humanIdle(raw, rand(callCfg.idle_between_duration[0], callCfg.idle_between_duration[1]), cursor.x, cursor.y, callCfg);
+      await humanIdle(raw, cursor.x, cursor.y, callCfg);
     }
     const { box, cursorX, cursorY } = await scrollToElement(page, raw, selector, cursor.x, cursor.y, callCfg, options?.timeout);
     cursor.x = cursorX;
@@ -355,11 +365,11 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // ==== hover ====
-  const humanHoverFn = async (selector: string, options?: any) => {
+  const humanHoverFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number })) => {
     await ensureCursorInit();
-    const callCfg = mergeConfig(cfg, options?.human_config);
+    const callCfg = mergeConfig(cfg, options);
     if (callCfg.idle_between_actions) {
-      await humanIdle(raw, rand(callCfg.idle_between_duration[0], callCfg.idle_between_duration[1]), cursor.x, cursor.y, callCfg);
+      await humanIdle(raw, cursor.x, cursor.y, callCfg);
     }
     const { box, cursorX, cursorY } = await scrollToElement(page, raw, selector, cursor.x, cursor.y, callCfg, options?.timeout);
     cursor.x = cursorX;
@@ -371,8 +381,11 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // ==== type ====
-  const humanTypeFn = async (selector: string, text: string, options?: any) => {
-    const callCfg = mergeConfig(cfg, options?.human_config);
+  const humanTypeFn = async (selector: string, text: string, options?: Partial<HumanConfig> & ({
+    delay?: number;
+    timeout?: number;
+  })) => {
+    const callCfg = mergeConfig(cfg, options);
     await sleep(randRange(callCfg.field_switch_delay));
     await humanClickFn(selector, options);
     await sleep(rand(100, 250));
@@ -395,7 +408,7 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // ==== tap ====
-  const humanTapFn = async (selector: string, options?: any) => {
+  const humanTapFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number })) => {
     await humanClickFn(selector, options);
   };
 
@@ -413,14 +426,19 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   // ============================================================
   // Mouse patches
   // ============================================================
-  page.mouse.move = async (x: number, y: number, options?: any) => {
+  page.mouse.move = async (x: number, y: number, options?: { steps?: number }) => {
     await ensureCursorInit();
     await humanMove(raw, cursor.x, cursor.y, x, y, cfg);
     cursor.x = x;
     cursor.y = y;
   };
 
-  page.mouse.click = async (x: number, y: number, options?: any) => {
+  page.mouse.click = async (x: number, y: number, options?: {
+    button?: 'left' | 'right' | 'middle' | 'back' | 'forward';
+    clickCount?: number;
+    count?: number;
+    delay?: number;
+  }) => {
     await ensureCursorInit();
     await humanMove(raw, cursor.x, cursor.y, x, y, cfg);
     cursor.x = x;
@@ -455,7 +473,7 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
     (page.mouse as any).dragAndDrop = async (
       start: { x: number; y: number },
       target: { x: number; y: number },
-      options?: any,
+      options?: { delay?: number },
     ) => {
       await ensureCursorInit();
       await humanMove(raw, cursor.x, cursor.y, start.x, start.y, cfg);
@@ -475,12 +493,12 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   // ============================================================
   // Keyboard patches
   // ============================================================
-  page.keyboard.type = async (text: string, options?: any) => {
+  page.keyboard.type = async (text: string, options?: { delay?: number }) => {
     const cdp = await ensureCdp();
     await humanType(page, rawKb, text, cfg, cdp);
   };
 
-  page.keyboard.press = async (key: any, options?: any) => {
+  page.keyboard.press = async (key: any, options?: { delay?: number }) => {
     await sleep(rand(20, 60));
     await originals.keyboardDown(key as any);
     await sleep(randRange(cfg.key_hold));
@@ -551,7 +569,11 @@ function patchElementHandle(
     return els;
   };
 
-  (page as any).waitForSelector = async (selector: string, options?: any) => {
+  (page as any).waitForSelector = async (selector: string, options?: {
+    hidden?: boolean;
+    timeout?: number;
+    visible?: boolean;
+  }) => {
     const el = await origWaitForSelector(selector, options);
     if (el) patchSingleElementHandle(el, page, cfg, cursor, raw, rawKb, originals, stealth);
     return el;
@@ -603,14 +625,18 @@ function patchSingleElementHandle(
     return children;
   };
 
-  (el as any).waitForSelector = async (selector: string, options?: any) => {
+  (el as any).waitForSelector = async (selector: string, options?: {
+    hidden?: boolean;
+    timeout?: number;
+    visible?: boolean;
+  }) => {
     const child = await origElWaitForSelector(selector, options);
     if (child) patchSingleElementHandle(child, page, cfg, cursor, raw, rawKb, originals, stealth);
     return child;
   };
 
   // --- Helper: get box and move cursor. Accepts a per-call ``callCfg``
-  // so type/fill overrides like ``el.type(text, { human_config: {...} })``
+  // so type/fill overrides like ``el.type(text, { typing_delay: 30 })``
   // carry through to mouse timing for that single call. Also scrolls into
   // view first so off-screen elements work (#129, #172 follow-up).
   const moveToElement = async (callCfg: HumanConfig = cfg) => {
@@ -633,7 +659,7 @@ function patchSingleElementHandle(
     const target = clickTarget(box, isInp, callCfg);
 
     if (callCfg.idle_between_actions) {
-      await humanIdle(raw, rand(callCfg.idle_between_duration[0], callCfg.idle_between_duration[1]), cursor.x, cursor.y, callCfg);
+      await humanIdle(raw, cursor.x, cursor.y, callCfg);
     }
 
     await humanMove(raw, cursor.x, cursor.y, target.x, target.y, callCfg);
@@ -643,8 +669,13 @@ function patchSingleElementHandle(
   };
 
   // --- el.click() ---
-  (el as any).click = async (options?: any) => {
-    const callCfg = mergeConfig(cfg, options?.human_config);
+  (el as any).click = async (options?: Partial<HumanConfig> & ({
+    button?: 'left' | 'right' | 'middle' | 'back' | 'forward';
+    clickCount?: number;
+    count?: number;
+    delay?: number;
+  })) => {
+    const callCfg = mergeConfig(cfg, options);
     const info = await moveToElement(callCfg);
     if (!info) return origElClick(options);
 
@@ -667,8 +698,8 @@ function patchSingleElementHandle(
   };
 
   // --- el.type() ---
-  (el as any).type = async (text: string, options?: any) => {
-    const callCfg = mergeConfig(cfg, options?.human_config);
+  (el as any).type = async (text: string, options?: Partial<HumanConfig> & ({ delay?: number })) => {
+    const callCfg = mergeConfig(cfg, options);
     const info = await moveToElement(callCfg);
     if (!info) return origElType(text, options);
     await humanClick(raw, info.isInp, callCfg);
@@ -684,8 +715,8 @@ function patchSingleElementHandle(
   // page.click(). Only patched when the underlying ElementHandle exposes
   // ``scrollIntoView`` (Puppeteer v22+).
   if (origElScrollIntoView) {
-    (el as any).scrollIntoView = async (options?: any) => {
-      const callCfg = mergeConfig(cfg, options?.human_config);
+    (el as any).scrollIntoView = async (options?: Partial<HumanConfig>) => {
+      const callCfg = mergeConfig(cfg, options);
       await (page as any)._ensureCursorInit();
       try {
         const { cursorX, cursorY } = await humanScrollIntoView(
@@ -703,7 +734,7 @@ function patchSingleElementHandle(
 
   // --- el.press() ---
   if (origElPress) {
-    (el as any).press = async (key: string, options?: any) => {
+    (el as any).press = async (key: string, options?: { delay?: number }) => {
       await sleep(rand(20, 60));
       await originals.keyboardDown(key as any);
       await sleep(randRange(cfg.key_hold));
@@ -742,7 +773,7 @@ function patchSingleElementHandle(
 
   // --- el.drop() ---
   if (origElDrop) {
-    (el as any).drop = async (draggable: ElementHandle, options?: any) => {
+    (el as any).drop = async (draggable: ElementHandle, options?: { delay?: number }) => {
       const srcBox = await draggable.boundingBox();
       const tgtBox = await el.boundingBox();
 
@@ -772,7 +803,7 @@ function patchSingleElementHandle(
 
   // --- el.dragAndDrop() ---
   if (origElDragAndDrop) {
-    (el as any).dragAndDrop = async (targetEl: ElementHandle, options?: any) => {
+    (el as any).dragAndDrop = async (targetEl: ElementHandle, options?: { delay?: number }) => {
       const srcBox = await el.boundingBox();
       const tgtBox = await targetEl.boundingBox();
 
@@ -836,15 +867,24 @@ function patchSingleFrame(
 
   const origFrameSelect = frame.select.bind(frame);
 
-  (frame as any).click = async (selector: string, options?: any) => {
+  (frame as any).click = async (selector: string, options?: Partial<HumanConfig> & ({
+    button?: 'left' | 'right' | 'middle' | 'back' | 'forward';
+    clickCount?: number;
+    count?: number;
+    delay?: number;
+    timeout?: number;
+  })) => {
     await (page as any).click(selector, options);
   };
 
-  (frame as any).hover = async (selector: string, options?: any) => {
+  (frame as any).hover = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number })) => {
     await (page as any).hover(selector, options);
   };
 
-  (frame as any).type = async (selector: string, text: string, options?: any) => {
+  (frame as any).type = async (selector: string, text: string, options?: Partial<HumanConfig> & ({
+    delay?: number;
+    timeout?: number;
+  })) => {
     await (page as any).type(selector, text, options);
   };
 
@@ -858,7 +898,7 @@ function patchSingleFrame(
     await (page as any).focus(selector);
   };
 
-  (frame as any).tap = async (selector: string, options?: any) => {
+  (frame as any).tap = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number })) => {
     await (page as any).click(selector, options);
   };
 
@@ -881,7 +921,11 @@ function patchSingleFrame(
     return els;
   };
 
-  (frame as any).waitForSelector = async (selector: string, options?: any) => {
+  (frame as any).waitForSelector = async (selector: string, options?: {
+    hidden?: boolean;
+    timeout?: number;
+    visible?: boolean;
+  }) => {
     const el = await origFrameWaitForSelector(selector, options);
     if (el) patchSingleElementHandle(el, page, cfg, cursor, raw, rawKb, originals, stealth);
     return el;
@@ -927,7 +971,7 @@ export function patchBrowser(browser: Browser, cfg: HumanConfig): void {
   for (const methodName of ['createBrowserContext', 'createIncognitoBrowserContext'] as const) {
     if (typeof (browser as any)[methodName] === 'function') {
       const origCreateContext = (browser as any)[methodName].bind(browser);
-      (browser as any)[methodName] = async (options?: any) => {
+      (browser as any)[methodName] = async (options?: Parameters<typeof origCreateContext>[0]) => {
         const context: BrowserContext = await origCreateContext(options);
 
         const origCtxNewPage = context.newPage.bind(context);

--- a/js/src/human/elementhandle.ts
+++ b/js/src/human/elementhandle.ts
@@ -130,7 +130,7 @@ export function patchSingleElementHandle(
     strict?: boolean;
     timeout?: number;
   }) => {
-    const child = await origElWaitForSelector(selector, options);
+    const child = await origElWaitForSelector(selector, options ?? {});
     if (child) patchSingleElementHandle(child, page, cfg, cursor, raw, rawKb, originals, stealth);
     return child;
   };
@@ -437,7 +437,7 @@ export function patchPageElementHandles(
       strict?: boolean;
       timeout?: number;
     }) => {
-      const el = await origWaitForSelector(selector, options);
+      const el = await origWaitForSelector(selector, options ?? {});
       if (el) patchSingleElementHandle(el, page, cfg, cursor, raw, rawKb, originals, stealth);
       return el;
     };
@@ -489,7 +489,7 @@ export function patchFrameElementHandles(
       strict?: boolean;
       timeout?: number;
     }) => {
-      const el = await origFrameWaitForSelector(selector, options);
+      const el = await origFrameWaitForSelector(selector, options ?? {});
       if (el) patchSingleElementHandle(el, page, cfg, cursor, raw, rawKb, originals, stealth);
       return el;
     };

--- a/js/src/human/elementhandle.ts
+++ b/js/src/human/elementhandle.ts
@@ -164,7 +164,7 @@ export function patchSingleElementHandle(
     const target = clickTarget(box, isInp, callCfg);
 
     if (callCfg.idle_between_actions) {
-      await humanIdle(raw, rand(callCfg.idle_between_duration[0], callCfg.idle_between_duration[1]), cursor.x, cursor.y, callCfg);
+      await humanIdle(raw, cursor.x, cursor.y, callCfg);
     }
 
     await humanMove(raw, cursor.x, cursor.y, target.x, target.y, callCfg);

--- a/js/src/human/elementhandle.ts
+++ b/js/src/human/elementhandle.ts
@@ -125,7 +125,11 @@ export function patchSingleElementHandle(
     return children;
   };
 
-  (el as any).waitForSelector = async (selector: string, options?: any) => {
+  (el as any).waitForSelector = async (selector: string, options?: {
+    state?: 'attached' | 'detached' | 'visible' | 'hidden';
+    strict?: boolean;
+    timeout?: number;
+  }) => {
     const child = await origElWaitForSelector(selector, options);
     if (child) patchSingleElementHandle(child, page, cfg, cursor, raw, rawKb, originals, stealth);
     return child;
@@ -133,8 +137,9 @@ export function patchSingleElementHandle(
 
   // --- Helper: get bounding box and move cursor to element ---
   // Accepts a per-call ``callCfg`` so type/fill overrides like
-  // ``el.type(text, { human_config: { typing_delay: 30 } })`` carry through to
-  // mouse movement & idle timing for that single call.
+  // ``el.type(text, { human_config: { typing_delay: 30 } })`` or
+  // ``el.type(text, { typing_delay: 30 })`` carry through to mouse movement
+  // & idle timing for that single call.
   // Also scrolls the element into view first so off-screen elements work
   // (#129, #172 follow-up): otherwise boundingBox() returns null and we'd
   // silently fall back to the unpatched native method.
@@ -174,16 +179,37 @@ export function patchSingleElementHandle(
   };
 
   // --- el.click() ---
-  (el as any).click = async (options?: any) => {
-    const callCfg = mergeConfig(cfg, options?.human_config);
+  (el as any).click = async (options?: Partial<HumanConfig> & ({
+    button?: 'left' | 'right' | 'middle';
+    clickCount?: number;
+    delay?: number;
+    force?: boolean;
+    human_config?: Partial<HumanConfig>;
+    modifiers?: Array<'Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift'>;
+    noWaitAfter?: boolean;
+    position?: { x: number; y: number };
+    timeout?: number;
+    trial?: boolean;
+  })) => {
+    const callCfg = mergeConfig(cfg, options?.human_config ?? options);
     const info = await moveToElement(callCfg);
     if (!info) return origElClick(options);
     await humanClick(raw, info.isInp, callCfg);
   };
 
   // --- el.dblclick() ---
-  (el as any).dblclick = async (options?: any) => {
-    const callCfg = mergeConfig(cfg, options?.human_config);
+  (el as any).dblclick = async (options?: Partial<HumanConfig> & ({
+    button?: 'left' | 'right' | 'middle';
+    delay?: number;
+    force?: boolean;
+    human_config?: Partial<HumanConfig>;
+    modifiers?: Array<'Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift'>;
+    noWaitAfter?: boolean;
+    position?: { x: number; y: number };
+    timeout?: number;
+    trial?: boolean;
+  })) => {
+    const callCfg = mergeConfig(cfg, options?.human_config ?? options);
     const info = await moveToElement(callCfg);
     if (!info) return origElDblclick(options);
     await raw.down({ clickCount: 2 });
@@ -192,16 +218,28 @@ export function patchSingleElementHandle(
   };
 
   // --- el.hover() ---
-  (el as any).hover = async (options?: any) => {
-    const callCfg = mergeConfig(cfg, options?.human_config);
+  (el as any).hover = async (options?: Partial<HumanConfig> & ({
+    force?: boolean;
+    human_config?: Partial<HumanConfig>;
+    modifiers?: Array<'Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift'>;
+    position?: { x: number; y: number };
+    timeout?: number;
+    trial?: boolean;
+  })) => {
+    const callCfg = mergeConfig(cfg, options?.human_config ?? options);
     const info = await moveToElement(callCfg);
     if (!info) return origElHover(options);
     // Just move — no click
   };
 
   // --- el.type() ---
-  (el as any).type = async (text: string, options?: any) => {
-    const callCfg = mergeConfig(cfg, options?.human_config);
+  (el as any).type = async (text: string, options?: Partial<HumanConfig> & ({
+    delay?: number;
+    human_config?: Partial<HumanConfig>;
+    noWaitAfter?: boolean;
+    timeout?: number;
+  })) => {
+    const callCfg = mergeConfig(cfg, options?.human_config ?? options);
     const info = await moveToElement(callCfg);
     if (!info) return origElType(text, options);
     await humanClick(raw, info.isInp, callCfg);
@@ -212,8 +250,13 @@ export function patchSingleElementHandle(
   };
 
   // --- el.fill() ---
-  (el as any).fill = async (value: string, options?: any) => {
-    const callCfg = mergeConfig(cfg, options?.human_config);
+  (el as any).fill = async (value: string, options?: Partial<HumanConfig> & ({
+    force?: boolean;
+    human_config?: Partial<HumanConfig>;
+    noWaitAfter?: boolean;
+    timeout?: number;
+  })) => {
+    const callCfg = mergeConfig(cfg, options?.human_config ?? options);
     const info = await moveToElement(callCfg);
     if (!info) return origElFill(value, options);
     await humanClick(raw, info.isInp, callCfg);
@@ -229,7 +272,7 @@ export function patchSingleElementHandle(
   };
 
   // --- el.press() ---
-  (el as any).press = async (key: string, options?: any) => {
+  (el as any).press = async (key: string, options?: { delay?: number; noWaitAfter?: boolean; timeout?: number }) => {
     await sleep(rand(20, 60));
     await originals.keyboardDown(key);
     await sleep(randRange(cfg.key_hold));
@@ -237,7 +280,11 @@ export function patchSingleElementHandle(
   };
 
   // --- el.selectOption() ---
-  (el as any).selectOption = async (values: any, options?: any) => {
+  (el as any).selectOption = async (values: any, options?: {
+    force?: boolean;
+    noWaitAfter?: boolean;
+    timeout?: number;
+  }) => {
     const info = await moveToElement();
     if (!info) return origElSelectOption(values, options);
     await humanClick(raw, false, cfg);
@@ -246,7 +293,13 @@ export function patchSingleElementHandle(
   };
 
   // --- el.check() ---
-  (el as any).check = async (options?: any) => {
+  (el as any).check = async (options?: {
+    force?: boolean;
+    noWaitAfter?: boolean;
+    position?: { x: number; y: number };
+    timeout?: number;
+    trial?: boolean;
+  }) => {
     try {
       const checked = await el.isChecked();
       if (checked) return; // Already checked
@@ -257,7 +310,13 @@ export function patchSingleElementHandle(
   };
 
   // --- el.uncheck() ---
-  (el as any).uncheck = async (options?: any) => {
+  (el as any).uncheck = async (options?: {
+    force?: boolean;
+    noWaitAfter?: boolean;
+    position?: { x: number; y: number };
+    timeout?: number;
+    trial?: boolean;
+  }) => {
     try {
       const checked = await el.isChecked();
       if (!checked) return; // Already unchecked
@@ -269,7 +328,13 @@ export function patchSingleElementHandle(
 
   // --- el.setChecked() ---
   if (origElSetChecked) {
-    (el as any).setChecked = async (checked: boolean, options?: any) => {
+    (el as any).setChecked = async (checked: boolean, options?: {
+      force?: boolean;
+      noWaitAfter?: boolean;
+      position?: { x: number; y: number };
+      timeout?: number;
+      trial?: boolean;
+    }) => {
       try {
         const current = await el.isChecked();
         if (current === checked) return;
@@ -281,7 +346,14 @@ export function patchSingleElementHandle(
   }
 
   // --- el.tap() ---
-  (el as any).tap = async (options?: any) => {
+  (el as any).tap = async (options?: {
+    force?: boolean;
+    modifiers?: Array<'Alt' | 'Control' | 'ControlOrMeta' | 'Meta' | 'Shift'>;
+    noWaitAfter?: boolean;
+    position?: { x: number; y: number };
+    timeout?: number;
+    trial?: boolean;
+  }) => {
     const info = await moveToElement();
     if (!info) return origElTap(options);
     await humanClick(raw, info.isInp, cfg);
@@ -302,8 +374,8 @@ export function patchSingleElementHandle(
   // wheel sequence used by page.click() etc. Falls back to the native
   // method if the element is detached or scrolling fails.
   if (origElScrollIntoViewIfNeeded) {
-    (el as any).scrollIntoViewIfNeeded = async (options?: any) => {
-      const callCfg = mergeConfig(cfg, options?.human_config);
+    (el as any).scrollIntoViewIfNeeded = async (options?: Partial<HumanConfig> & ({ human_config?: Partial<HumanConfig>; timeout?: number })) => {
+      const callCfg = mergeConfig(cfg, options?.human_config ?? options);
       const ensureCursorInit = (page as any)._ensureCursorInit;
       if (ensureCursorInit) await ensureCursorInit();
       try {
@@ -360,7 +432,11 @@ export function patchPageElementHandles(
   // Patch page.waitForSelector()
   if (typeof page.waitForSelector === 'function') {
     const origWaitForSelector = page.waitForSelector.bind(page);
-    (page as any).waitForSelector = async (selector: string, options?: any) => {
+    (page as any).waitForSelector = async (selector: string, options?: {
+      state?: 'attached' | 'detached' | 'visible' | 'hidden';
+      strict?: boolean;
+      timeout?: number;
+    }) => {
       const el = await origWaitForSelector(selector, options);
       if (el) patchSingleElementHandle(el, page, cfg, cursor, raw, rawKb, originals, stealth);
       return el;
@@ -408,7 +484,11 @@ export function patchFrameElementHandles(
   // Patch frame.waitForSelector()
   if (typeof frame.waitForSelector === 'function') {
     const origFrameWaitForSelector = frame.waitForSelector.bind(frame);
-    (frame as any).waitForSelector = async (selector: string, options?: any) => {
+    (frame as any).waitForSelector = async (selector: string, options?: {
+      state?: 'attached' | 'detached' | 'visible' | 'hidden';
+      strict?: boolean;
+      timeout?: number;
+    }) => {
       const el = await origFrameWaitForSelector(selector, options);
       if (el) patchSingleElementHandle(el, page, cfg, cursor, raw, rawKb, originals, stealth);
       return el;

--- a/js/src/human/index.ts
+++ b/js/src/human/index.ts
@@ -307,9 +307,9 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- click ---
-  const humanClickFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+  const humanClickFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await ensureCursorInit();
-    const callCfg = mergeConfig(cfg, options);
+    const callCfg = mergeConfig(cfg, options?.human_config ?? options);
     if (callCfg.idle_between_actions) {
       await humanIdle(raw, cursor.x, cursor.y, callCfg);
     }
@@ -325,9 +325,9 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- dblclick ---
-  const humanDblclickFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+  const humanDblclickFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await ensureCursorInit();
-    const callCfg = mergeConfig(cfg, options);
+    const callCfg = mergeConfig(cfg, options?.human_config ?? options);
     if (callCfg.idle_between_actions) {
       await humanIdle(raw, cursor.x, cursor.y, callCfg);
     }
@@ -346,9 +346,9 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- hover ---
-  const humanHoverFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+  const humanHoverFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await ensureCursorInit();
-    const callCfg = mergeConfig(cfg, options);
+    const callCfg = mergeConfig(cfg, options?.human_config ?? options);
     if (callCfg.idle_between_actions) {
       await humanIdle(raw, cursor.x, cursor.y, callCfg);
     }
@@ -362,8 +362,8 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- type ---
-  const humanTypeFn = async (selector: string, text: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
-    const callCfg = mergeConfig(cfg, options);
+  const humanTypeFn = async (selector: string, text: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
+    const callCfg = mergeConfig(cfg, options?.human_config ?? options);
     await sleep(randRange(callCfg.field_switch_delay));
     await humanClickFn(selector, options);
     await sleep(rand(100, 250));
@@ -372,8 +372,8 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- fill (clears existing content first) ---
-  const humanFillFn = async (selector: string, value: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
-    const callCfg = mergeConfig(cfg, options);
+  const humanFillFn = async (selector: string, value: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
+    const callCfg = mergeConfig(cfg, options?.human_config ?? options);
     await sleep(randRange(callCfg.field_switch_delay));
     await humanClickFn(selector, options);
     await sleep(rand(100, 250));
@@ -386,7 +386,7 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- clear ---
-  const humanClearFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+  const humanClearFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     if (!await isSelectorFocused(stealth, page, selector)) {
       await humanClickFn(selector, options);
     }
@@ -397,8 +397,8 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- check ---
-  const humanCheckFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
-    const callCfg = mergeConfig(cfg, options);
+  const humanCheckFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
+    const callCfg = mergeConfig(cfg, options?.human_config ?? options);
     if (callCfg.idle_between_actions) {
       await humanIdle(raw, cursor.x, cursor.y, callCfg);
     }
@@ -409,8 +409,8 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- uncheck ---
-  const humanUncheckFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
-    const callCfg = mergeConfig(cfg, options);
+  const humanUncheckFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
+    const callCfg = mergeConfig(cfg, options?.human_config ?? options);
     if (callCfg.idle_between_actions) {
       await humanIdle(raw, cursor.x, cursor.y, callCfg);
     }
@@ -421,14 +421,14 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- selectOption ---
-  const humanSelectOptionFn = async (selector: string, values: any, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+  const humanSelectOptionFn = async (selector: string, values: any, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await humanHoverFn(selector, options);
     await sleep(rand(100, 300));
     return originals.selectOption(selector, values, options);
   };
 
   // --- press (checks focus first — avoids redundant mouse moves) ---
-  const humanPressFn = async (selector: string, key: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+  const humanPressFn = async (selector: string, key: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     if (!await isSelectorFocused(stealth, page, selector)) {
       await humanClickFn(selector, options);
     }
@@ -437,8 +437,8 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- pressSequentially ---
-  const humanPressSequentiallyFn = async (selector: string, text: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
-    const callCfg = mergeConfig(cfg, options);
+  const humanPressSequentiallyFn = async (selector: string, text: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
+    const callCfg = mergeConfig(cfg, options?.human_config ?? options);
     if (!await isSelectorFocused(stealth, page, selector)) {
       await humanClickFn(selector, options);
     }
@@ -448,7 +448,7 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- tap ---
-  const humanTapFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+  const humanTapFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await humanClickFn(selector, options);
   };
 
@@ -562,53 +562,53 @@ function patchSingleFrame(
   const origFrameSelectOption = frame.selectOption.bind(frame);
   const origFrameDragAndDrop = frame.dragAndDrop.bind(frame);
 
-  (frame as any).click = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+  (frame as any).click = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await (page as any).click(selector, options);
   };
 
-  (frame as any).dblclick = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+  (frame as any).dblclick = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await (page as any).dblclick(selector, options);
   };
 
-  (frame as any).hover = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+  (frame as any).hover = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await (page as any).hover(selector, options);
   };
 
-  (frame as any).type = async (selector: string, text: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+  (frame as any).type = async (selector: string, text: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await (page as any).type(selector, text, options);
   };
 
-  (frame as any).fill = async (selector: string, value: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+  (frame as any).fill = async (selector: string, value: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await (page as any).fill(selector, value, options);
   };
 
-  (frame as any).check = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+  (frame as any).check = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await (page as any).check(selector, options);
   };
 
-  (frame as any).uncheck = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+  (frame as any).uncheck = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await (page as any).uncheck(selector, options);
   };
 
-  (frame as any).selectOption = async (selector: string, values: any, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+  (frame as any).selectOption = async (selector: string, values: any, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await (page as any).hover(selector, options);
     await sleep(rand(100, 300));
     return origFrameSelectOption(selector, values, options);
   };
 
-  (frame as any).press = async (selector: string, key: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+  (frame as any).press = async (selector: string, key: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await (page as any).press(selector, key, options);
   };
 
-  (frame as any).pressSequentially = async (selector: string, text: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+  (frame as any).pressSequentially = async (selector: string, text: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await (page as any).pressSequentially(selector, text, options);
   };
 
-  (frame as any).tap = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+  (frame as any).tap = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     await (page as any).tap(selector, options);
   };
 
-  (frame as any).clear = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+  (frame as any).clear = async (selector: string, options?: Partial<HumanConfig> & ({ timeout?: number; human_config?: Partial<HumanConfig> })) => {
     if (!await isSelectorFocused(stealth, page, selector)) {
       await (page as any).click(selector, options);
     }

--- a/js/src/human/index.ts
+++ b/js/src/human/index.ts
@@ -295,7 +295,11 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   }
 
   // --- goto (invalidate isolated world on navigation) ---
-  const humanGoto = async (url: string, options?: any) => {
+  const humanGoto = async (url: string, options?: {
+    referer?: string;
+    timeout?: number;
+    waitUntil?: 'load' | 'domcontentloaded' | 'networkidle' | 'commit';
+  }) => {
     const response = await originals.goto(url, options);
     stealth.invalidate();
     patchFrames(page, cfg, cursor, raw, rawKb, originals, stealth);
@@ -303,11 +307,11 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- click ---
-  const humanClickFn = async (selector: string, options?: any) => {
+  const humanClickFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
     await ensureCursorInit();
-    const callCfg = mergeConfig(cfg, options?.human_config);
+    const callCfg = mergeConfig(cfg, options);
     if (callCfg.idle_between_actions) {
-      await humanIdle(raw, rand(callCfg.idle_between_duration[0], callCfg.idle_between_duration[1]), cursor.x, cursor.y, callCfg);
+      await humanIdle(raw, cursor.x, cursor.y, callCfg);
     }
     const { box, cursorX, cursorY } = await scrollToElement(page, raw, selector, cursor.x, cursor.y, callCfg, options?.timeout);
     cursor.x = cursorX;
@@ -321,12 +325,13 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- dblclick ---
-  const humanDblclickFn = async (selector: string, options?: any) => {
+  const humanDblclickFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
     await ensureCursorInit();
-    const callCfg = mergeConfig(cfg, options?.human_config);
+    const callCfg = mergeConfig(cfg, options);
     if (callCfg.idle_between_actions) {
-      await humanIdle(raw, rand(callCfg.idle_between_duration[0], callCfg.idle_between_duration[1]), cursor.x, cursor.y, callCfg);
+      await humanIdle(raw, cursor.x, cursor.y, callCfg);
     }
+
     const { box, cursorX, cursorY } = await scrollToElement(page, raw, selector, cursor.x, cursor.y, callCfg, options?.timeout);
     cursor.x = cursorX;
     cursor.y = cursorY;
@@ -341,11 +346,11 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- hover ---
-  const humanHoverFn = async (selector: string, options?: any) => {
+  const humanHoverFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
     await ensureCursorInit();
-    const callCfg = mergeConfig(cfg, options?.human_config);
+    const callCfg = mergeConfig(cfg, options);
     if (callCfg.idle_between_actions) {
-      await humanIdle(raw, rand(callCfg.idle_between_duration[0], callCfg.idle_between_duration[1]), cursor.x, cursor.y, callCfg);
+      await humanIdle(raw, cursor.x, cursor.y, callCfg);
     }
     const { box, cursorX, cursorY } = await scrollToElement(page, raw, selector, cursor.x, cursor.y, callCfg, options?.timeout);
     cursor.x = cursorX;
@@ -357,8 +362,8 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- type ---
-  const humanTypeFn = async (selector: string, text: string, options?: any) => {
-    const callCfg = mergeConfig(cfg, options?.human_config);
+  const humanTypeFn = async (selector: string, text: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+    const callCfg = mergeConfig(cfg, options);
     await sleep(randRange(callCfg.field_switch_delay));
     await humanClickFn(selector, options);
     await sleep(rand(100, 250));
@@ -367,8 +372,8 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- fill (clears existing content first) ---
-  const humanFillFn = async (selector: string, value: string, options?: any) => {
-    const callCfg = mergeConfig(cfg, options?.human_config);
+  const humanFillFn = async (selector: string, value: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+    const callCfg = mergeConfig(cfg, options);
     await sleep(randRange(callCfg.field_switch_delay));
     await humanClickFn(selector, options);
     await sleep(rand(100, 250));
@@ -381,9 +386,9 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- clear ---
-  const humanClearFn = async (selector: string, options?: any) => {
+  const humanClearFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
     if (!await isSelectorFocused(stealth, page, selector)) {
-      await humanClickFn(selector);
+      await humanClickFn(selector, options);
     }
     await sleep(rand(50, 150));
     await originals.keyboardPress(SELECT_ALL);
@@ -392,46 +397,48 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- check ---
-  const humanCheckFn = async (selector: string, options?: any) => {
-    if (cfg.idle_between_actions) {
-      await humanIdle(raw, rand(cfg.idle_between_duration[0], cfg.idle_between_duration[1]), cursor.x, cursor.y, cfg);
+  const humanCheckFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+    const callCfg = mergeConfig(cfg, options);
+    if (callCfg.idle_between_actions) {
+      await humanIdle(raw, cursor.x, cursor.y, callCfg);
     }
     const checked = await originals.isChecked(selector).catch(() => false);
     if (!checked) {
-      await humanClickFn(selector);
+      await humanClickFn(selector, options);
     }
   };
 
   // --- uncheck ---
-  const humanUncheckFn = async (selector: string, options?: any) => {
-    if (cfg.idle_between_actions) {
-      await humanIdle(raw, rand(cfg.idle_between_duration[0], cfg.idle_between_duration[1]), cursor.x, cursor.y, cfg);
+  const humanUncheckFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+    const callCfg = mergeConfig(cfg, options);
+    if (callCfg.idle_between_actions) {
+      await humanIdle(raw, cursor.x, cursor.y, callCfg);
     }
     const checked = await originals.isChecked(selector).catch(() => true);
     if (checked) {
-      await humanClickFn(selector);
+      await humanClickFn(selector, options);
     }
   };
 
   // --- selectOption ---
-  const humanSelectOptionFn = async (selector: string, values: any, options?: any) => {
-    await humanHoverFn(selector);
+  const humanSelectOptionFn = async (selector: string, values: any, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+    await humanHoverFn(selector, options);
     await sleep(rand(100, 300));
     return originals.selectOption(selector, values, options);
   };
 
   // --- press (checks focus first — avoids redundant mouse moves) ---
-  const humanPressFn = async (selector: string, key: string, options?: any) => {
+  const humanPressFn = async (selector: string, key: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
     if (!await isSelectorFocused(stealth, page, selector)) {
-      await humanClickFn(selector);
+      await humanClickFn(selector, options);
     }
     await sleep(rand(50, 150));
     await originals.keyboardPress(key);
   };
 
   // --- pressSequentially ---
-  const humanPressSequentiallyFn = async (selector: string, text: string, options?: any) => {
-    const callCfg = mergeConfig(cfg, options?.human_config);
+  const humanPressSequentiallyFn = async (selector: string, text: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+    const callCfg = mergeConfig(cfg, options);
     if (!await isSelectorFocused(stealth, page, selector)) {
       await humanClickFn(selector, options);
     }
@@ -441,7 +448,7 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- tap ---
-  const humanTapFn = async (selector: string, options?: any) => {
+  const humanTapFn = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
     await humanClickFn(selector, options);
   };
 
@@ -461,14 +468,20 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   (page as any).clear = humanClearFn;
 
   // --- mouse patches ---
-  page.mouse.move = async (x: number, y: number, options?: any) => {
+  page.mouse.move = async (x: number, y: number, options?: {
+    steps?: number;
+  }) => {
     await ensureCursorInit();
     await humanMove(raw, cursor.x, cursor.y, x, y, cfg);
     cursor.x = x;
     cursor.y = y;
   };
 
-  page.mouse.click = async (x: number, y: number, options?: any) => {
+  page.mouse.click = async (x: number, y: number, options?: {
+    button?: 'left' | 'right' | 'middle';
+    clickCount?: number;
+    delay?: number;
+  }) => {
     await ensureCursorInit();
     await humanMove(raw, cursor.x, cursor.y, x, y, cfg);
     cursor.x = x;
@@ -477,7 +490,7 @@ function patchPage(page: Page, cfg: HumanConfig, cursor: CursorState): void {
   };
 
   // --- keyboard patches ---
-  page.keyboard.type = async (text: string, options?: any) => {
+  page.keyboard.type = async (text: string, options?: { delay?: number }) => {
     const cdp = await ensureCdp();
     await humanType(page, rawKb, text, cfg, cdp);
   };
@@ -549,55 +562,55 @@ function patchSingleFrame(
   const origFrameSelectOption = frame.selectOption.bind(frame);
   const origFrameDragAndDrop = frame.dragAndDrop.bind(frame);
 
-  (frame as any).click = async (selector: string, options?: any) => {
+  (frame as any).click = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
     await (page as any).click(selector, options);
   };
 
-  (frame as any).dblclick = async (selector: string, options?: any) => {
+  (frame as any).dblclick = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
     await (page as any).dblclick(selector, options);
   };
 
-  (frame as any).hover = async (selector: string, options?: any) => {
+  (frame as any).hover = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
     await (page as any).hover(selector, options);
   };
 
-  (frame as any).type = async (selector: string, text: string, options?: any) => {
+  (frame as any).type = async (selector: string, text: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
     await (page as any).type(selector, text, options);
   };
 
-  (frame as any).fill = async (selector: string, value: string, options?: any) => {
+  (frame as any).fill = async (selector: string, value: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
     await (page as any).fill(selector, value, options);
   };
 
-  (frame as any).check = async (selector: string, options?: any) => {
+  (frame as any).check = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
     await (page as any).check(selector, options);
   };
 
-  (frame as any).uncheck = async (selector: string, options?: any) => {
+  (frame as any).uncheck = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
     await (page as any).uncheck(selector, options);
   };
 
-  (frame as any).selectOption = async (selector: string, values: any, options?: any) => {
-    await (page as any).hover(selector);
+  (frame as any).selectOption = async (selector: string, values: any, options?: Partial<HumanConfig> & ({ timeout: number })) => {
+    await (page as any).hover(selector, options);
     await sleep(rand(100, 300));
     return origFrameSelectOption(selector, values, options);
   };
 
-  (frame as any).press = async (selector: string, key: string, options?: any) => {
+  (frame as any).press = async (selector: string, key: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
     await (page as any).press(selector, key, options);
   };
 
-  (frame as any).pressSequentially = async (selector: string, text: string, options?: any) => {
+  (frame as any).pressSequentially = async (selector: string, text: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
     await (page as any).pressSequentially(selector, text, options);
   };
 
-  (frame as any).tap = async (selector: string, options?: any) => {
+  (frame as any).tap = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
     await (page as any).tap(selector, options);
   };
 
-  (frame as any).clear = async (selector: string, options?: any) => {
+  (frame as any).clear = async (selector: string, options?: Partial<HumanConfig> & ({ timeout: number })) => {
     if (!await isSelectorFocused(stealth, page, selector)) {
-      await (page as any).click(selector);
+      await (page as any).click(selector, options);
     }
     await sleep(rand(50, 150));
     await originals.keyboardPress(SELECT_ALL);
@@ -605,7 +618,15 @@ function patchSingleFrame(
     await originals.keyboardPress('Backspace');
   };
 
-  (frame as any).dragAndDrop = async (source: string, target: string, options?: any) => {
+  (frame as any).dragAndDrop = async (source: string, target: string, options?: {
+    force?: boolean;
+    noWaitAfter?: boolean;
+    sourcePosition?: { x: number; y: number };
+    strict?: boolean;
+    targetPosition?: { x: number; y: number };
+    timeout?: number;
+    trial?: boolean;
+  }) => {
     const srcBox = await frame.locator(source).boundingBox().catch(() => null);
     const tgtBox = await frame.locator(target).boundingBox().catch(() => null);
 
@@ -676,14 +697,14 @@ export function patchBrowser(browser: Browser, cfg: HumanConfig): void {
   }
 
   const origNewContext = browser.newContext.bind(browser);
-  (browser as any).newContext = async (options?: any) => {
+  (browser as any).newContext = async (options?: Parameters<typeof origNewContext>[0]) => {
     const context = await origNewContext(options);
     patchContext(context, cfg);
     return context;
   };
 
   const origNewPage = browser.newPage.bind(browser);
-  (browser as any).newPage = async (options?: any) => {
+  (browser as any).newPage = async (options?: Parameters<typeof origNewPage>[0]) => {
     const page = await origNewPage(options);
     if (!(page as any)._original) {
       const ctx = page.context();

--- a/js/src/human/mouse.ts
+++ b/js/src/human/mouse.ts
@@ -174,12 +174,11 @@ export async function humanClick(
 
 export async function humanIdle(
   raw: RawMouse,
-  seconds: number,
   cx: number,
   cy: number,
   cfg: HumanConfig,
 ): Promise<void> {
-  const endTime = Date.now() + seconds * 1000;
+  const endTime = Date.now() + rand(cfg.idle_between_duration[0], cfg.idle_between_duration[1]) * 1000;
   let x = cx;
   let y = cy;
   while (Date.now() < endTime) {

--- a/js/src/human/mouse.ts
+++ b/js/src/human/mouse.ts
@@ -172,13 +172,34 @@ export async function humanClick(
 // Human idle / drift
 // ---------------------------------------------------------------------------
 
-export async function humanIdle(
+export function humanIdle(
   raw: RawMouse,
   cx: number,
   cy: number,
   cfg: HumanConfig,
+): Promise<void>;
+export function humanIdle(
+  raw: RawMouse,
+  seconds: number,
+  cx: number,
+  cy: number,
+  cfg: HumanConfig,
+): Promise<void>;
+export async function humanIdle(
+  raw: RawMouse,
+  secondsOrCx: number,
+  cxOrCy: number,
+  cyOrCfg: number | HumanConfig,
+  maybeCfg?: HumanConfig,
 ): Promise<void> {
-  const endTime = Date.now() + rand(cfg.idle_between_duration[0], cfg.idle_between_duration[1]) * 1000;
+  const hasExplicitSeconds = maybeCfg !== undefined;
+  const seconds = hasExplicitSeconds
+    ? secondsOrCx
+    : rand((cyOrCfg as HumanConfig).idle_between_duration[0], (cyOrCfg as HumanConfig).idle_between_duration[1]);
+  const cx = hasExplicitSeconds ? cxOrCy : secondsOrCx;
+  const cy = hasExplicitSeconds ? (cyOrCfg as number) : cxOrCy;
+  const cfg = hasExplicitSeconds ? maybeCfg! : (cyOrCfg as HumanConfig);
+  const endTime = Date.now() + seconds * 1000;
   let x = cx;
   let y = cy;
   while (Date.now() < endTime) {

--- a/js/tests/humanize.test.ts
+++ b/js/tests/humanize.test.ts
@@ -1156,7 +1156,7 @@ describe("page.click(selector, { timeout }) forwards timeout to scroll", () => {
 // Per-call human config override
 // =========================================================================
 describe("page.type / page.fill accept per-call human config override", () => {
-  it("page.type forwards merged config to humanType", async () => {
+  it("page.type forwards nested human_config to humanType", async () => {
     const keyboardMod = await import("../src/human/keyboard.js");
     const scrollMod = await import("../src/human/scroll.js");
     const { patchPage } = await import("../src/human/index.js");
@@ -1184,8 +1184,7 @@ describe("page.type / page.fill accept per-call human config override", () => {
     patchPage(page as any, cfg, cursor as any);
 
     await (page as any).type("#email", "hi", {
-      typing_delay: 30,
-      mistype_chance: 0,
+      human_config: { typing_delay: 30, mistype_chance: 0 },
     });
 
     expect(captured.typing_delay).toBe(30);
@@ -1197,7 +1196,7 @@ describe("page.type / page.fill accept per-call human config override", () => {
     scrollSpy.mockRestore();
   }, 30000);
 
-  it("page.fill forwards merged config to humanType", async () => {
+  it("page.fill forwards flat config to humanType", async () => {
     const keyboardMod = await import("../src/human/keyboard.js");
     const scrollMod = await import("../src/human/scroll.js");
     const { patchPage } = await import("../src/human/index.js");

--- a/js/tests/humanize.test.ts
+++ b/js/tests/humanize.test.ts
@@ -106,9 +106,9 @@ describe("humanMove", () => {
     return {
       raw: {
         move: vi.fn(async (x: number, y: number) => { moves.push({ x, y }); }),
-        down: vi.fn(async () => {}),
-        up: vi.fn(async () => {}),
-        wheel: vi.fn(async () => {}),
+        down: vi.fn(async () => { }),
+        up: vi.fn(async () => { }),
+        wheel: vi.fn(async () => { }),
       },
       moves,
     };
@@ -180,10 +180,10 @@ describe("humanClick", () => {
     const cfg = resolveConfig("default");
     const callOrder: string[] = [];
     const raw = {
-      move: vi.fn(async () => {}),
+      move: vi.fn(async () => { }),
       down: vi.fn(async () => { callOrder.push("down"); }),
       up: vi.fn(async () => { callOrder.push("up"); }),
-      wheel: vi.fn(async () => {}),
+      wheel: vi.fn(async () => { }),
     };
     await humanClick(raw, false, cfg);
     expect(raw.down).toHaveBeenCalledTimes(1);
@@ -199,12 +199,12 @@ describe("humanIdle", () => {
   it("calls raw.move at least once during idle", async () => {
     const cfg = resolveConfig("default");
     const raw = {
-      move: vi.fn(async () => {}),
-      down: vi.fn(async () => {}),
-      up: vi.fn(async () => {}),
-      wheel: vi.fn(async () => {}),
+      move: vi.fn(async () => { }),
+      down: vi.fn(async () => { }),
+      up: vi.fn(async () => { }),
+      wheel: vi.fn(async () => { }),
     };
-    await humanIdle(raw, 10, 100, 100, cfg);
+    await humanIdle(raw, 100, 100, cfg);
     expect(raw.move).toHaveBeenCalled();
   }, 15000);
 });
@@ -265,7 +265,7 @@ describe("patchPage fill", () => {
     const cursor = { x: 0, y: 0, initialized: false };
     patchPage(page as any, cfg, cursor as any);
 
-    try { await (page as any).fill("input#name", "hello"); } catch (_) {}
+    try { await (page as any).fill("input#name", "hello"); } catch (_) { }
 
     const expected = process.platform === "darwin" ? "Meta+a" : "Control+a";
     const wrong = process.platform === "darwin" ? "Control+a" : "Meta+a";
@@ -298,7 +298,7 @@ describe("patchPage check/uncheck idle", () => {
     const cursor = { x: 100, y: 100, initialized: true };
     patchPage(page as any, cfg, cursor as any);
 
-    try { await (page as any).check("input#cb"); } catch (_) {}
+    try { await (page as any).check("input#cb"); } catch (_) { }
 
     // humanCheckFn → humanIdle → humanClickFn → humanClick → raw.down
     expect(downCalled).toBe(true);
@@ -321,7 +321,7 @@ describe("patchPage check/uncheck idle", () => {
     const cursor = { x: 100, y: 100, initialized: true };
     patchPage(page as any, cfg, cursor as any);
 
-    try { await (page as any).uncheck("input#cb"); } catch (_) {}
+    try { await (page as any).uncheck("input#cb"); } catch (_) { }
 
     expect(downCalled).toBe(true);
   }, 30000);
@@ -354,7 +354,7 @@ describe("patchPage press focus", () => {
     const cursor = { x: 50, y: 50, initialized: true };
     patchPage(page as any, cfg, cursor as any);
 
-    try { await (page as any).press("input#field", "Enter"); } catch (_) {}
+    try { await (page as any).press("input#field", "Enter"); } catch (_) { }
 
     expect(downCount).toBeGreaterThan(0);
   });
@@ -372,7 +372,7 @@ describe("patchPage press focus", () => {
     const cursor = { x: 50, y: 50, initialized: true };
     patchPage(page as any, cfg, cursor as any);
 
-    try { await (page as any).press("input#field", "Enter"); } catch (_) {}
+    try { await (page as any).press("input#field", "Enter"); } catch (_) { }
 
     expect(downCount).toBe(0);
   });
@@ -465,7 +465,7 @@ describe("patchBrowser CDP-connected workflow", () => {
       pages: vi.fn(() => [page]),
       on: vi.fn(),
       newPage: vi.fn(async () => buildMockPage()),
-      addInitScript: vi.fn(async () => {}),
+      addInitScript: vi.fn(async () => { }),
     };
     const browser: any = {
       contexts: vi.fn(() => [context]),
@@ -494,7 +494,7 @@ describe("patchBrowser CDP-connected workflow", () => {
       pages: vi.fn(() => [page]),
       on: vi.fn(),
       newPage: vi.fn(async () => buildMockPage()),
-      addInitScript: vi.fn(async () => {}),
+      addInitScript: vi.fn(async () => { }),
     };
     const browser: any = {
       contexts: vi.fn(() => [context]),
@@ -505,7 +505,7 @@ describe("patchBrowser CDP-connected workflow", () => {
     patchBrowser(browser, resolveConfig("default"));
 
     // Click through the patched method — should go through humanize path
-    try { await (page as any).click("button"); } catch (_) {}
+    try { await (page as any).click("button"); } catch (_) { }
 
     expect(downCalled).toBe(true);
   }, 30000);
@@ -518,7 +518,7 @@ describe("patchBrowser CDP-connected workflow", () => {
       pages: vi.fn(() => [newPage]),
       on: vi.fn(),
       newPage: vi.fn(async () => buildMockPage()),
-      addInitScript: vi.fn(async () => {}),
+      addInitScript: vi.fn(async () => { }),
     };
     const browser: any = {
       contexts: vi.fn(() => []),
@@ -542,27 +542,27 @@ describe("patchBrowser CDP-connected workflow", () => {
 function buildMockPage(overrides: Record<string, any> = {}): any {
   const mainFrameObj = overrides.mainFrameReturn ?? {
     childFrames: vi.fn(() => []),
-    click: vi.fn(async () => {}),
-    dblclick: vi.fn(async () => {}),
-    hover: vi.fn(async () => {}),
-    type: vi.fn(async () => {}),
-    fill: vi.fn(async () => {}),
-    check: vi.fn(async () => {}),
-    uncheck: vi.fn(async () => {}),
-    selectOption: vi.fn(async () => {}),
-    press: vi.fn(async () => {}),
-    clear: vi.fn(async () => {}),
-    dragAndDrop: vi.fn(async () => {}),
+    click: vi.fn(async () => { }),
+    dblclick: vi.fn(async () => { }),
+    hover: vi.fn(async () => { }),
+    type: vi.fn(async () => { }),
+    fill: vi.fn(async () => { }),
+    check: vi.fn(async () => { }),
+    uncheck: vi.fn(async () => { }),
+    selectOption: vi.fn(async () => { }),
+    press: vi.fn(async () => { }),
+    clear: vi.fn(async () => { }),
+    dragAndDrop: vi.fn(async () => { }),
     locator: vi.fn(() => ({
       boundingBox: vi.fn(async () => ({ x: 0, y: 0, width: 100, height: 30 })),
-      first: vi.fn(function(this: any) { return this; }),
+      first: vi.fn(function (this: any) { return this; }),
     })),
   };
 
   const makeLocator = () => {
     const loc: any = {
       boundingBox: vi.fn(async () => ({ x: 100, y: 100, width: 200, height: 30 })),
-      scrollIntoViewIfNeeded: vi.fn(async () => {}),
+      scrollIntoViewIfNeeded: vi.fn(async () => { }),
       isChecked: overrides.isChecked ?? vi.fn(async () => false),
     };
     loc.first = vi.fn(() => loc);
@@ -571,33 +571,33 @@ function buildMockPage(overrides: Record<string, any> = {}): any {
 
   const page: any = {
     evaluate: overrides.evaluate ?? vi.fn(async () => false),
-    addInitScript: vi.fn(async () => {}),
+    addInitScript: vi.fn(async () => { }),
     mouse: {
-      move: vi.fn(async () => {}),
-      down: vi.fn(async () => {}),
-      up: vi.fn(async () => {}),
-      click: vi.fn(async () => {}),
-      dblclick: vi.fn(async () => {}),
-      wheel: vi.fn(async () => {}),
+      move: vi.fn(async () => { }),
+      down: vi.fn(async () => { }),
+      up: vi.fn(async () => { }),
+      click: vi.fn(async () => { }),
+      dblclick: vi.fn(async () => { }),
+      wheel: vi.fn(async () => { }),
     },
     keyboard: {
       press: overrides.keyboardPress
         ? vi.fn(overrides.keyboardPress)
-        : vi.fn(async () => {}),
-      type: vi.fn(async () => {}),
-      down: vi.fn(async () => {}),
-      up: vi.fn(async () => {}),
-      insertText: vi.fn(async () => {}),
+        : vi.fn(async () => { }),
+      type: vi.fn(async () => { }),
+      down: vi.fn(async () => { }),
+      up: vi.fn(async () => { }),
+      insertText: vi.fn(async () => { }),
     },
-    click: vi.fn(async () => {}),
-    dblclick: vi.fn(async () => {}),
-    hover: vi.fn(async () => {}),
-    type: vi.fn(async () => {}),
-    fill: vi.fn(async () => {}),
-    check: vi.fn(async () => {}),
-    uncheck: vi.fn(async () => {}),
-    selectOption: vi.fn(async () => {}),
-    press: vi.fn(async () => {}),
+    click: vi.fn(async () => { }),
+    dblclick: vi.fn(async () => { }),
+    hover: vi.fn(async () => { }),
+    type: vi.fn(async () => { }),
+    fill: vi.fn(async () => { }),
+    check: vi.fn(async () => { }),
+    uncheck: vi.fn(async () => { }),
+    selectOption: vi.fn(async () => { }),
+    press: vi.fn(async () => { }),
     goto: vi.fn(async () => ({})),
     isChecked: overrides.isChecked ?? vi.fn(async () => false),
     locator: vi.fn(() => makeLocator()),
@@ -606,10 +606,10 @@ function buildMockPage(overrides: Record<string, any> = {}): any {
     frames: vi.fn(() => []),
     context: vi.fn(() => ({
       pages: vi.fn(() => []),
-      addInitScript: vi.fn(async () => {}),
+      addInitScript: vi.fn(async () => { }),
     })),
     url: vi.fn(() => "about:blank"),
-    waitForTimeout: vi.fn(async () => {}),
+    waitForTimeout: vi.fn(async () => { }),
   };
   return page;
 }
@@ -623,8 +623,8 @@ describe("humanType non-ASCII", () => {
     const insertedChars: string[] = [];
     const raw = {
       down: vi.fn(async (k: string) => { downKeys.push(k); }),
-      up: vi.fn(async () => {}),
-      type: vi.fn(async () => {}),
+      up: vi.fn(async () => { }),
+      type: vi.fn(async () => { }),
       insertText: vi.fn(async (t: string) => { insertedChars.push(t); }),
     };
     return { raw, downKeys, insertedChars };
@@ -696,18 +696,18 @@ describe("humanType non-ASCII", () => {
 
 function buildMockElementHandle(overrides: Record<string, any> = {}): any {
   const el: any = {
-    click: vi.fn(async () => {}),
-    dblclick: vi.fn(async () => {}),
-    hover: vi.fn(async () => {}),
-    type: vi.fn(async () => {}),
-    fill: vi.fn(async () => {}),
-    press: vi.fn(async () => {}),
-    selectOption: vi.fn(async () => {}),
-    check: vi.fn(async () => {}),
-    uncheck: vi.fn(async () => {}),
-    setChecked: vi.fn(async () => {}),
-    tap: vi.fn(async () => {}),
-    focus: vi.fn(async () => {}),
+    click: vi.fn(async () => { }),
+    dblclick: vi.fn(async () => { }),
+    hover: vi.fn(async () => { }),
+    type: vi.fn(async () => { }),
+    fill: vi.fn(async () => { }),
+    press: vi.fn(async () => { }),
+    selectOption: vi.fn(async () => { }),
+    check: vi.fn(async () => { }),
+    uncheck: vi.fn(async () => { }),
+    setChecked: vi.fn(async () => { }),
+    tap: vi.fn(async () => { }),
+    focus: vi.fn(async () => { }),
     boundingBox: overrides.boundingBox ?? vi.fn(async () => ({ x: 100, y: 100, width: 200, height: 30 })),
     evaluate: overrides.evaluate ?? vi.fn(async () => false),
     isChecked: overrides.isChecked ?? vi.fn(async () => false),
@@ -725,21 +725,21 @@ describe("patchSingleElementHandle", () => {
     const cfg = resolveConfig("default");
     const cursor = { x: 100, y: 100, initialized: true };
     const raw = {
-      move: vi.fn(async () => {}),
-      down: vi.fn(async () => {}),
-      up: vi.fn(async () => {}),
-      wheel: vi.fn(async () => {}),
+      move: vi.fn(async () => { }),
+      down: vi.fn(async () => { }),
+      up: vi.fn(async () => { }),
+      wheel: vi.fn(async () => { }),
     };
     const rawKb = {
-      down: vi.fn(async () => {}),
-      up: vi.fn(async () => {}),
-      type: vi.fn(async () => {}),
-      insertText: vi.fn(async () => {}),
+      down: vi.fn(async () => { }),
+      up: vi.fn(async () => { }),
+      type: vi.fn(async () => { }),
+      insertText: vi.fn(async () => { }),
     };
     const originals = {
-      keyboardPress: vi.fn(async () => {}),
-      keyboardDown: vi.fn(async () => {}),
-      keyboardUp: vi.fn(async () => {}),
+      keyboardPress: vi.fn(async () => { }),
+      keyboardDown: vi.fn(async () => { }),
+      keyboardUp: vi.fn(async () => { }),
     };
 
     const el = buildMockElementHandle();
@@ -762,23 +762,23 @@ describe("patchSingleElementHandle", () => {
       move: vi.fn(async () => { moveCount++; }),
       down: vi.fn(async () => { downCalled = true; }),
       up: vi.fn(async () => { upCalled = true; }),
-      wheel: vi.fn(async () => {}),
+      wheel: vi.fn(async () => { }),
     };
     const rawKb = {
-      down: vi.fn(async () => {}),
-      up: vi.fn(async () => {}),
-      type: vi.fn(async () => {}),
-      insertText: vi.fn(async () => {}),
+      down: vi.fn(async () => { }),
+      up: vi.fn(async () => { }),
+      type: vi.fn(async () => { }),
+      insertText: vi.fn(async () => { }),
     };
     const originals = {
-      keyboardPress: vi.fn(async () => {}),
-      keyboardDown: vi.fn(async () => {}),
-      keyboardUp: vi.fn(async () => {}),
+      keyboardPress: vi.fn(async () => { }),
+      keyboardDown: vi.fn(async () => { }),
+      keyboardUp: vi.fn(async () => { }),
     };
 
     const el = buildMockElementHandle();
     const page = buildMockPage();
-    (page as any)._ensureCursorInit = vi.fn(async () => {});
+    (page as any)._ensureCursorInit = vi.fn(async () => { });
 
     patchSingleElementHandle(el, page as any, cfg, cursor as any, raw, rawKb, originals, null);
 
@@ -796,22 +796,22 @@ describe("patchSingleElementHandle", () => {
 
     let downCalled = false;
     const raw = {
-      move: vi.fn(async () => {}),
+      move: vi.fn(async () => { }),
       down: vi.fn(async () => { downCalled = true; }),
-      up: vi.fn(async () => {}),
-      wheel: vi.fn(async () => {}),
+      up: vi.fn(async () => { }),
+      wheel: vi.fn(async () => { }),
     };
     const rawKb = {
-      down: vi.fn(async () => {}),
-      up: vi.fn(async () => {}),
-      type: vi.fn(async () => {}),
-      insertText: vi.fn(async () => {}),
+      down: vi.fn(async () => { }),
+      up: vi.fn(async () => { }),
+      type: vi.fn(async () => { }),
+      insertText: vi.fn(async () => { }),
     };
-    const originals = { keyboardPress: vi.fn(async () => {}), keyboardDown: vi.fn(async () => {}), keyboardUp: vi.fn(async () => {}) };
+    const originals = { keyboardPress: vi.fn(async () => { }), keyboardDown: vi.fn(async () => { }), keyboardUp: vi.fn(async () => { }) };
 
     const el = buildMockElementHandle();
     const page = buildMockPage();
-    (page as any)._ensureCursorInit = vi.fn(async () => {});
+    (page as any)._ensureCursorInit = vi.fn(async () => { });
 
     patchSingleElementHandle(el, page as any, cfg, cursor as any, raw, rawKb, originals, null);
 
@@ -827,22 +827,22 @@ describe("patchSingleElementHandle", () => {
     const cursor = { x: 50, y: 50, initialized: true };
 
     const raw = {
-      move: vi.fn(async () => {}),
-      down: vi.fn(async () => {}),
-      up: vi.fn(async () => {}),
-      wheel: vi.fn(async () => {}),
+      move: vi.fn(async () => { }),
+      down: vi.fn(async () => { }),
+      up: vi.fn(async () => { }),
+      wheel: vi.fn(async () => { }),
     };
     const rawKb = {
-      down: vi.fn(async () => {}),
-      up: vi.fn(async () => {}),
-      type: vi.fn(async () => {}),
-      insertText: vi.fn(async () => {}),
+      down: vi.fn(async () => { }),
+      up: vi.fn(async () => { }),
+      type: vi.fn(async () => { }),
+      insertText: vi.fn(async () => { }),
     };
-    const originals = { keyboardPress: vi.fn(async () => {}), keyboardDown: vi.fn(async () => {}), keyboardUp: vi.fn(async () => {}) };
+    const originals = { keyboardPress: vi.fn(async () => { }), keyboardDown: vi.fn(async () => { }), keyboardUp: vi.fn(async () => { }) };
 
     const el = buildMockElementHandle({ evaluate: vi.fn(async () => true) }); // isInput = true
     const page = buildMockPage();
-    (page as any)._ensureCursorInit = vi.fn(async () => {});
+    (page as any)._ensureCursorInit = vi.fn(async () => { });
 
     patchSingleElementHandle(el, page as any, cfg, cursor as any, raw, rawKb, originals, null);
 
@@ -860,26 +860,26 @@ describe("patchSingleElementHandle", () => {
 
     const pressedKeys: string[] = [];
     const raw = {
-      move: vi.fn(async () => {}),
-      down: vi.fn(async () => {}),
-      up: vi.fn(async () => {}),
-      wheel: vi.fn(async () => {}),
+      move: vi.fn(async () => { }),
+      down: vi.fn(async () => { }),
+      up: vi.fn(async () => { }),
+      wheel: vi.fn(async () => { }),
     };
     const rawKb = {
-      down: vi.fn(async () => {}),
-      up: vi.fn(async () => {}),
-      type: vi.fn(async () => {}),
-      insertText: vi.fn(async () => {}),
+      down: vi.fn(async () => { }),
+      up: vi.fn(async () => { }),
+      type: vi.fn(async () => { }),
+      insertText: vi.fn(async () => { }),
     };
     const originals = {
       keyboardPress: vi.fn(async (key: string) => { pressedKeys.push(key); }),
-      keyboardDown: vi.fn(async () => {}),
-      keyboardUp: vi.fn(async () => {}),
+      keyboardDown: vi.fn(async () => { }),
+      keyboardUp: vi.fn(async () => { }),
     };
 
     const el = buildMockElementHandle({ evaluate: vi.fn(async () => true) });
     const page = buildMockPage();
-    (page as any)._ensureCursorInit = vi.fn(async () => {});
+    (page as any)._ensureCursorInit = vi.fn(async () => { });
 
     patchSingleElementHandle(el, page as any, cfg, cursor as any, raw, rawKb, originals, null);
 
@@ -894,9 +894,9 @@ describe("patchSingleElementHandle", () => {
     const { patchSingleElementHandle } = await import("../src/human/elementhandle.js");
     const cfg = resolveConfig("default");
     const cursor = { x: 0, y: 0, initialized: false };
-    const raw = { move: vi.fn(async () => {}), down: vi.fn(async () => {}), up: vi.fn(async () => {}), wheel: vi.fn(async () => {}) };
-    const rawKb = { down: vi.fn(async () => {}), up: vi.fn(async () => {}), type: vi.fn(async () => {}), insertText: vi.fn(async () => {}) };
-    const originals = { keyboardPress: vi.fn(async () => {}), keyboardDown: vi.fn(async () => {}), keyboardUp: vi.fn(async () => {}) };
+    const raw = { move: vi.fn(async () => { }), down: vi.fn(async () => { }), up: vi.fn(async () => { }), wheel: vi.fn(async () => { }) };
+    const rawKb = { down: vi.fn(async () => { }), up: vi.fn(async () => { }), type: vi.fn(async () => { }), insertText: vi.fn(async () => { }) };
+    const originals = { keyboardPress: vi.fn(async () => { }), keyboardDown: vi.fn(async () => { }), keyboardUp: vi.fn(async () => { }) };
 
     const el = buildMockElementHandle();
     const page = buildMockPage();
@@ -913,9 +913,9 @@ describe("patchSingleElementHandle", () => {
     const { patchSingleElementHandle } = await import("../src/human/elementhandle.js");
     const cfg = resolveConfig("default");
     const cursor = { x: 0, y: 0, initialized: false };
-    const raw = { move: vi.fn(async () => {}), down: vi.fn(async () => {}), up: vi.fn(async () => {}), wheel: vi.fn(async () => {}) };
-    const rawKb = { down: vi.fn(async () => {}), up: vi.fn(async () => {}), type: vi.fn(async () => {}), insertText: vi.fn(async () => {}) };
-    const originals = { keyboardPress: vi.fn(async () => {}), keyboardDown: vi.fn(async () => {}), keyboardUp: vi.fn(async () => {}) };
+    const raw = { move: vi.fn(async () => { }), down: vi.fn(async () => { }), up: vi.fn(async () => { }), wheel: vi.fn(async () => { }) };
+    const rawKb = { down: vi.fn(async () => { }), up: vi.fn(async () => { }), type: vi.fn(async () => { }), insertText: vi.fn(async () => { }) };
+    const originals = { keyboardPress: vi.fn(async () => { }), keyboardDown: vi.fn(async () => { }), keyboardUp: vi.fn(async () => { }) };
 
     const child = buildMockElementHandle();
     const el = buildMockElementHandle();
@@ -935,9 +935,9 @@ describe("patchPageElementHandles", () => {
     const { patchPageElementHandles } = await import("../src/human/elementhandle.js");
     const cfg = resolveConfig("default");
     const cursor = { x: 0, y: 0, initialized: false };
-    const raw = { move: vi.fn(async () => {}), down: vi.fn(async () => {}), up: vi.fn(async () => {}), wheel: vi.fn(async () => {}) };
-    const rawKb = { down: vi.fn(async () => {}), up: vi.fn(async () => {}), type: vi.fn(async () => {}), insertText: vi.fn(async () => {}) };
-    const originals = { keyboardPress: vi.fn(async () => {}), keyboardDown: vi.fn(async () => {}), keyboardUp: vi.fn(async () => {}) };
+    const raw = { move: vi.fn(async () => { }), down: vi.fn(async () => { }), up: vi.fn(async () => { }), wheel: vi.fn(async () => { }) };
+    const rawKb = { down: vi.fn(async () => { }), up: vi.fn(async () => { }), type: vi.fn(async () => { }), insertText: vi.fn(async () => { }) };
+    const originals = { keyboardPress: vi.fn(async () => { }), keyboardDown: vi.fn(async () => { }), keyboardUp: vi.fn(async () => { }) };
 
     const el = buildMockElementHandle();
     const page = buildMockPage();
@@ -955,9 +955,9 @@ describe("patchPageElementHandles", () => {
     const { patchPageElementHandles } = await import("../src/human/elementhandle.js");
     const cfg = resolveConfig("default");
     const cursor = { x: 0, y: 0, initialized: false };
-    const raw = { move: vi.fn(async () => {}), down: vi.fn(async () => {}), up: vi.fn(async () => {}), wheel: vi.fn(async () => {}) };
-    const rawKb = { down: vi.fn(async () => {}), up: vi.fn(async () => {}), type: vi.fn(async () => {}), insertText: vi.fn(async () => {}) };
-    const originals = { keyboardPress: vi.fn(async () => {}), keyboardDown: vi.fn(async () => {}), keyboardUp: vi.fn(async () => {}) };
+    const raw = { move: vi.fn(async () => { }), down: vi.fn(async () => { }), up: vi.fn(async () => { }), wheel: vi.fn(async () => { }) };
+    const rawKb = { down: vi.fn(async () => { }), up: vi.fn(async () => { }), type: vi.fn(async () => { }), insertText: vi.fn(async () => { }) };
+    const originals = { keyboardPress: vi.fn(async () => { }), keyboardDown: vi.fn(async () => { }), keyboardUp: vi.fn(async () => { }) };
 
     const el1 = buildMockElementHandle();
     const el2 = buildMockElementHandle();
@@ -977,9 +977,9 @@ describe("patchPageElementHandles", () => {
     const { patchPageElementHandles } = await import("../src/human/elementhandle.js");
     const cfg = resolveConfig("default");
     const cursor = { x: 0, y: 0, initialized: false };
-    const raw = { move: vi.fn(async () => {}), down: vi.fn(async () => {}), up: vi.fn(async () => {}), wheel: vi.fn(async () => {}) };
-    const rawKb = { down: vi.fn(async () => {}), up: vi.fn(async () => {}), type: vi.fn(async () => {}), insertText: vi.fn(async () => {}) };
-    const originals = { keyboardPress: vi.fn(async () => {}), keyboardDown: vi.fn(async () => {}), keyboardUp: vi.fn(async () => {}) };
+    const raw = { move: vi.fn(async () => { }), down: vi.fn(async () => { }), up: vi.fn(async () => { }), wheel: vi.fn(async () => { }) };
+    const rawKb = { down: vi.fn(async () => { }), up: vi.fn(async () => { }), type: vi.fn(async () => { }), insertText: vi.fn(async () => { }) };
+    const originals = { keyboardPress: vi.fn(async () => { }), keyboardDown: vi.fn(async () => { }), keyboardUp: vi.fn(async () => { }) };
 
     const el = buildMockElementHandle();
     const page = buildMockPage();
@@ -997,9 +997,9 @@ describe("patchPageElementHandles", () => {
     const { patchPageElementHandles } = await import("../src/human/elementhandle.js");
     const cfg = resolveConfig("default");
     const cursor = { x: 0, y: 0, initialized: false };
-    const raw = { move: vi.fn(async () => {}), down: vi.fn(async () => {}), up: vi.fn(async () => {}), wheel: vi.fn(async () => {}) };
-    const rawKb = { down: vi.fn(async () => {}), up: vi.fn(async () => {}), type: vi.fn(async () => {}), insertText: vi.fn(async () => {}) };
-    const originals = { keyboardPress: vi.fn(async () => {}), keyboardDown: vi.fn(async () => {}), keyboardUp: vi.fn(async () => {}) };
+    const raw = { move: vi.fn(async () => { }), down: vi.fn(async () => { }), up: vi.fn(async () => { }), wheel: vi.fn(async () => { }) };
+    const rawKb = { down: vi.fn(async () => { }), up: vi.fn(async () => { }), type: vi.fn(async () => { }), insertText: vi.fn(async () => { }) };
+    const originals = { keyboardPress: vi.fn(async () => { }), keyboardDown: vi.fn(async () => { }), keyboardUp: vi.fn(async () => { }) };
 
     const page = buildMockPage();
     (page as any).$ = vi.fn(async () => null);
@@ -1035,17 +1035,17 @@ describe("patchPage integrates ElementHandle patching", () => {
 
 function buildMockFrame(): any {
   return {
-    click: vi.fn(async () => {}),
-    dblclick: vi.fn(async () => {}),
-    hover: vi.fn(async () => {}),
-    type: vi.fn(async () => {}),
-    fill: vi.fn(async () => {}),
-    check: vi.fn(async () => {}),
-    uncheck: vi.fn(async () => {}),
-    selectOption: vi.fn(async () => {}),
-    press: vi.fn(async () => {}),
-    clear: vi.fn(async () => {}),
-    dragAndDrop: vi.fn(async () => {}),
+    click: vi.fn(async () => { }),
+    dblclick: vi.fn(async () => { }),
+    hover: vi.fn(async () => { }),
+    type: vi.fn(async () => { }),
+    fill: vi.fn(async () => { }),
+    check: vi.fn(async () => { }),
+    uncheck: vi.fn(async () => { }),
+    selectOption: vi.fn(async () => { }),
+    press: vi.fn(async () => { }),
+    clear: vi.fn(async () => { }),
+    dragAndDrop: vi.fn(async () => { }),
     locator: vi.fn(() => ({
       boundingBox: vi.fn(async () => ({ x: 0, y: 0, width: 100, height: 30 })),
     })),
@@ -1098,10 +1098,10 @@ describe("page.click(selector, { timeout }) forwards timeout to scroll", () => {
       locator: vi.fn(() => ({ first: () => ({ boundingBox }) })),
     };
     const raw = {
-      move: vi.fn(async () => {}),
-      down: vi.fn(async () => {}),
-      up: vi.fn(async () => {}),
-      wheel: vi.fn(async () => {}),
+      move: vi.fn(async () => { }),
+      down: vi.fn(async () => { }),
+      up: vi.fn(async () => { }),
+      wheel: vi.fn(async () => { }),
     };
 
     await scrollToElement(page, raw, "#x", 0, 0, cfg, 5000);
@@ -1118,10 +1118,10 @@ describe("page.click(selector, { timeout }) forwards timeout to scroll", () => {
       locator: vi.fn(() => ({ first: () => ({ boundingBox }) })),
     };
     const raw = {
-      move: vi.fn(async () => {}),
-      down: vi.fn(async () => {}),
-      up: vi.fn(async () => {}),
-      wheel: vi.fn(async () => {}),
+      move: vi.fn(async () => { }),
+      down: vi.fn(async () => { }),
+      up: vi.fn(async () => { }),
+      wheel: vi.fn(async () => { }),
     };
 
     await scrollToElement(page, raw, "#x", 0, 0, cfg);
@@ -1153,9 +1153,9 @@ describe("page.click(selector, { timeout }) forwards timeout to scroll", () => {
 
 
 // =========================================================================
-// Per-call human_config override
+// Per-call human config override
 // =========================================================================
-describe("page.type / page.fill accept per-call human_config override", () => {
+describe("page.type / page.fill accept per-call human config override", () => {
   it("page.type forwards merged config to humanType", async () => {
     const keyboardMod = await import("../src/human/keyboard.js");
     const scrollMod = await import("../src/human/scroll.js");
@@ -1184,7 +1184,8 @@ describe("page.type / page.fill accept per-call human_config override", () => {
     patchPage(page as any, cfg, cursor as any);
 
     await (page as any).type("#email", "hi", {
-      human_config: { typing_delay: 30, mistype_chance: 0 },
+      typing_delay: 30,
+      mistype_chance: 0,
     });
 
     expect(captured.typing_delay).toBe(30);
@@ -1222,7 +1223,7 @@ describe("page.type / page.fill accept per-call human_config override", () => {
     patchPage(page as any, cfg, cursor as any);
 
     await (page as any).fill("#password", "secret", {
-      human_config: { typing_delay: 150 },
+      typing_delay: 150,
     });
 
     expect(captured.typing_delay).toBe(150);
@@ -1242,13 +1243,13 @@ describe("page.type / page.fill accept per-call human_config override", () => {
       async (_page, _raw, _text, callCfg) => { captured = callCfg; },
     );
 
-    const raw = { move: vi.fn(async () => {}), down: vi.fn(async () => {}), up: vi.fn(async () => {}), wheel: vi.fn(async () => {}) };
-    const rawKb = { down: vi.fn(async () => {}), up: vi.fn(async () => {}), type: vi.fn(async () => {}), insertText: vi.fn(async () => {}) };
-    const originals = { keyboardPress: vi.fn(async () => {}), keyboardDown: vi.fn(async () => {}), keyboardUp: vi.fn(async () => {}) };
+    const raw = { move: vi.fn(async () => { }), down: vi.fn(async () => { }), up: vi.fn(async () => { }), wheel: vi.fn(async () => { }) };
+    const rawKb = { down: vi.fn(async () => { }), up: vi.fn(async () => { }), type: vi.fn(async () => { }), insertText: vi.fn(async () => { }) };
+    const originals = { keyboardPress: vi.fn(async () => { }), keyboardDown: vi.fn(async () => { }), keyboardUp: vi.fn(async () => { }) };
 
     const el = buildMockElementHandle({ evaluate: vi.fn(async () => true) });
     const page = buildMockPage();
-    (page as any)._ensureCursorInit = vi.fn(async () => {});
+    (page as any)._ensureCursorInit = vi.fn(async () => { });
 
     patchSingleElementHandle(el, page as any, cfg, cursor as any, raw, rawKb, originals, null);
 
@@ -1270,10 +1271,10 @@ describe("humanScrollIntoView", () => {
 
     const page: any = { viewportSize: () => ({ width: 1280, height: 720 }) };
     const raw = {
-      move: vi.fn(async () => {}),
-      down: vi.fn(async () => {}),
-      up: vi.fn(async () => {}),
-      wheel: vi.fn(async () => {}),
+      move: vi.fn(async () => { }),
+      down: vi.fn(async () => { }),
+      up: vi.fn(async () => { }),
+      wheel: vi.fn(async () => { }),
     };
     // Box centered in viewport — squarely in scroll_target_zone
     const inViewBox = { x: 200, y: 300, width: 50, height: 30 };
@@ -1295,10 +1296,10 @@ describe("humanScrollIntoView", () => {
 
     const page: any = { viewportSize: () => ({ width: 1280, height: 720 }) };
     const raw = {
-      move: vi.fn(async () => {}),
-      down: vi.fn(async () => {}),
-      up: vi.fn(async () => {}),
-      wheel: vi.fn(async () => {}),
+      move: vi.fn(async () => { }),
+      down: vi.fn(async () => { }),
+      up: vi.fn(async () => { }),
+      wheel: vi.fn(async () => { }),
     };
 
     const boxes = [
@@ -1332,14 +1333,14 @@ describe("el.scrollIntoViewIfNeeded humanization", () => {
 
     const cfg = resolveConfig("default", { idle_between_actions: false });
     const cursor = { x: 50, y: 50, initialized: true };
-    const raw = { move: vi.fn(async () => {}), down: vi.fn(async () => {}), up: vi.fn(async () => {}), wheel: vi.fn(async () => {}) };
-    const rawKb = { down: vi.fn(async () => {}), up: vi.fn(async () => {}), type: vi.fn(async () => {}), insertText: vi.fn(async () => {}) };
-    const originals = { keyboardPress: vi.fn(async () => {}), keyboardDown: vi.fn(async () => {}), keyboardUp: vi.fn(async () => {}) };
+    const raw = { move: vi.fn(async () => { }), down: vi.fn(async () => { }), up: vi.fn(async () => { }), wheel: vi.fn(async () => { }) };
+    const rawKb = { down: vi.fn(async () => { }), up: vi.fn(async () => { }), type: vi.fn(async () => { }), insertText: vi.fn(async () => { }) };
+    const originals = { keyboardPress: vi.fn(async () => { }), keyboardDown: vi.fn(async () => { }), keyboardUp: vi.fn(async () => { }) };
 
     const el = buildMockElementHandle();
-    el.scrollIntoViewIfNeeded = vi.fn(async () => {});
+    el.scrollIntoViewIfNeeded = vi.fn(async () => { });
     const page = buildMockPage();
-    (page as any)._ensureCursorInit = vi.fn(async () => {});
+    (page as any)._ensureCursorInit = vi.fn(async () => { });
 
     patchSingleElementHandle(el, page as any, cfg, cursor as any, raw, rawKb, originals, null);
     await el.scrollIntoViewIfNeeded();
@@ -1358,15 +1359,15 @@ describe("el.scrollIntoViewIfNeeded humanization", () => {
 
     const cfg = resolveConfig("default", { idle_between_actions: false });
     const cursor = { x: 50, y: 50, initialized: true };
-    const raw = { move: vi.fn(async () => {}), down: vi.fn(async () => {}), up: vi.fn(async () => {}), wheel: vi.fn(async () => {}) };
-    const rawKb = { down: vi.fn(async () => {}), up: vi.fn(async () => {}), type: vi.fn(async () => {}), insertText: vi.fn(async () => {}) };
-    const originals = { keyboardPress: vi.fn(async () => {}), keyboardDown: vi.fn(async () => {}), keyboardUp: vi.fn(async () => {}) };
+    const raw = { move: vi.fn(async () => { }), down: vi.fn(async () => { }), up: vi.fn(async () => { }), wheel: vi.fn(async () => { }) };
+    const rawKb = { down: vi.fn(async () => { }), up: vi.fn(async () => { }), type: vi.fn(async () => { }), insertText: vi.fn(async () => { }) };
+    const originals = { keyboardPress: vi.fn(async () => { }), keyboardDown: vi.fn(async () => { }), keyboardUp: vi.fn(async () => { }) };
 
-    const nativeFallback = vi.fn(async () => {});
+    const nativeFallback = vi.fn(async () => { });
     const el = buildMockElementHandle();
     el.scrollIntoViewIfNeeded = nativeFallback;
     const page = buildMockPage();
-    (page as any)._ensureCursorInit = vi.fn(async () => {});
+    (page as any)._ensureCursorInit = vi.fn(async () => { });
 
     patchSingleElementHandle(el, page as any, cfg, cursor as any, raw, rawKb, originals, null);
     await el.scrollIntoViewIfNeeded();

--- a/js/tests/stealth.puppeteer.test.ts
+++ b/js/tests/stealth.puppeteer.test.ts
@@ -533,6 +533,52 @@ describe("Puppeteer: non-ASCII text avoids CDP shift path", () => {
 
 
 // =========================================================================
+// Per-call human config override (Puppeteer page-level)
+// =========================================================================
+describe("Puppeteer: page.type accepts per-call human config override", () => {
+  it("page.type forwards merged config to humanType", async () => {
+    const keyboardMod = await import("../src/human-puppeteer/keyboard.js");
+    const scrollMod = await import("../src/human-puppeteer/scroll.js");
+
+    const cfg = resolveConfig("default", {
+      idle_between_actions: false,
+      field_switch_delay: [0, 1],
+    });
+    expect(cfg.typing_delay).toBe(70);
+
+    let captured: any = null;
+    const typeSpy = vi.spyOn(keyboardMod, "humanType").mockImplementation(
+      async (_page, _raw, _text, callCfg) => { captured = callCfg; },
+    );
+    const scrollSpy = vi.spyOn(scrollMod, "scrollToElement").mockImplementation(
+      async (_page, _raw, _sel, cx, cy) => ({
+        box: { x: 100, y: 100, width: 50, height: 30 },
+        cursorX: cx,
+        cursorY: cy,
+      }),
+    );
+
+    const { patchPage } = await import("../src/human-puppeteer/index.js");
+    const page = buildMockPage();
+    const cursor = { x: 100, y: 100, initialized: true };
+    patchPage(page as any, cfg, cursor as any);
+
+    await (page as any).type("#email", "hi", {
+      typing_delay: 30,
+      mistype_chance: 0,
+    });
+
+    expect(captured.typing_delay).toBe(30);
+    expect(captured.mistype_chance).toBe(0);
+    expect(cfg.typing_delay).toBe(70);
+
+    typeSpy.mockRestore();
+    scrollSpy.mockRestore();
+  });
+});
+
+
+// =========================================================================
 // patchPage stealth infrastructure (Puppeteer)
 // =========================================================================
 describe("Puppeteer: patchPage stealth infrastructure", () => {


### PR DESCRIPTION
Typed the remaining human interaction `options` in `js/src/human/index.ts` using `Partial<HumanConfig> & ({ timeout: number })` style, and updated the wrappers to merge config directly from `options` instead of nested `human_config`.