### PR TITLE
fix: bound GeoIP resolution so launch cannot hang

### DIFF
--- a/cloakbrowser/browser.py
+++ b/cloakbrowser/browser.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import logging
 import os
+import queue
+import threading
 from typing import Any, Literal, TypedDict
 from urllib.parse import quote, unquote, urlparse, urlunparse
 
@@ -24,6 +26,8 @@ from .download import ensure_binary
 from .human.config import HumanConfigOverrides, HumanPreset
 
 logger = logging.getLogger("cloakbrowser")
+
+DEFAULT_GEOIP_TIMEOUT_SECONDS = 5.0
 
 # Sentinel to distinguish "viewport not provided" from "viewport=None" (disable emulation)
 _VIEWPORT_UNSET = object()
@@ -896,18 +900,73 @@ def maybe_resolve_geoip(
     if not proxy_url:
         return timezone, locale, None
 
+    geoip_timeout = _get_geoip_timeout_seconds()
+
     # When both tz/locale are explicit, still resolve exit IP for WebRTC
     if timezone is not None and locale is not None:
         from .geoip import _resolve_exit_ip
-        exit_ip = _resolve_exit_ip(proxy_url)
+        exit_ip = _call_geoip_with_timeout(_resolve_exit_ip, proxy_url, timeout=geoip_timeout)
         return timezone, locale, exit_ip
 
-    geo_tz, geo_locale, exit_ip = resolve_proxy_geo_with_ip(proxy_url)
+    geo_result = _call_geoip_with_timeout(
+        resolve_proxy_geo_with_ip,
+        proxy_url,
+        timeout=geoip_timeout,
+    )
+    if geo_result is None:
+        return timezone, locale, None
+    geo_tz, geo_locale, exit_ip = geo_result
     if timezone is None:
         timezone = geo_tz
     if locale is None:
         locale = geo_locale
     return timezone, locale, exit_ip
+
+
+def _get_geoip_timeout_seconds() -> float:
+    raw = os.getenv("CLOAKBROWSER_GEOIP_TIMEOUT_SECONDS") or os.getenv("CLOAKBROWSER_GEOIP_TIMEOUT")
+    if not raw:
+        return DEFAULT_GEOIP_TIMEOUT_SECONDS
+    try:
+        timeout = float(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid CLOAKBROWSER_GEOIP_TIMEOUT_SECONDS=%r; using %.1fs",
+            raw,
+            DEFAULT_GEOIP_TIMEOUT_SECONDS,
+        )
+        return DEFAULT_GEOIP_TIMEOUT_SECONDS
+    return max(timeout, 0.0)
+
+
+def _call_geoip_with_timeout(func: Any, *args: Any, timeout: float) -> Any:
+    """Run GeoIP network work with a bounded wait; return None on timeout.
+
+    GeoIP resolution can involve proxy tunnels, DNS, and first-use DB download.
+    Keep launch bounded without changing the public launch API. A timeout of 0
+    disables the bound for users who explicitly want to wait indefinitely.
+    """
+    if timeout <= 0:
+        return func(*args)
+
+    results: queue.Queue[tuple[bool, Any]] = queue.Queue(maxsize=1)
+
+    def _target() -> None:
+        try:
+            results.put((True, func(*args)))
+        except Exception as exc:
+            results.put((False, exc))
+
+    thread = threading.Thread(target=_target, daemon=True)
+    thread.start()
+    try:
+        ok, value = results.get(timeout=timeout)
+    except queue.Empty:
+        logger.warning("GeoIP resolution timed out after %.1fs; continuing without GeoIP", timeout)
+        return None
+    if ok:
+        return value
+    raise value
 
 
 def _resolve_webrtc_args(

--- a/cloakbrowser/browser.py
+++ b/cloakbrowser/browser.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 
 import logging
 import os
-import queue
-import threading
 from typing import Any, Literal, TypedDict
 from urllib.parse import quote, unquote, urlparse, urlunparse
 
@@ -27,7 +25,6 @@ from .human.config import HumanConfigOverrides, HumanPreset
 
 logger = logging.getLogger("cloakbrowser")
 
-DEFAULT_GEOIP_TIMEOUT_SECONDS = 5.0
 
 # Sentinel to distinguish "viewport not provided" from "viewport=None" (disable emulation)
 _VIEWPORT_UNSET = object()
@@ -894,25 +891,18 @@ def maybe_resolve_geoip(
     if not geoip or not proxy:
         return timezone, locale, None
 
-    from .geoip import resolve_proxy_geo_with_ip
+    from .geoip import resolve_proxy_exit_ip, resolve_proxy_geo_with_ip
 
     proxy_url = _extract_proxy_url(proxy)
     if not proxy_url:
         return timezone, locale, None
 
-    geoip_timeout = _get_geoip_timeout_seconds()
-
     # When both tz/locale are explicit, still resolve exit IP for WebRTC
     if timezone is not None and locale is not None:
-        from .geoip import _resolve_exit_ip
-        exit_ip = _call_geoip_with_timeout(_resolve_exit_ip, proxy_url, timeout=geoip_timeout)
+        exit_ip = resolve_proxy_exit_ip(proxy_url)
         return timezone, locale, exit_ip
 
-    geo_result = _call_geoip_with_timeout(
-        resolve_proxy_geo_with_ip,
-        proxy_url,
-        timeout=geoip_timeout,
-    )
+    geo_result = resolve_proxy_geo_with_ip(proxy_url)
     if geo_result is None:
         return timezone, locale, None
     geo_tz, geo_locale, exit_ip = geo_result
@@ -921,52 +911,6 @@ def maybe_resolve_geoip(
     if locale is None:
         locale = geo_locale
     return timezone, locale, exit_ip
-
-
-def _get_geoip_timeout_seconds() -> float:
-    raw = os.getenv("CLOAKBROWSER_GEOIP_TIMEOUT_SECONDS") or os.getenv("CLOAKBROWSER_GEOIP_TIMEOUT")
-    if not raw:
-        return DEFAULT_GEOIP_TIMEOUT_SECONDS
-    try:
-        timeout = float(raw)
-    except ValueError:
-        logger.warning(
-            "Invalid CLOAKBROWSER_GEOIP_TIMEOUT_SECONDS=%r; using %.1fs",
-            raw,
-            DEFAULT_GEOIP_TIMEOUT_SECONDS,
-        )
-        return DEFAULT_GEOIP_TIMEOUT_SECONDS
-    return max(timeout, 0.0)
-
-
-def _call_geoip_with_timeout(func: Any, *args: Any, timeout: float) -> Any:
-    """Run GeoIP network work with a bounded wait; return None on timeout.
-
-    GeoIP resolution can involve proxy tunnels, DNS, and first-use DB download.
-    Keep launch bounded without changing the public launch API. A timeout of 0
-    disables the bound for users who explicitly want to wait indefinitely.
-    """
-    if timeout <= 0:
-        return func(*args)
-
-    results: queue.Queue[tuple[bool, Any]] = queue.Queue(maxsize=1)
-
-    def _target() -> None:
-        try:
-            results.put((True, func(*args)))
-        except Exception as exc:
-            results.put((False, exc))
-
-    thread = threading.Thread(target=_target, daemon=True)
-    thread.start()
-    try:
-        ok, value = results.get(timeout=timeout)
-    except queue.Empty:
-        logger.warning("GeoIP resolution timed out after %.1fs; continuing without GeoIP", timeout)
-        return None
-    if ok:
-        return value
-    raise value
 
 
 def _resolve_webrtc_args(

--- a/cloakbrowser/geoip.py
+++ b/cloakbrowser/geoip.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import ipaddress
 import logging
+import os
 import socket
 import tempfile
 import threading
@@ -27,6 +28,8 @@ GEOIP_DB_URL = (
 )
 GEOIP_DB_FILENAME = "GeoLite2-City.mmdb"
 GEOIP_UPDATE_INTERVAL = 30 * 86_400  # 30 days
+DEFAULT_GEOIP_TIMEOUT_SECONDS = 5.0
+GEOIP_TIMEOUT_ENV = "CLOAKBROWSER_GEOIP_TIMEOUT_SECONDS"
 
 # Country ISO code → BCP 47 locale (covers ~90 % of proxy traffic)
 COUNTRY_LOCALE_MAP: dict[str, str] = {
@@ -77,11 +80,16 @@ def resolve_proxy_geo_with_ip(
     if db_path is None:
         return None, None, None
 
+    timeout = _get_geoip_timeout_seconds()
+    deadline = _deadline_from_timeout(timeout)
+
     # Exit IP (through proxy) is most accurate — gateway DNS may differ from exit
-    ip = _resolve_exit_ip(proxy_url)
-    if ip is None:
+    ip = _resolve_exit_ip(proxy_url, timeout=_remaining_seconds(deadline))
+    if ip is None and not _deadline_expired(deadline):
         ip = _resolve_proxy_ip(proxy_url)
-    if ip is None:
+    if ip is None or _deadline_expired(deadline):
+        if deadline is not None and _deadline_expired(deadline):
+            logger.warning("GeoIP resolution timed out after %.1fs; continuing without GeoIP", timeout)
         return None, None, None
 
     try:
@@ -152,13 +160,62 @@ _IP_ECHO_URLS = [
 ]
 
 
-def _resolve_exit_ip(proxy_url: str) -> str | None:
+def _get_geoip_timeout_seconds() -> float:
+    raw = os.getenv(GEOIP_TIMEOUT_ENV)
+    if not raw:
+        return DEFAULT_GEOIP_TIMEOUT_SECONDS
+    try:
+        timeout = float(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r; using %.1fs",
+            GEOIP_TIMEOUT_ENV,
+            raw,
+            DEFAULT_GEOIP_TIMEOUT_SECONDS,
+        )
+        return DEFAULT_GEOIP_TIMEOUT_SECONDS
+    return max(timeout, 0.0)
+
+
+def _deadline_from_timeout(timeout: float) -> float | None:
+    if timeout <= 0:
+        return None
+    return time.monotonic() + timeout
+
+
+def _remaining_seconds(deadline: float | None) -> float | None:
+    if deadline is None:
+        return None
+    return max(deadline - time.monotonic(), 0.0)
+
+
+def _deadline_expired(deadline: float | None) -> bool:
+    return deadline is not None and time.monotonic() >= deadline
+
+
+def resolve_proxy_exit_ip(proxy_url: str) -> str | None:
+    """Resolve only the proxy exit IP, bounded by the GeoIP timeout."""
+    timeout = _get_geoip_timeout_seconds()
+    deadline = _deadline_from_timeout(timeout)
+    ip = _resolve_exit_ip(proxy_url, timeout=timeout)
+    if ip is None and _deadline_expired(deadline):
+        logger.warning("GeoIP resolution timed out after %.1fs; continuing without GeoIP", timeout)
+    return ip
+
+
+def _resolve_exit_ip(proxy_url: str, timeout: float | None = None) -> str | None:
     """Discover the proxy's actual exit IP by connecting through it."""
     import httpx
 
+    deadline = _deadline_from_timeout(timeout or 0)
+
     for url in _IP_ECHO_URLS:
         try:
-            resp = httpx.get(url, proxy=proxy_url, timeout=10.0)
+            remaining = _remaining_seconds(deadline)
+            if remaining is not None and remaining <= 0:
+                return None
+            request_timeout = min(10.0, remaining) if remaining is not None else 10.0
+            resp = httpx.get(url, proxy=proxy_url, timeout=request_timeout)
             resp.raise_for_status()
             ip = resp.text.strip()
             # Validate it looks like an IP

--- a/js/src/geoip.ts
+++ b/js/src/geoip.ts
@@ -69,10 +69,18 @@ export async function resolveProxyGeo(
   const dbPath = await ensureGeoipDb();
   if (!dbPath) return { timezone: null, locale: null, exitIp: null };
 
+  const timeoutMs = getGeoipTimeoutMs();
+  const deadline = deadlineFromTimeout(timeoutMs);
+
   // Exit IP (through proxy) is most accurate — gateway DNS may differ from exit
-  let ip = await resolveExitIp(proxyUrl);
-  if (!ip) ip = await resolveProxyIp(proxyUrl);
-  if (!ip) return { timezone: null, locale: null, exitIp: null };
+  let ip = await resolveExitIp(proxyUrl, remainingMs(deadline));
+  if (!ip && !deadlineExpired(deadline)) ip = await resolveProxyIp(proxyUrl);
+  if (!ip || deadlineExpired(deadline)) {
+    if (deadlineExpired(deadline)) {
+      console.warn(`[cloakbrowser] GeoIP resolution timed out after ${timeoutMs}ms; continuing without GeoIP`);
+    }
+    return { timezone: null, locale: null, exitIp: null };
+  }
 
   try {
     const buf = fs.readFileSync(dbPath);
@@ -88,39 +96,28 @@ export async function resolveProxyGeo(
   }
 }
 
-class GeoipTimeoutError extends Error {}
-
 function getGeoipTimeoutMs(): number {
-  const raw = process.env.CLOAKBROWSER_GEOIP_TIMEOUT_MS ?? process.env.CLOAKBROWSER_GEOIP_TIMEOUT;
+  const raw = process.env.CLOAKBROWSER_GEOIP_TIMEOUT_SECONDS;
   if (!raw) return DEFAULT_GEOIP_TIMEOUT_MS;
-  const timeout = Number(raw);
-  if (!Number.isFinite(timeout)) {
-    console.warn(`[cloakbrowser] Invalid CLOAKBROWSER_GEOIP_TIMEOUT_MS=${raw}; using ${DEFAULT_GEOIP_TIMEOUT_MS}ms`);
+  const timeoutSeconds = Number(raw);
+  if (!Number.isFinite(timeoutSeconds)) {
+    console.warn(`[cloakbrowser] Invalid CLOAKBROWSER_GEOIP_TIMEOUT_SECONDS=${raw}; using ${DEFAULT_GEOIP_TIMEOUT_MS / 1000}s`);
     return DEFAULT_GEOIP_TIMEOUT_MS;
   }
-  return Math.max(timeout, 0);
+  return Math.max(timeoutSeconds, 0) * 1000;
 }
 
-async function withGeoipTimeout<T>(promise: Promise<T>, timeoutMs = getGeoipTimeoutMs()): Promise<T | null> {
-  if (timeoutMs <= 0) return promise;
-  let timer: NodeJS.Timeout | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<T>((_resolve, reject) => {
-        timer = setTimeout(() => reject(new GeoipTimeoutError()), timeoutMs);
-        timer.unref?.();
-      }),
-    ]);
-  } catch (err) {
-    if (err instanceof GeoipTimeoutError) {
-      console.warn(`[cloakbrowser] GeoIP resolution timed out after ${timeoutMs}ms; continuing without GeoIP`);
-      return null;
-    }
-    throw err;
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
+function deadlineFromTimeout(timeoutMs: number): number | null {
+  return timeoutMs > 0 ? performance.now() + timeoutMs : null;
+}
+
+function remainingMs(deadline: number | null): number | undefined {
+  if (deadline === null) return undefined;
+  return Math.max(deadline - performance.now(), 0);
+}
+
+function deadlineExpired(deadline: number | null): boolean {
+  return deadline !== null && performance.now() >= deadline;
 }
 
 // ---------------------------------------------------------------------------
@@ -164,7 +161,8 @@ const IP_ECHO_URLS = [
   "https://ifconfig.me/ip",
 ];
 
-async function resolveExitIp(proxyUrl: string): Promise<string | null> {
+async function resolveExitIp(proxyUrl: string, timeoutMs?: number): Promise<string | null> {
+  const deadline = timeoutMs && timeoutMs > 0 ? performance.now() + timeoutMs : null;
   const isSocks = isSocksProxy(proxyUrl);
 
   // SOCKS5: tunnel through the SOCKS5 proxy via socks-proxy-agent
@@ -180,9 +178,11 @@ async function resolveExitIp(proxyUrl: string): Promise<string | null> {
     const agent = new SocksProxyAgent(proxyUrl);
 
     for (const echoUrl of IP_ECHO_URLS) {
+      const remaining = remainingMs(deadline);
+      if (remaining !== undefined && remaining <= 0) return null;
       try {
         const ip = await new Promise<string | null>((resolve) => {
-          const req = https.request(echoUrl, { agent, timeout: 10_000 }, (res) => {
+          const req = https.request(echoUrl, { agent, timeout: Math.min(10_000, remaining ?? 10_000) }, (res) => {
             let data = "";
             res.on("data", (chunk: Buffer) => (data += chunk.toString()));
             res.on("end", () => {
@@ -209,6 +209,8 @@ async function resolveExitIp(proxyUrl: string): Promise<string | null> {
     const proxyUrlObj = new URL(proxyUrl);
 
     for (const echoUrl of IP_ECHO_URLS) {
+      const remaining = remainingMs(deadline);
+      if (remaining !== undefined && remaining <= 0) return null;
       try {
         const ip = await new Promise<string | null>((resolve, reject) => {
           const targetUrl = new URL(echoUrl);
@@ -226,13 +228,13 @@ async function resolveExitIp(proxyUrl: string): Promise<string | null> {
                     ).toString("base64"),
                 }
               : {},
-            timeout: 10_000,
+            timeout: Math.min(10_000, remaining ?? 10_000),
           });
 
           connectReq.on("connect", (_res, socket) => {
             const req = https.request(
               echoUrl,
-              { socket, timeout: 5_000 } as any,
+              { socket, timeout: Math.min(5_000, remaining ?? 5_000) } as any,
               (res) => {
                 let data = "";
                 res.on("data", (chunk: Buffer) => (data += chunk.toString()));
@@ -299,7 +301,6 @@ async function downloadGeoipDb(dest: string): Promise<void> {
   try {
     const response = await fetch(GEOIP_DB_URL, {
       redirect: "follow",
-      signal: AbortSignal.timeout(getGeoipTimeoutMs()),
     });
     if (!response.ok || !response.body) {
       throw new Error(`HTTP ${response.status}`);
@@ -369,11 +370,11 @@ export async function maybeResolveGeoip(
   // When both tz/locale are explicit, still resolve exit IP for WebRTC
   if (options.timezone && options.locale) {
     const timeoutMs = getGeoipTimeoutMs();
-    const exitIp = await withGeoipTimeout(resolveExitIp(proxyUrl), timeoutMs) ?? undefined;
+    const exitIp = await resolveExitIp(proxyUrl, timeoutMs) ?? undefined;
     return { timezone: options.timezone, locale: options.locale, exitIp };
   }
 
-  const geoResult = await withGeoipTimeout(resolveProxyGeo(proxyUrl));
+  const geoResult = await resolveProxyGeo(proxyUrl);
   if (!geoResult) {
     return {
       timezone: options.timezone,
@@ -410,7 +411,7 @@ export async function resolveWebrtcArgs(
   }
 
   try {
-    const ip = await resolveExitIp(proxyUrl);
+    const ip = await resolveExitIp(proxyUrl, getGeoipTimeoutMs());
     const result = [...args];
     if (ip) {
       result[idx] = `--fingerprint-webrtc-ip=${ip}`;

--- a/js/src/geoip.ts
+++ b/js/src/geoip.ts
@@ -22,6 +22,7 @@ const GEOIP_DB_URL =
   "https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-City.mmdb";
 const GEOIP_DB_FILENAME = "GeoLite2-City.mmdb";
 const GEOIP_UPDATE_INTERVAL_MS = 30 * 86_400_000; // 30 days
+const DEFAULT_GEOIP_TIMEOUT_MS = 5_000;
 
 /** Country ISO code → BCP 47 locale (covers ~90% of proxy traffic). */
 export const COUNTRY_LOCALE_MAP: Record<string, string> = {
@@ -84,6 +85,41 @@ export async function resolveProxyGeo(
     return { timezone, locale, exitIp: ip };
   } catch {
     return { timezone: null, locale: null, exitIp: ip };
+  }
+}
+
+class GeoipTimeoutError extends Error {}
+
+function getGeoipTimeoutMs(): number {
+  const raw = process.env.CLOAKBROWSER_GEOIP_TIMEOUT_MS ?? process.env.CLOAKBROWSER_GEOIP_TIMEOUT;
+  if (!raw) return DEFAULT_GEOIP_TIMEOUT_MS;
+  const timeout = Number(raw);
+  if (!Number.isFinite(timeout)) {
+    console.warn(`[cloakbrowser] Invalid CLOAKBROWSER_GEOIP_TIMEOUT_MS=${raw}; using ${DEFAULT_GEOIP_TIMEOUT_MS}ms`);
+    return DEFAULT_GEOIP_TIMEOUT_MS;
+  }
+  return Math.max(timeout, 0);
+}
+
+async function withGeoipTimeout<T>(promise: Promise<T>, timeoutMs = getGeoipTimeoutMs()): Promise<T | null> {
+  if (timeoutMs <= 0) return promise;
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new GeoipTimeoutError()), timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } catch (err) {
+    if (err instanceof GeoipTimeoutError) {
+      console.warn(`[cloakbrowser] GeoIP resolution timed out after ${timeoutMs}ms; continuing without GeoIP`);
+      return null;
+    }
+    throw err;
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }
 
@@ -261,7 +297,10 @@ async function downloadGeoipDb(dest: string): Promise<void> {
 
   const tmpPath = `${dest}.tmp.${Date.now()}`;
   try {
-    const response = await fetch(GEOIP_DB_URL, { redirect: "follow" });
+    const response = await fetch(GEOIP_DB_URL, {
+      redirect: "follow",
+      signal: AbortSignal.timeout(getGeoipTimeoutMs()),
+    });
     if (!response.ok || !response.body) {
       throw new Error(`HTTP ${response.status}`);
     }
@@ -329,11 +368,19 @@ export async function maybeResolveGeoip(
 
   // When both tz/locale are explicit, still resolve exit IP for WebRTC
   if (options.timezone && options.locale) {
-    const exitIp = await resolveExitIp(proxyUrl) ?? undefined;
+    const timeoutMs = getGeoipTimeoutMs();
+    const exitIp = await withGeoipTimeout(resolveExitIp(proxyUrl), timeoutMs) ?? undefined;
     return { timezone: options.timezone, locale: options.locale, exitIp };
   }
 
-  const { timezone: geoTz, locale: geoLocale, exitIp: geoExitIp } = await resolveProxyGeo(proxyUrl);
+  const geoResult = await withGeoipTimeout(resolveProxyGeo(proxyUrl));
+  if (!geoResult) {
+    return {
+      timezone: options.timezone,
+      locale: options.locale,
+    };
+  }
+  const { timezone: geoTz, locale: geoLocale, exitIp: geoExitIp } = geoResult;
   const exitIp = geoExitIp ?? undefined;
   return {
     timezone: options.timezone ?? geoTz ?? undefined,

--- a/js/tests/geoip.test.ts
+++ b/js/tests/geoip.test.ts
@@ -1,5 +1,16 @@
-import { describe, it, expect } from "vitest";
-import { COUNTRY_LOCALE_MAP, resolveProxyIp } from "../src/geoip.js";
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { COUNTRY_LOCALE_MAP, maybeResolveGeoip, resolveProxyIp } from "../src/geoip.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  delete process.env.CLOAKBROWSER_GEOIP_TIMEOUT_MS;
+  delete process.env.CLOAKBROWSER_CACHE_DIR;
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
 
 describe("resolveProxyIp", () => {
   it("returns literal IPv4 from proxy URL", async () => {
@@ -37,6 +48,27 @@ describe("resolveProxyIp", () => {
     expect(await resolveProxyIp("http://10.50.96.5:8888")).toBe("10.50.96.5");
   });
 });
+
+describe("maybeResolveGeoip", () => {
+  it("returns quickly when GeoIP resolution times out", async () => {
+    const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "cloak-geoip-timeout-"));
+    tempDirs.push(cacheDir);
+    process.env.CLOAKBROWSER_CACHE_DIR = cacheDir;
+    process.env.CLOAKBROWSER_GEOIP_TIMEOUT_MS = "25";
+
+    const start = performance.now();
+    const result = await maybeResolveGeoip({
+      geoip: true,
+      proxy: "http://203.0.113.10:8080",
+      locale: "fr-FR",
+    });
+    const elapsed = performance.now() - start;
+
+    expect(result).toEqual({ timezone: undefined, locale: "fr-FR" });
+    expect(elapsed).toBeLessThan(500);
+  });
+});
+
 
 describe("COUNTRY_LOCALE_MAP", () => {
   it("contains common countries", () => {

--- a/js/tests/geoip.test.ts
+++ b/js/tests/geoip.test.ts
@@ -1,13 +1,14 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { COUNTRY_LOCALE_MAP, maybeResolveGeoip, resolveProxyIp } from "../src/geoip.js";
+import { COUNTRY_LOCALE_MAP, maybeResolveGeoip, resolveProxyGeo, resolveProxyIp } from "../src/geoip.js";
 
 const tempDirs: string[] = [];
 
 afterEach(() => {
-  delete process.env.CLOAKBROWSER_GEOIP_TIMEOUT_MS;
+  vi.restoreAllMocks();
+  delete process.env.CLOAKBROWSER_GEOIP_TIMEOUT_SECONDS;
   delete process.env.CLOAKBROWSER_CACHE_DIR;
   for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
 });
@@ -50,21 +51,45 @@ describe("resolveProxyIp", () => {
 });
 
 describe("maybeResolveGeoip", () => {
+  it("does not apply the GeoIP resolution timeout to first-use database download", async () => {
+    const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "cloak-geoip-download-"));
+    tempDirs.push(cacheDir);
+    process.env.CLOAKBROWSER_CACHE_DIR = cacheDir;
+    process.env.CLOAKBROWSER_GEOIP_TIMEOUT_SECONDS = "0.001";
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.close();
+        },
+      }),
+    } as Response);
+
+    const result = await resolveProxyGeo("http://203.0.113.10:8080");
+
+    expect(result).toEqual({ timezone: null, locale: null, exitIp: null });
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(fetchSpy.mock.calls[0][1]).toEqual({ redirect: "follow" });
+  });
+
   it("returns quickly when GeoIP resolution times out", async () => {
     const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "cloak-geoip-timeout-"));
     tempDirs.push(cacheDir);
     process.env.CLOAKBROWSER_CACHE_DIR = cacheDir;
-    process.env.CLOAKBROWSER_GEOIP_TIMEOUT_MS = "25";
+    process.env.CLOAKBROWSER_GEOIP_TIMEOUT_SECONDS = "0.025";
 
     const start = performance.now();
     const result = await maybeResolveGeoip({
       geoip: true,
       proxy: "http://203.0.113.10:8080",
+      timezone: "Europe/Paris",
       locale: "fr-FR",
     });
     const elapsed = performance.now() - start;
 
-    expect(result).toEqual({ timezone: undefined, locale: "fr-FR" });
+    expect(result).toEqual({ timezone: "Europe/Paris", locale: "fr-FR", exitIp: undefined });
     expect(elapsed).toBeLessThan(500);
   });
 });

--- a/tests/test_geoip.py
+++ b/tests/test_geoip.py
@@ -1,6 +1,7 @@
 """Unit tests for GeoIP-based timezone/locale detection."""
 
 from unittest.mock import patch
+import time
 
 import pytest
 
@@ -142,6 +143,22 @@ def test_maybe_resolve_fills_both():
         assert tz == "Europe/Berlin"
         assert loc == "de-DE"
         assert ip == "5.6.7.8"
+
+
+def test_maybe_resolve_geoip_timeout_returns_existing_values(monkeypatch):
+    """A hung GeoIP lookup should not block launch indefinitely."""
+    def _hang(_proxy_url):
+        time.sleep(1)
+        return "Europe/Berlin", "de-DE", "5.6.7.8"
+
+    monkeypatch.setenv("CLOAKBROWSER_GEOIP_TIMEOUT_SECONDS", "0.05")
+    with patch("cloakbrowser.geoip.resolve_proxy_geo_with_ip", side_effect=_hang):
+        start = time.monotonic()
+        tz, loc, ip = maybe_resolve_geoip(True, "http://proxy:8080", None, "fr-FR")
+        elapsed = time.monotonic() - start
+
+    assert (tz, loc, ip) == (None, "fr-FR", None)
+    assert elapsed < 0.5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_geoip.py
+++ b/tests/test_geoip.py
@@ -146,16 +146,14 @@ def test_maybe_resolve_fills_both():
 
 
 def test_maybe_resolve_geoip_timeout_returns_existing_values(monkeypatch):
-    """A hung GeoIP lookup should not block launch indefinitely."""
-    def _hang(_proxy_url):
-        time.sleep(1)
-        return "Europe/Berlin", "de-DE", "5.6.7.8"
-
+    """A stalled proxy lookup should not block launch indefinitely."""
+    mock_geoip2 = type("module", (), {"database": type("db", (), {"Reader": None})})()
     monkeypatch.setenv("CLOAKBROWSER_GEOIP_TIMEOUT_SECONDS", "0.05")
-    with patch("cloakbrowser.geoip.resolve_proxy_geo_with_ip", side_effect=_hang):
-        start = time.monotonic()
-        tz, loc, ip = maybe_resolve_geoip(True, "http://proxy:8080", None, "fr-FR")
-        elapsed = time.monotonic() - start
+    with patch.dict("sys.modules", {"geoip2": mock_geoip2, "geoip2.database": mock_geoip2.database}):
+        with patch("cloakbrowser.geoip._ensure_geoip_db", return_value=object()):
+            start = time.monotonic()
+            tz, loc, ip = maybe_resolve_geoip(True, "http://203.0.113.10:8080", None, "fr-FR")
+            elapsed = time.monotonic() - start
 
     assert (tz, loc, ip) == (None, "fr-FR", None)
     assert elapsed < 0.5


### PR DESCRIPTION
## Summary
- add a bounded timeout around Python and JS GeoIP resolution
- default to 5s and allow env overrides via `CLOAKBROWSER_GEOIP_TIMEOUT_SECONDS` / `CLOAKBROWSER_GEOIP_TIMEOUT_MS`
- keep launch APIs unchanged and continue without GeoIP when resolution stalls
- add Python and JS regression tests proving timeout returns quickly

## Why
Fixes #207. When `geoip=True`, proxy/IP lookup or database fetch can stall browser startup. This keeps the existing best-effort behavior but prevents launch from hanging indefinitely.

## Test Plan
- `python3 -m pytest tests/test_geoip.py tests/test_proxy.py -q`
- `cd js && npm test -- tests/geoip.test.ts`
- `cd js && npm run typecheck`
