### PR TITLE
chore(js): sync package-lock metadata

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloakbrowser",
-  "version": "0.3.23",
+  "version": "0.3.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cloakbrowser",
-      "version": "0.3.23",
+      "version": "0.3.28",
       "license": "MIT",
       "dependencies": {
         "tar": "^7.0.0"
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@types/node": "^20.10.0",
         "mmdb-lib": "^3.0.2",
-        "playwright-core": "^1.40.0",
+        "playwright-core": "^1.53.0",
         "puppeteer-core": "^21.0.0",
         "socks-proxy-agent": "^10.0.0",
         "typescript": "^5.3.0",
@@ -28,9 +28,9 @@
       },
       "peerDependencies": {
         "mmdb-lib": ">=2.0.0",
-        "playwright-core": ">=1.40.0",
+        "playwright-core": ">=1.53.0",
         "puppeteer-core": ">=21.0.0",
-        "socks-proxy-agent": ">=8.0.0"
+        "socks-proxy-agent": ">=10.0.0"
       },
       "peerDependenciesMeta": {
         "mmdb-lib": {
@@ -1329,7 +1329,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
       "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",


### PR DESCRIPTION
Sync js/package-lock.json root metadata with js/package.json after the 0.3.28 release.\n\nThis updates the lockfile package version and root dependency metadata without changing runtime code.\n\nValidation:\n- npm_config_cache=/private/tmp/npm-cache npm ci --ignore-scripts\n- npm run typecheck\n- ./node_modules/.bin/vitest run --root .