### PR TITLE
Add flake.nix for Nix / NixOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ js/dist/
 *.whl
 AGENTS.md
 .beads
+result
 
 # Private docs (launch posts, strategy)
 docs/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -207,8 +207,8 @@
             hatchling
             httpx
             playwright
-            pytest_8_3
-            pytest-asyncio_0
+            pytest
+            pytest-asyncio
             socksio
             websockets
           ]);

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,189 @@
+{
+  description = "CloakBrowser development shell with Nix-packaged Chromium binaries";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      inherit (nixpkgs) lib;
+
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+
+      forAllSystems = lib.genAttrs supportedSystems;
+
+      chromiumVersion = "146.0.7680.177.3";
+
+      packageInfo = {
+        x86_64-linux = {
+          platformTag = "linux-x64";
+          hash = "sha256-WvAn+q+x/vmTPreEwJS3ZHBt4io3KizuhLwRf8SrU38=";
+        };
+        aarch64-linux = {
+          platformTag = "linux-arm64";
+          hash = "sha256-i3HOU7T9ExMnMxox+6ODXXGILRm/qr3njdD1OQvRb0U=";
+        };
+      };
+
+      mkPkgs = system: import nixpkgs {
+        inherit system;
+        config.allowUnfree = true;
+      };
+
+      runtimeLibraries = pkgs: with pkgs; [
+        alsa-lib
+        at-spi2-atk
+        at-spi2-core
+        atk
+        cairo
+        cups
+        dbus
+        expat
+        fontconfig
+        freetype
+        gdk-pixbuf
+        glib
+        gtk3
+        libdrm
+        libgbm
+        libGL
+        libpulseaudio
+        libxkbcommon
+        mesa
+        nspr
+        nss
+        pango
+        systemd
+        wayland
+        libx11
+        libxcb
+        libxcomposite
+        libxcursor
+        libxdamage
+        libxext
+        libxfixes
+        libxi
+        libxrandr
+        libxrender
+        libxscrnsaver
+        libxshmfence
+        libxtst
+      ];
+
+      fontPackages = pkgs: with pkgs; [
+        freefont_ttf
+        ipafont
+        liberation_ttf
+        noto-fonts
+        noto-fonts-cjk-sans
+        noto-fonts-color-emoji
+        tlwg
+        unifont
+        wqy_zenhei
+      ];
+
+      mkCloakBrowserChromium = pkgs: system:
+        let
+          info = packageInfo.${system} or (throw "CloakBrowser flake package currently supports only x86_64-linux and aarch64-linux.");
+          archiveName = "cloakbrowser-${info.platformTag}.tar.gz";
+          libs = runtimeLibraries pkgs;
+        in
+        pkgs.stdenvNoCC.mkDerivation {
+          pname = "cloakbrowser-chromium";
+          version = chromiumVersion;
+
+          src = pkgs.fetchurl {
+            url = "https://cloakbrowser.dev/chromium-v${chromiumVersion}/${archiveName}";
+            inherit (info) hash;
+          };
+
+          dontUnpack = true;
+
+          nativeBuildInputs = with pkgs; [
+            autoPatchelfHook
+            makeWrapper
+          ];
+
+          buildInputs = libs;
+          runtimeDependencies = libs;
+
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p "$out/lib/cloakbrowser" "$out/bin"
+            tar -xzf "$src" -C "$out/lib/cloakbrowser"
+            chmod +x "$out/lib/cloakbrowser/chrome"
+
+            runHook postInstall
+          '';
+
+          postFixup = ''
+            makeWrapper "$out/lib/cloakbrowser/chrome" "$out/bin/cloakbrowser-chrome" \
+              --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath libs}"
+          '';
+
+          meta = {
+            description = "Official CloakBrowser patched Chromium binary";
+            homepage = "https://github.com/CloakHQ/CloakBrowser";
+            license = lib.licenses.unfreeRedistributable;
+            mainProgram = "cloakbrowser-chrome";
+            platforms = supportedSystems;
+            sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+          };
+        };
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = mkPkgs system;
+          cloakbrowserChromium = mkCloakBrowserChromium pkgs system;
+        in
+        {
+          inherit cloakbrowserChromium;
+          default = cloakbrowserChromium;
+        });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = mkPkgs system;
+          cloakbrowserChromium = self.packages.${system}.cloakbrowserChromium;
+          python = pkgs.python312.withPackages (ps: with ps; [
+            aiohttp
+            geoip2
+            hatchling
+            httpx
+            playwright
+            pytest_8_3
+            pytest-asyncio_0
+            socksio
+            websockets
+          ]);
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [
+              cloakbrowserChromium
+              python
+              pkgs.cacert
+              pkgs.curl
+              pkgs.git
+              pkgs.jq
+              pkgs.nodejs_20
+              pkgs.which
+              pkgs.xdotool
+              pkgs.xvfb-run
+            ]
+            ++ runtimeLibraries pkgs
+            ++ fontPackages pkgs;
+
+            shellHook = ''
+              export CLOAKBROWSER_BINARY_PATH="${cloakbrowserChromium}/bin/cloakbrowser-chrome"
+            '';
+          };
+        });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -16,17 +16,25 @@
 
       forAllSystems = lib.genAttrs supportedSystems;
 
-      chromiumVersion = "146.0.7680.177.3";
-
       packageInfo = {
         x86_64-linux = {
           platformTag = "linux-x64";
+          version = "146.0.7680.177.3";
           hash = "sha256-WvAn+q+x/vmTPreEwJS3ZHBt4io3KizuhLwRf8SrU38=";
         };
         aarch64-linux = {
           platformTag = "linux-arm64";
+          version = "146.0.7680.177.3";
           hash = "sha256-i3HOU7T9ExMnMxox+6ODXXGILRm/qr3njdD1OQvRb0U=";
         };
+      };
+
+      cloakbrowserBinaryLicense = {
+        shortName = "cloakbrowser-binary";
+        fullName = "CloakBrowser Binary License";
+        url = "https://github.com/CloakHQ/CloakBrowser/blob/main/BINARY-LICENSE.md";
+        free = false;
+        redistributable = false;
       };
 
       mkPkgs = system: import nixpkgs {
@@ -86,11 +94,23 @@
         wqy_zenhei
       ];
 
+      desktopPackages = pkgs: with pkgs; [
+        adwaita-icon-theme
+        gsettings-desktop-schemas
+        xdg-utils
+      ];
+
       mkCloakBrowserChromium = pkgs: system:
         let
           info = packageInfo.${system} or (throw "CloakBrowser flake package currently supports only x86_64-linux and aarch64-linux.");
           archiveName = "cloakbrowser-${info.platformTag}.tar.gz";
+          chromiumVersion = info.version;
           libs = runtimeLibraries pkgs;
+          desktopDeps = desktopPackages pkgs;
+          fonts = fontPackages pkgs;
+          fontsConf = pkgs.makeFontsConf {
+            fontDirectories = fonts;
+          };
         in
         pkgs.stdenvNoCC.mkDerivation {
           pname = "cloakbrowser-chromium";
@@ -108,7 +128,7 @@
             makeWrapper
           ];
 
-          buildInputs = libs;
+          buildInputs = libs ++ desktopDeps;
           runtimeDependencies = libs;
 
           installPhase = ''
@@ -117,19 +137,27 @@
             mkdir -p "$out/lib/cloakbrowser" "$out/bin"
             tar -xzf "$src" -C "$out/lib/cloakbrowser"
             chmod +x "$out/lib/cloakbrowser/chrome"
+            chmod +x "$out/lib/cloakbrowser/chromedriver"
 
             runHook postInstall
           '';
 
           postFixup = ''
             makeWrapper "$out/lib/cloakbrowser/chrome" "$out/bin/cloakbrowser-chrome" \
+              --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath libs}" \
+              --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$XDG_ICON_DIRS" \
+              --suffix PATH : "${lib.makeBinPath [ pkgs.xdg-utils ]}" \
+              --set FONTCONFIG_FILE "${fontsConf}" \
+              --set CHROME_WRAPPER "cloakbrowser-chrome"
+
+            makeWrapper "$out/lib/cloakbrowser/chromedriver" "$out/bin/cloakbrowser-chromedriver" \
               --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath libs}"
           '';
 
           meta = {
             description = "Official CloakBrowser patched Chromium binary";
             homepage = "https://github.com/CloakHQ/CloakBrowser";
-            license = lib.licenses.unfreeRedistributable;
+            license = cloakbrowserBinaryLicense;
             mainProgram = "cloakbrowser-chrome";
             platforms = supportedSystems;
             sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
@@ -145,6 +173,28 @@
         {
           inherit cloakbrowserChromium;
           default = cloakbrowserChromium;
+        });
+
+      apps = forAllSystems (system:
+        let
+          cloakbrowserChromium = self.packages.${system}.cloakbrowserChromium;
+        in
+        {
+          default = {
+            type = "app";
+            program = "${cloakbrowserChromium}/bin/cloakbrowser-chrome";
+            meta.description = "Run CloakBrowser Chromium";
+          };
+          cloakbrowser-chrome = {
+            type = "app";
+            program = "${cloakbrowserChromium}/bin/cloakbrowser-chrome";
+            meta.description = "Run CloakBrowser Chromium";
+          };
+          cloakbrowser-chromedriver = {
+            type = "app";
+            program = "${cloakbrowserChromium}/bin/cloakbrowser-chromedriver";
+            meta.description = "Run the CloakBrowser Chromedriver binary";
+          };
         });
 
       devShells = forAllSystems (system:
@@ -180,9 +230,7 @@
             ++ runtimeLibraries pkgs
             ++ fontPackages pkgs;
 
-            shellHook = ''
-              export CLOAKBROWSER_BINARY_PATH="${cloakbrowserChromium}/bin/cloakbrowser-chrome"
-            '';
+            CLOAKBROWSER_BINARY_PATH = "${cloakbrowserChromium}/bin/cloakbrowser-chrome";
           };
         });
     };


### PR DESCRIPTION
## Why

I use NixOS and try to use Nix in my projects. An official `flake.nix` lets me use CloakBrowser as a deterministic Nix dependency instead of depending on npm/Python install-time browser downloads.

I already use this PR from my own flakes:

- https://github.com/Seryiza/yo-url-yo-json/blob/master/flake.nix
- https://github.com/Seryiza/housekg-telegram-notifications/blob/master/flake.nix

## What

This PR adds a Nix flake for Linux developers. It packages the official CloakBrowser Chromium binary and exposes:

- `packages.${system}.cloakbrowserChromium`
- `packages.${system}.default`
- `apps.${system}.default`
- `apps.${system}.cloakbrowser-chrome`
- `apps.${system}.cloakbrowser-chromedriver`
- `devShells.${system}.default`

It also wraps the browser with the needed runtime libraries, fonts, desktop/GSettings data, and sets `CLOAKBROWSER_BINARY_PATH` in the dev shell.

To update it for a new Linux binary, change `packageInfo`:

- `platformTag`
- `version`
- `hash`

Supported systems:

- `x86_64-linux`
- `aarch64-linux`

## Usage Example

Run CloakBrowser directly from this PR/fork:

```bash
nix run github:Seryiza/CloakBrowser#cloakbrowser-chrome -- --new-window
```

After this PR is merged, the upstream command will work too:

```bash
nix run github:CloakHQ/CloakBrowser#cloakbrowser-chrome -- --new-window
```

Use it from another flake:

```nix
{
  inputs = {
    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";

    cloakbrowser = {
      url = "github:CloakHQ/CloakBrowser";
      inputs.nixpkgs.follows = "nixpkgs";
    };
  };

  outputs = { nixpkgs, cloakbrowser, ... }:
    let
      system = "x86_64-linux";
      pkgs = import nixpkgs { inherit system; };
      cloakbrowserChromium = cloakbrowser.packages.${system}.cloakbrowserChromium;
    in
    {
      devShells.${system}.default = pkgs.mkShell {
        packages = [
          cloakbrowserChromium
          pkgs.python312
        ];

        CLOAKBROWSER_BINARY_PATH = "${cloakbrowserChromium}/bin/cloakbrowser-chrome";
      };
    };
}
```
