### PR TITLE
fix(security): bump tar + transitive deps via npm audit fix

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloakbrowser",
-  "version": "0.3.23",
+  "version": "0.3.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cloakbrowser",
-      "version": "0.3.23",
+      "version": "0.3.28",
       "license": "MIT",
       "dependencies": {
         "tar": "^7.0.0"
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@types/node": "^20.10.0",
         "mmdb-lib": "^3.0.2",
-        "playwright-core": "^1.40.0",
+        "playwright-core": "^1.53.0",
         "puppeteer-core": "^21.0.0",
         "socks-proxy-agent": "^10.0.0",
         "typescript": "^5.3.0",
@@ -28,9 +28,9 @@
       },
       "peerDependencies": {
         "mmdb-lib": ">=2.0.0",
-        "playwright-core": ">=1.40.0",
+        "playwright-core": ">=1.53.0",
         "puppeteer-core": ">=21.0.0",
-        "socks-proxy-agent": ">=8.0.0"
+        "socks-proxy-agent": ">=10.0.0"
       },
       "peerDependenciesMeta": {
         "mmdb-lib": {
@@ -1092,9 +1092,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1684,9 +1684,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2114,9 +2114,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -2496,9 +2496,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
-      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",


### PR DESCRIPTION
## Summary

Patches 8 of 14 dependency CVEs flagged by `osv-scanner` against `js/package-lock.json`. All bumps fit within the existing semver ranges in `package.json`, produced by `npm audit fix --package-lock-only`. The other 6 are gated on a `puppeteer-core` / `vitest` major-version bump and intentionally left for a separate PR.

## Impact

The only runtime (shipped-to-users) dep in the bundle is **`tar`** (7.5.9 → 7.5.15), which addresses two HIGH CVEs:

- `GHSA-9ppj-qmqm-q256` — Symlink Path Traversal via Drive-Relative Linkpath
- `GHSA-qffp-2rhf-9h96` — Hardlink Path Traversal via Drive-Relative Linkpath

Reach: `tar.extract()` is called from `js/src/download.ts:extractTar` to unpack the Chromium tarball under `~/.cloakbrowser/`. The existing entry `filter()` rejects absolute paths and `..` in the `name` field, but does not inspect the **linkpath** of a symlink/hardlink entry. A malicious Chromium mirror (or a downgrade-attack on the SHA256SUMS lookup, which warns-and-skips when missing) could ship a tarball with a drive-relative linkpath that writes outside the cache directory on Windows.

The other 6 patched CVEs are in **dev-only** transitive deps (`basic-ftp`, `ip-address`, `postcss`) so they do not ship to consumers of `cloakbrowser`, but they still affect anyone who runs `npm install` against this repo (CI, contributors).

## Location

`js/package-lock.json`

## Fix

| package      | before  | after   | CVEs                                   |
|--------------|---------|---------|----------------------------------------|
| tar          | 7.5.9   | 7.5.15  | GHSA-9ppj-qmqm-q256, GHSA-qffp-2rhf-9h96 (both HIGH, runtime) |
| basic-ftp    | 5.2.0   | 5.3.1   | GHSA-6v7q-wjvx-w8wg, -chqc-8p9q-pq6q, -rp42-5vxx-qpwr, -rpmf-866q-6p89 (4 × HIGH, dev) |
| ip-address   | 10.1.0  | 10.2.0  | GHSA-v2v4-37r5-5v8g (MOD, dev)         |
| postcss      | 8.5.6   | 8.5.14  | GHSA-qx2v-qp2m-jg93 (MOD, dev)         |

### Lockfile metadata side-effects

`npm audit fix --package-lock-only` also regenerated the lockfile metadata to match the current `package.json` (which had drifted ahead of the committed lockfile):

- top-level `name@version` (0.3.23 → 0.3.28)
- `devDependencies.playwright-core` range (^1.40.0 → ^1.53.0)
- `peerDependencies.playwright-core` range (>=1.40.0 → >=1.53.0)
- `peerDependencies.socks-proxy-agent` range (>=8.0.0 → >=10.0.0)

These are not editorial changes — they're npm bringing the lockfile back in sync with what `package.json` already declares. Happy to split them out into a separate cleanup PR if you'd prefer to keep this one pure-CVE.

## Detected by

Aeon + osv-scanner.
- Severity: high (runtime tar) / high+moderate (dev deps)
- 8 of 14 CVEs from the initial scan; remaining 6 (esbuild, tar-fs ×3, vite, ws) need a `puppeteer-core` 21 → 24 + `vitest` 1 → 3 bump, which is a breaking change.

## Verification

- `npm test` → **320 passed / 11 skipped / 0 failed** across 9 test files (including the tar-using download tests).
- `npm run typecheck` → clean.
- `osv-scanner` before this PR: 14 vulnerable advisories. After: 6 (all dev-only, all gated on the major bump above).

---

Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).