### PR TITLE
feat(docker): opt-in GPU acceleration via CLOAKBROWSER_GPU_ACCEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ Access the original un-patched Playwright page at `page._original` if you need r
 | `CLOAKBROWSER_AUTO_UPDATE` | `true` | Set to `false` to disable background update checks |
 | `CLOAKBROWSER_SKIP_CHECKSUM` | `false` | Set to `true` to skip SHA-256 verification after download |
 | `CLOAKBROWSER_GEOIP_TIMEOUT_SECONDS` | `5` | Max seconds for GeoIP resolution before continuing without it |
+| `CLOAKBROWSER_GPU_ACCEL` | — | Set to `1` to opt in to Docker GPU acceleration flags |
 
 ## Fingerprint Management
 
@@ -856,6 +857,12 @@ services:
       retries: 3
       start_period: 10s
 ```
+
+### GPU acceleration in Docker
+
+GPU acceleration is opt-in. Set `CLOAKBROWSER_GPU_ACCEL=1` to add Chromium's EGL, GPU rasterization, GPU blocklist bypass, and Linux Vaapi video decode flags. If you use NVIDIA GPUs, install the NVIDIA Container Toolkit on the Docker host and add a GPU device reservation to your Compose service.
+
+See [`examples/docker-compose.gpu.yml`](examples/docker-compose.gpu.yml) for a complete Compose example. If you run CloakBrowser inside your own multi-container stack, mirror the environment variable and GPU reservation in that service.
 
 **Per-connection fingerprint seeds** — run multiple browser identities from a single container. Each unique seed spawns a separate Chrome process with its own fingerprint:
 

--- a/README.md
+++ b/README.md
@@ -666,6 +666,7 @@ Access the original un-patched Playwright page at `page._original` if you need r
 | `CLOAKBROWSER_WIDEVINE` | `1` | Set to `0` to disable automatic Widevine hint-file seeding for persistent contexts |
 | `CLOAKBROWSER_FETCH_WIDEVINE` | `0` | Docker only: set to `1` to auto-fetch the Widevine CDM on container start (Linux x86-64 only). See [Widevine / DRM](#widevine--drm) |
 | `CLOAKBROWSER_VERSION` | — | Pin to an exact Chromium version for rollback (e.g. `148.0.7778.215.2`). Works with Free and Pro binaries |
+| `CLOAKBROWSER_GPU_ACCEL` | — | Set to `1` to opt in to Docker GPU acceleration flags |
 
 ## Fingerprint Management
 
@@ -976,6 +977,12 @@ services:
       retries: 3
       start_period: 10s
 ```
+
+### GPU acceleration in Docker
+
+GPU acceleration is opt-in. Set `CLOAKBROWSER_GPU_ACCEL=1` to add Chromium's EGL, GPU rasterization, GPU blocklist bypass, and Linux Vaapi video decode flags. If you use NVIDIA GPUs, install the NVIDIA Container Toolkit on the Docker host and add a GPU device reservation to your Compose service.
+
+See [`examples/docker-compose.gpu.yml`](examples/docker-compose.gpu.yml) for a complete Compose example. If you run CloakBrowser inside your own multi-container stack, mirror the environment variable and GPU reservation in that service.
 
 **Per-connection fingerprint seeds** — run multiple browser identities from a single container. Each unique seed spawns a separate Chrome process with its own fingerprint:
 

--- a/cloakbrowser/browser.py
+++ b/cloakbrowser/browser.py
@@ -556,6 +556,7 @@ def launch_context(
     human_preset: HumanPreset = "default",
     human_config: HumanConfigOverrides | None = None,
     extension_paths: list[str] | None = None,
+    gpu_accel: bool = False,
     **kwargs: Any,
 ) -> Any:
     """Launch stealth browser and return a BrowserContext with common options pre-set.
@@ -599,7 +600,8 @@ def launch_context(
     # so it applies to ALL contexts, not just the default one.
     # locale and timezone are set via binary flags only — no CDP emulation.
     browser = launch(headless=headless, proxy=proxy, args=args, stealth_args=stealth_args,
-                     timezone=timezone, locale=locale, backend=backend, extension_paths=extension_paths)
+                     timezone=timezone, locale=locale, backend=backend, extension_paths=extension_paths,
+                     gpu_accel=gpu_accel)
 
     context_kwargs: dict[str, Any] = {}
     if user_agent:
@@ -657,6 +659,7 @@ async def launch_context_async(
     human_preset: HumanPreset = "default",
     human_config: HumanConfigOverrides | None = None,
     extension_paths: list[str] | None = None,
+    gpu_accel: bool = False,
     **kwargs: Any,
 ) -> Any:
     """Async version of launch_context().
@@ -719,7 +722,8 @@ async def launch_context_async(
     # so it applies to ALL contexts, not just the default one.
     # locale and timezone are set via binary flags only — no CDP emulation.
     browser = await launch_async(headless=headless, proxy=proxy, args=args, stealth_args=stealth_args,
-                                 timezone=timezone, locale=locale, backend=backend, extension_paths=extension_paths)
+                                 timezone=timezone, locale=locale, backend=backend, extension_paths=extension_paths,
+                                 gpu_accel=gpu_accel)
 
     context_kwargs: dict[str, Any] = {}
     if user_agent:

--- a/cloakbrowser/browser.py
+++ b/cloakbrowser/browser.py
@@ -161,6 +161,7 @@ def launch(
     human_preset: HumanPreset = "default",
     human_config: HumanConfigOverrides | None = None,
     extension_paths: list[str] | None = None,
+    gpu_accel: bool = False,
     license_key: str | None = None,
     browser_version: str | None = None,
     _suppress_maximize: bool = False,
@@ -187,6 +188,8 @@ def launch(
         humanize: Enable human-like mouse, keyboard, scroll behavior (default False).
         human_preset: Humanize preset — 'default' or 'careful' (default 'default').
         human_config: Custom humanize config mapping to override preset values.
+        gpu_accel: Enable Docker GPU acceleration flags (default False).
+            Can also be enabled with CLOAKBROWSER_GPU_ACCEL=1.
         **kwargs: Passed directly to playwright.chromium.launch().
 
     Returns:
@@ -210,7 +213,19 @@ def launch(
     args = _resolve_webrtc_args(args, proxy)
     args = _append_webrtc_exit_ip(args, exit_ip)
 
-    chrome_args = build_args(stealth_args, (args or []) + proxy_extra_args, timezone=timezone, locale=locale, headless=headless, extension_paths=extension_paths, start_maximized=binary_supports_maximized_window(license_key, browser_version) and not _suppress_maximize)
+    chrome_args = build_args(
+        stealth_args,
+        (args or []) + proxy_extra_args,
+        timezone=timezone,
+        locale=locale,
+        headless=headless,
+        extension_paths=extension_paths,
+        gpu_accel=gpu_accel,
+        start_maximized=(
+            binary_supports_maximized_window(license_key, browser_version)
+            and not _suppress_maximize
+        ),
+    )
     _maybe_warn_windows_fonts(chrome_args)
 
     logger.debug("Launching stealth Chromium (headless=%s, args=%d)", headless, len(chrome_args))
@@ -269,6 +284,7 @@ async def launch_async(  # noqa: C901
     human_preset: HumanPreset = "default",
     human_config: HumanConfigOverrides | None = None,
     extension_paths: list[str] | None = None,
+    gpu_accel: bool = False,
     license_key: str | None = None,
     browser_version: str | None = None,
     _suppress_maximize: bool = False,
@@ -288,6 +304,8 @@ async def launch_async(  # noqa: C901
         humanize: Enable human-like mouse, keyboard, scroll behavior (default False).
         human_preset: Humanize preset — 'default' or 'careful' (default 'default').
         human_config: Custom humanize config mapping to override preset values.
+        gpu_accel: Enable Docker GPU acceleration flags (default False).
+            Can also be enabled with CLOAKBROWSER_GPU_ACCEL=1.
         **kwargs: Passed directly to playwright.chromium.launch().
 
     Returns:
@@ -315,7 +333,19 @@ async def launch_async(  # noqa: C901
     proxy_kwargs, proxy_extra_args = _resolve_proxy_config(proxy, browser_version)
     args = _resolve_webrtc_args(args, proxy)
     args = _append_webrtc_exit_ip(args, exit_ip)
-    chrome_args = build_args(stealth_args, (args or []) + proxy_extra_args, timezone=timezone, locale=locale, headless=headless, extension_paths=extension_paths, start_maximized=binary_supports_maximized_window(license_key, browser_version) and not _suppress_maximize)
+    chrome_args = build_args(
+        stealth_args,
+        (args or []) + proxy_extra_args,
+        timezone=timezone,
+        locale=locale,
+        headless=headless,
+        extension_paths=extension_paths,
+        gpu_accel=gpu_accel,
+        start_maximized=(
+            binary_supports_maximized_window(license_key, browser_version)
+            and not _suppress_maximize
+        ),
+    )
     _maybe_warn_windows_fonts(chrome_args)
 
     logger.debug("Launching stealth Chromium async (headless=%s, args=%d)", headless, len(chrome_args))
@@ -376,6 +406,7 @@ def launch_persistent_context(
     human_preset: HumanPreset = "default",
     human_config: HumanConfigOverrides | None = None,
     extension_paths: list[str] | None = None,
+    gpu_accel: bool = False,
     license_key: str | None = None,
     browser_version: str | None = None,
     **kwargs: Any,
@@ -407,6 +438,8 @@ def launch_persistent_context(
         humanize: Enable human-like mouse, keyboard, scroll behavior (default False).
         human_preset: Humanize preset — 'default' or 'careful' (default 'default').
         human_config: Custom humanize config mapping to override preset values.
+        gpu_accel: Enable Docker GPU acceleration flags (default False).
+            Can also be enabled with CLOAKBROWSER_GPU_ACCEL=1.
         **kwargs: Passed directly to playwright.chromium.launch_persistent_context().
 
     Returns:
@@ -431,7 +464,21 @@ def launch_persistent_context(
     proxy_kwargs, proxy_extra_args = _resolve_proxy_config(proxy, browser_version)
     args = _resolve_webrtc_args(args, proxy)
     args = _append_webrtc_exit_ip(args, exit_ip)
-    chrome_args = build_args(stealth_args, (args or []) + proxy_extra_args, timezone=timezone, locale=locale, headless=headless, extension_paths=extension_paths, start_maximized=binary_supports_maximized_window(license_key, browser_version) and viewport is _VIEWPORT_UNSET and "viewport" not in kwargs and "no_viewport" not in kwargs)
+    chrome_args = build_args(
+        stealth_args,
+        (args or []) + proxy_extra_args,
+        timezone=timezone,
+        locale=locale,
+        headless=headless,
+        extension_paths=extension_paths,
+        gpu_accel=gpu_accel,
+        start_maximized=(
+            binary_supports_maximized_window(license_key, browser_version)
+            and viewport is _VIEWPORT_UNSET
+            and "viewport" not in kwargs
+            and "no_viewport" not in kwargs
+        ),
+    )
     _maybe_warn_windows_fonts(chrome_args)
 
     logger.debug(
@@ -511,6 +558,7 @@ async def launch_persistent_context_async(
     human_preset: HumanPreset = "default",
     human_config: HumanConfigOverrides | None = None,
     extension_paths: list[str] | None = None,
+    gpu_accel: bool = False,
     license_key: str | None = None,
     browser_version: str | None = None,
     **kwargs: Any,
@@ -539,6 +587,8 @@ async def launch_persistent_context_async(
         humanize: Enable human-like mouse, keyboard, scroll behavior (default False).
         human_preset: Humanize preset — 'default' or 'careful' (default 'default').
         human_config: Custom humanize config mapping to override preset values.
+        gpu_accel: Enable Docker GPU acceleration flags (default False).
+            Can also be enabled with CLOAKBROWSER_GPU_ACCEL=1.
         **kwargs: Passed directly to playwright.chromium.launch_persistent_context().
 
     Returns:
@@ -568,7 +618,21 @@ async def launch_persistent_context_async(
     proxy_kwargs, proxy_extra_args = _resolve_proxy_config(proxy, browser_version)
     args = _resolve_webrtc_args(args, proxy)
     args = _append_webrtc_exit_ip(args, exit_ip)
-    chrome_args = build_args(stealth_args, (args or []) + proxy_extra_args, timezone=timezone, locale=locale, headless=headless, extension_paths=extension_paths, start_maximized=binary_supports_maximized_window(license_key, browser_version) and viewport is _VIEWPORT_UNSET and "viewport" not in kwargs and "no_viewport" not in kwargs)
+    chrome_args = build_args(
+        stealth_args,
+        (args or []) + proxy_extra_args,
+        timezone=timezone,
+        locale=locale,
+        headless=headless,
+        extension_paths=extension_paths,
+        gpu_accel=gpu_accel,
+        start_maximized=(
+            binary_supports_maximized_window(license_key, browser_version)
+            and viewport is _VIEWPORT_UNSET
+            and "viewport" not in kwargs
+            and "no_viewport" not in kwargs
+        ),
+    )
     _maybe_warn_windows_fonts(chrome_args)
 
     logger.debug(
@@ -647,6 +711,7 @@ def launch_context(
     human_preset: HumanPreset = "default",
     human_config: HumanConfigOverrides | None = None,
     extension_paths: list[str] | None = None,
+    gpu_accel: bool = False,
     license_key: str | None = None,
     browser_version: str | None = None,
     **kwargs: Any,
@@ -673,6 +738,8 @@ def launch_context(
         humanize: Enable human-like mouse, keyboard, scroll behavior (default False).
         human_preset: Humanize preset — 'default' or 'careful' (default 'default').
         human_config: Custom humanize config mapping to override preset values.
+        gpu_accel: Enable Docker GPU acceleration flags (default False).
+            Can also be enabled with CLOAKBROWSER_GPU_ACCEL=1.
         **kwargs: Passed to browser.new_context().
 
     Returns:
@@ -690,12 +757,21 @@ def launch_context(
     # --fingerprint-timezone is process-wide (reads CommandLine in renderer),
     # so it applies to ALL contexts, not just the default one.
     # locale and timezone are set via binary flags only — no CDP emulation.
-    browser = launch(headless=headless, proxy=proxy, args=args, stealth_args=stealth_args,
-                     timezone=timezone, locale=locale, extension_paths=extension_paths,
-                     license_key=license_key, browser_version=browser_version,
-                     # Caller chose a viewport geometry → don't also auto-maximize
-                     # the window (mirrors the persistent-context path + JS).
-                     _suppress_maximize=(viewport is not _VIEWPORT_UNSET or "no_viewport" in kwargs))
+    browser = launch(
+        headless=headless,
+        proxy=proxy,
+        args=args,
+        stealth_args=stealth_args,
+        timezone=timezone,
+        locale=locale,
+        extension_paths=extension_paths,
+        gpu_accel=gpu_accel,
+        license_key=license_key,
+        browser_version=browser_version,
+        # Caller chose a viewport geometry → don't also auto-maximize
+        # the window (mirrors the persistent-context path + JS).
+        _suppress_maximize=(viewport is not _VIEWPORT_UNSET or "no_viewport" in kwargs),
+    )
 
     context_kwargs: dict[str, Any] = {}
     if user_agent:
@@ -752,6 +828,7 @@ async def launch_context_async(
     human_preset: HumanPreset = "default",
     human_config: HumanConfigOverrides | None = None,
     extension_paths: list[str] | None = None,
+    gpu_accel: bool = False,
     license_key: str | None = None,
     browser_version: str | None = None,
     **kwargs: Any,
@@ -779,6 +856,8 @@ async def launch_context_async(
         humanize: Enable human-like mouse, keyboard, scroll behavior (default False).
         human_preset: Humanize preset — 'default' or 'careful' (default 'default').
         human_config: Custom humanize config mapping to override preset values.
+        gpu_accel: Enable Docker GPU acceleration flags (default False).
+            Can also be enabled with CLOAKBROWSER_GPU_ACCEL=1.
         **kwargs: Passed to browser.new_context() — e.g. storage_state, permissions.
 
     Returns:
@@ -814,12 +893,21 @@ async def launch_context_async(
     # --fingerprint-timezone is process-wide (reads CommandLine in renderer),
     # so it applies to ALL contexts, not just the default one.
     # locale and timezone are set via binary flags only — no CDP emulation.
-    browser = await launch_async(headless=headless, proxy=proxy, args=args, stealth_args=stealth_args,
-                                 timezone=timezone, locale=locale, extension_paths=extension_paths,
-                                 license_key=license_key, browser_version=browser_version,
-                                 # Caller chose a viewport geometry → don't also auto-maximize
-                                 # the window (mirrors the persistent-context path + JS).
-                                 _suppress_maximize=(viewport is not _VIEWPORT_UNSET or "no_viewport" in kwargs))
+    browser = await launch_async(
+        headless=headless,
+        proxy=proxy,
+        args=args,
+        stealth_args=stealth_args,
+        timezone=timezone,
+        locale=locale,
+        extension_paths=extension_paths,
+        gpu_accel=gpu_accel,
+        license_key=license_key,
+        browser_version=browser_version,
+        # Caller chose a viewport geometry → don't also auto-maximize
+        # the window (mirrors the persistent-context path + JS).
+        _suppress_maximize=(viewport is not _VIEWPORT_UNSET or "no_viewport" in kwargs),
+    )
 
     context_kwargs: dict[str, Any] = {}
     if user_agent:
@@ -1093,6 +1181,7 @@ def build_args(
     locale: str | None = None,
     headless: bool = True,
     extension_paths: list[str] | None = None,
+    gpu_accel: bool = False,
     start_maximized: bool = False,
 ) -> list[str]:
     """Combine stealth args with user-provided args and locale flags.
@@ -1115,6 +1204,13 @@ def build_args(
     import platform as _platform
     if not headless or _platform.system() == "Windows":
         seen["--ignore-gpu-blocklist"] = "--ignore-gpu-blocklist"
+
+    if gpu_accel or os.environ.get("CLOAKBROWSER_GPU_ACCEL"):
+        seen["--use-gl"] = "--use-gl=egl"
+        seen["--enable-gpu-rasterization"] = "--enable-gpu-rasterization"
+        seen["--ignore-gpu-blocklist"] = "--ignore-gpu-blocklist"
+        if sys.platform.startswith("linux"):
+            seen["--enable-features"] = "--enable-features=VaapiVideoDecoder"
 
     if extra_args:
         for arg in extra_args:

--- a/cloakbrowser/browser.py
+++ b/cloakbrowser/browser.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from typing import Any, Literal, TypedDict
 from urllib.parse import quote, unquote, urlparse, urlunparse
 
@@ -65,6 +66,7 @@ def launch(
     human_preset: HumanPreset = "default",
     human_config: HumanConfigOverrides | None = None,
     extension_paths: list[str] | None = None,
+    gpu_accel: bool = False,
     **kwargs: Any,
 ) -> Any:
     """Launch stealth Chromium browser. Returns a Playwright Browser object.
@@ -92,6 +94,8 @@ def launch(
         humanize: Enable human-like mouse, keyboard, scroll behavior (default False).
         human_preset: Humanize preset — 'default' or 'careful' (default 'default').
         human_config: Custom humanize config mapping to override preset values.
+        gpu_accel: Enable Docker GPU acceleration flags (default False).
+            Can also be enabled with CLOAKBROWSER_GPU_ACCEL=1.
         **kwargs: Passed directly to playwright.chromium.launch().
 
     Returns:
@@ -114,8 +118,15 @@ def launch(
     if exit_ip and not (args and any(a.startswith("--fingerprint-webrtc-ip") for a in args)):
         args = list(args or [])
         args.append(f"--fingerprint-webrtc-ip={exit_ip}")
-        
-    chrome_args = build_args(stealth_args, (args or []) + proxy_extra_args, timezone=timezone, locale=locale, headless=headless, extension_paths=extension_paths)
+    chrome_args = build_args(
+        stealth_args,
+        (args or []) + proxy_extra_args,
+        timezone=timezone,
+        locale=locale,
+        headless=headless,
+        extension_paths=extension_paths,
+        gpu_accel=gpu_accel,
+    )
 
     logger.debug("Launching stealth Chromium (headless=%s, args=%d)", headless, len(chrome_args))
 
@@ -163,6 +174,7 @@ async def launch_async(  # noqa: C901
     human_preset: HumanPreset = "default",
     human_config: HumanConfigOverrides | None = None,
     extension_paths: list[str] | None = None,
+    gpu_accel: bool = False,
     **kwargs: Any,
 ) -> Any:
     """Async version of launch(). Returns a Playwright Browser object.
@@ -180,6 +192,8 @@ async def launch_async(  # noqa: C901
         humanize: Enable human-like mouse, keyboard, scroll behavior (default False).
         human_preset: Humanize preset — 'default' or 'careful' (default 'default').
         human_config: Custom humanize config mapping to override preset values.
+        gpu_accel: Enable Docker GPU acceleration flags (default False).
+            Can also be enabled with CLOAKBROWSER_GPU_ACCEL=1.
         **kwargs: Passed directly to playwright.chromium.launch().
 
     Returns:
@@ -207,7 +221,15 @@ async def launch_async(  # noqa: C901
     if exit_ip and not (args and any(a.startswith("--fingerprint-webrtc-ip") for a in args)):
         args = list(args or [])
         args.append(f"--fingerprint-webrtc-ip={exit_ip}")
-    chrome_args = build_args(stealth_args, (args or []) + proxy_extra_args, timezone=timezone, locale=locale, headless=headless, extension_paths=extension_paths)
+    chrome_args = build_args(
+        stealth_args,
+        (args or []) + proxy_extra_args,
+        timezone=timezone,
+        locale=locale,
+        headless=headless,
+        extension_paths=extension_paths,
+        gpu_accel=gpu_accel,
+    )
 
     logger.debug("Launching stealth Chromium async (headless=%s, args=%d)", headless, len(chrome_args))
 
@@ -259,6 +281,7 @@ def launch_persistent_context(
     human_preset: HumanPreset = "default",
     human_config: HumanConfigOverrides | None = None,
     extension_paths: list[str] | None = None,
+    gpu_accel: bool = False,
     **kwargs: Any,
 ) -> Any:
     """Launch stealth browser with a persistent profile and return a BrowserContext.
@@ -289,6 +312,8 @@ def launch_persistent_context(
         humanize: Enable human-like mouse, keyboard, scroll behavior (default False).
         human_preset: Humanize preset — 'default' or 'careful' (default 'default').
         human_config: Custom humanize config mapping to override preset values.
+        gpu_accel: Enable Docker GPU acceleration flags (default False).
+            Can also be enabled with CLOAKBROWSER_GPU_ACCEL=1.
         **kwargs: Passed directly to playwright.chromium.launch_persistent_context().
 
     Returns:
@@ -313,7 +338,15 @@ def launch_persistent_context(
     if exit_ip and not (args and any(a.startswith("--fingerprint-webrtc-ip") for a in args)):
         args = list(args or [])
         args.append(f"--fingerprint-webrtc-ip={exit_ip}")
-    chrome_args = build_args(stealth_args, (args or []) + proxy_extra_args, timezone=timezone, locale=locale, headless=headless, extension_paths=extension_paths)
+    chrome_args = build_args(
+        stealth_args,
+        (args or []) + proxy_extra_args,
+        timezone=timezone,
+        locale=locale,
+        headless=headless,
+        extension_paths=extension_paths,
+        gpu_accel=gpu_accel,
+    )
 
     logger.debug(
         "Launching persistent stealth Chromium (headless=%s, user_data_dir=%s)",
@@ -385,6 +418,7 @@ async def launch_persistent_context_async(
     human_preset: HumanPreset = "default",
     human_config: HumanConfigOverrides | None = None,
     extension_paths: list[str] | None = None,
+    gpu_accel: bool = False,
     **kwargs: Any,
 ) -> Any:
     """Async version of launch_persistent_context().
@@ -412,6 +446,8 @@ async def launch_persistent_context_async(
         humanize: Enable human-like mouse, keyboard, scroll behavior (default False).
         human_preset: Humanize preset — 'default' or 'careful' (default 'default').
         human_config: Custom humanize config mapping to override preset values.
+        gpu_accel: Enable Docker GPU acceleration flags (default False).
+            Can also be enabled with CLOAKBROWSER_GPU_ACCEL=1.
         **kwargs: Passed directly to playwright.chromium.launch_persistent_context().
 
     Returns:
@@ -441,7 +477,15 @@ async def launch_persistent_context_async(
     if exit_ip and not (args and any(a.startswith("--fingerprint-webrtc-ip") for a in args)):
         args = list(args or [])
         args.append(f"--fingerprint-webrtc-ip={exit_ip}")
-    chrome_args = build_args(stealth_args, (args or []) + proxy_extra_args, timezone=timezone, locale=locale, headless=headless, extension_paths=extension_paths)
+    chrome_args = build_args(
+        stealth_args,
+        (args or []) + proxy_extra_args,
+        timezone=timezone,
+        locale=locale,
+        headless=headless,
+        extension_paths=extension_paths,
+        gpu_accel=gpu_accel,
+    )
 
     logger.debug(
         "Launching persistent stealth Chromium async (headless=%s, user_data_dir=%s)",
@@ -971,6 +1015,7 @@ def build_args(
     locale: str | None = None,
     headless: bool = True,
     extension_paths: list[str] | None = None,
+    gpu_accel: bool = False,
 ) -> list[str]:
     """Combine stealth args with user-provided args and locale flags.
 
@@ -992,6 +1037,13 @@ def build_args(
     import platform as _platform
     if not headless or _platform.system() == "Windows":
         seen["--ignore-gpu-blocklist"] = "--ignore-gpu-blocklist"
+
+    if gpu_accel or os.environ.get("CLOAKBROWSER_GPU_ACCEL"):
+        seen["--use-gl"] = "--use-gl=egl"
+        seen["--enable-gpu-rasterization"] = "--enable-gpu-rasterization"
+        seen["--ignore-gpu-blocklist"] = "--ignore-gpu-blocklist"
+        if sys.platform.startswith("linux"):
+            seen["--enable-features"] = "--enable-features=VaapiVideoDecoder"
 
     if extra_args:
         for arg in extra_args:

--- a/examples/docker-compose.gpu.yml
+++ b/examples/docker-compose.gpu.yml
@@ -1,0 +1,22 @@
+services:
+  cloakbrowser:
+    image: cloakhq/cloakbrowser
+    command: cloakserve
+    restart: unless-stopped
+    environment:
+      CLOAKBROWSER_GPU_ACCEL: "1"
+    ports:
+      - "127.0.0.1:9222:9222"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9222/json/version"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/js/src/args.ts
+++ b/js/src/args.ts
@@ -29,6 +29,14 @@ export function buildArgs(options: LaunchOptions): string[] {
   if (options.headless === false || process.platform === "win32") {
     seen.set("--ignore-gpu-blocklist", "--ignore-gpu-blocklist");
   }
+  if (options.gpuAccel || process.env.CLOAKBROWSER_GPU_ACCEL) {
+    seen.set("--use-gl", "--use-gl=egl");
+    seen.set("--enable-gpu-rasterization", "--enable-gpu-rasterization");
+    seen.set("--ignore-gpu-blocklist", "--ignore-gpu-blocklist");
+    if (process.platform === "linux") {
+      seen.set("--enable-features", "--enable-features=VaapiVideoDecoder");
+    }
+  }
   if (options.args) {
     for (const arg of options.args) {
       const key = arg.split("=")[0];

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -27,6 +27,8 @@ export interface LaunchOptions {
   locale?: string;
   /** Auto-detect timezone/locale from proxy IP (requires: npm install mmdb-lib). */
   geoip?: boolean;
+  /** Enable Docker GPU acceleration flags. Can also be enabled with CLOAKBROWSER_GPU_ACCEL=1. */
+  gpuAccel?: boolean;
   /** Raw options passed directly to playwright/puppeteer launch(). */
   launchOptions?: Record<string, unknown>;
   /** Enable human-like mouse, keyboard, and scroll behavior. */

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -27,6 +27,8 @@ export interface LaunchOptions {
   locale?: string;
   /** Auto-detect timezone/locale from proxy IP (requires: npm install mmdb-lib). */
   geoip?: boolean;
+  /** Enable Docker GPU acceleration flags. Can also be enabled with CLOAKBROWSER_GPU_ACCEL=1. */
+  gpuAccel?: boolean;
   /** Pro license key. Also reads from CLOAKBROWSER_LICENSE_KEY env var. */
   licenseKey?: string;
   /** Exact Chromium version pin. Also reads from CLOAKBROWSER_VERSION env var. */

--- a/js/tests/config.test.ts
+++ b/js/tests/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect } from "vitest";
 import {
   CHROMIUM_VERSION,
   getArchiveExt,
@@ -10,6 +10,22 @@ import {
   getFallbackDownloadUrl,
 } from "../src/config.js";
 import { _buildArgsForTest, resolveTimezone } from "../src/playwright.js";
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform")!;
+const originalGpuAccel = process.env.CLOAKBROWSER_GPU_ACCEL;
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", originalPlatform);
+  if (originalGpuAccel === undefined) {
+    delete process.env.CLOAKBROWSER_GPU_ACCEL;
+  } else {
+    process.env.CLOAKBROWSER_GPU_ACCEL = originalGpuAccel;
+  }
+});
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { ...originalPlatform, value: platform });
+}
 
 describe("config", () => {
   it("CHROMIUM_VERSION matches expected format", () => {
@@ -180,6 +196,45 @@ describe("buildArgs deduplication", () => {
     expect(args).toContain("--disable-gpu");
     expect(args).toContain("--no-zygote");
     expect(args).toContain("--no-sandbox");
+  });
+});
+
+describe("buildArgs GPU acceleration", () => {
+  it("leaves GPU acceleration flags off by default", () => {
+    delete process.env.CLOAKBROWSER_GPU_ACCEL;
+    const args = _buildArgsForTest({});
+    expect(args).not.toContain("--use-gl=egl");
+    expect(args).not.toContain("--enable-gpu-rasterization");
+    expect(args).not.toContain("--enable-features=VaapiVideoDecoder");
+  });
+
+  it("CLOAKBROWSER_GPU_ACCEL adds Linux GPU flags", () => {
+    process.env.CLOAKBROWSER_GPU_ACCEL = "1";
+    setPlatform("linux");
+    const args = _buildArgsForTest({});
+    expect(args).toContain("--use-gl=egl");
+    expect(args).toContain("--enable-gpu-rasterization");
+    expect(args).toContain("--ignore-gpu-blocklist");
+    expect(args).toContain("--enable-features=VaapiVideoDecoder");
+  });
+
+  it("skips VaapiVideoDecoder off Linux", () => {
+    process.env.CLOAKBROWSER_GPU_ACCEL = "1";
+    setPlatform("darwin");
+    const args = _buildArgsForTest({});
+    expect(args).toContain("--use-gl=egl");
+    expect(args).toContain("--enable-gpu-rasterization");
+    expect(args).not.toContain("--enable-features=VaapiVideoDecoder");
+  });
+
+  it("gpuAccel option adds GPU flags without the environment variable", () => {
+    delete process.env.CLOAKBROWSER_GPU_ACCEL;
+    setPlatform("linux");
+    const args = _buildArgsForTest({ gpuAccel: true });
+    expect(args).toContain("--use-gl=egl");
+    expect(args).toContain("--enable-gpu-rasterization");
+    expect(args).toContain("--ignore-gpu-blocklist");
+    expect(args).toContain("--enable-features=VaapiVideoDecoder");
   });
 });
 

--- a/js/tests/config.test.ts
+++ b/js/tests/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect } from "vitest";
 import {
   CHROMIUM_VERSION,
   getArchiveExt,
@@ -13,6 +13,22 @@ import {
   binarySupportsMaximizedWindow,
 } from "../src/config.js";
 import { _buildArgsForTest, resolveTimezone } from "../src/playwright.js";
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform")!;
+const originalGpuAccel = process.env.CLOAKBROWSER_GPU_ACCEL;
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", originalPlatform);
+  if (originalGpuAccel === undefined) {
+    delete process.env.CLOAKBROWSER_GPU_ACCEL;
+  } else {
+    process.env.CLOAKBROWSER_GPU_ACCEL = originalGpuAccel;
+  }
+});
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { ...originalPlatform, value: platform });
+}
 
 describe("config", () => {
   it("CHROMIUM_VERSION matches expected format", () => {
@@ -215,6 +231,45 @@ describe("buildArgs deduplication", () => {
     expect(args).toContain("--disable-gpu");
     expect(args).toContain("--no-zygote");
     expect(args).toContain("--no-sandbox");
+  });
+});
+
+describe("buildArgs GPU acceleration", () => {
+  it("leaves GPU acceleration flags off by default", () => {
+    delete process.env.CLOAKBROWSER_GPU_ACCEL;
+    const args = _buildArgsForTest({});
+    expect(args).not.toContain("--use-gl=egl");
+    expect(args).not.toContain("--enable-gpu-rasterization");
+    expect(args).not.toContain("--enable-features=VaapiVideoDecoder");
+  });
+
+  it("CLOAKBROWSER_GPU_ACCEL adds Linux GPU flags", () => {
+    process.env.CLOAKBROWSER_GPU_ACCEL = "1";
+    setPlatform("linux");
+    const args = _buildArgsForTest({});
+    expect(args).toContain("--use-gl=egl");
+    expect(args).toContain("--enable-gpu-rasterization");
+    expect(args).toContain("--ignore-gpu-blocklist");
+    expect(args).toContain("--enable-features=VaapiVideoDecoder");
+  });
+
+  it("skips VaapiVideoDecoder off Linux", () => {
+    process.env.CLOAKBROWSER_GPU_ACCEL = "1";
+    setPlatform("darwin");
+    const args = _buildArgsForTest({});
+    expect(args).toContain("--use-gl=egl");
+    expect(args).toContain("--enable-gpu-rasterization");
+    expect(args).not.toContain("--enable-features=VaapiVideoDecoder");
+  });
+
+  it("gpuAccel option adds GPU flags without the environment variable", () => {
+    delete process.env.CLOAKBROWSER_GPU_ACCEL;
+    setPlatform("linux");
+    const args = _buildArgsForTest({ gpuAccel: true });
+    expect(args).toContain("--use-gl=egl");
+    expect(args).toContain("--enable-gpu-rasterization");
+    expect(args).toContain("--ignore-gpu-blocklist");
+    expect(args).toContain("--enable-features=VaapiVideoDecoder");
   });
 });
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,10 @@
 """Shared test fixtures."""
 
-import os
-
 import pytest
 
 
 @pytest.fixture(autouse=True)
-def _clean_backend_env(monkeypatch):
-    """Ensure CLOAKBROWSER_BACKEND doesn't leak into tests from the host environment."""
+def _clean_env(monkeypatch):
+    """Ensure host-level wrapper env vars don't leak into tests."""
     monkeypatch.delenv("CLOAKBROWSER_BACKEND", raising=False)
+    monkeypatch.delenv("CLOAKBROWSER_GPU_ACCEL", raising=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Shared test fixtures."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Ensure host-level wrapper env vars don't leak into tests."""
+    monkeypatch.delenv("CLOAKBROWSER_BACKEND", raising=False)
+    monkeypatch.delenv("CLOAKBROWSER_GPU_ACCEL", raising=False)

--- a/tests/test_build_args.py
+++ b/tests/test_build_args.py
@@ -1,5 +1,7 @@
 """Unit tests for build_args timezone/locale injection and timezone alias."""
 
+import sys
+
 from cloakbrowser.browser import build_args, _resolve_timezone
 
 
@@ -149,6 +151,50 @@ def test_non_value_flags_preserved():
     assert "--disable-gpu" in args
     assert "--no-zygote" in args
     assert "--no-sandbox" in args
+
+
+# --- GPU acceleration ---
+
+
+def test_gpu_accel_default_off(monkeypatch):
+    """GPU acceleration flags should stay off unless explicitly enabled."""
+    monkeypatch.delenv("CLOAKBROWSER_GPU_ACCEL", raising=False)
+    args = build_args(stealth_args=True, extra_args=None)
+    assert "--use-gl=egl" not in args
+    assert "--enable-gpu-rasterization" not in args
+    assert "--enable-features=VaapiVideoDecoder" not in args
+
+
+def test_gpu_accel_env_adds_linux_flags(monkeypatch):
+    """CLOAKBROWSER_GPU_ACCEL enables GPU flags, including Vaapi on Linux."""
+    monkeypatch.setenv("CLOAKBROWSER_GPU_ACCEL", "1")
+    monkeypatch.setattr(sys, "platform", "linux")
+    args = build_args(stealth_args=True, extra_args=None)
+    assert "--use-gl=egl" in args
+    assert "--enable-gpu-rasterization" in args
+    assert "--ignore-gpu-blocklist" in args
+    assert "--enable-features=VaapiVideoDecoder" in args
+
+
+def test_gpu_accel_skips_vaapi_off_linux(monkeypatch):
+    """VaapiVideoDecoder is Linux-only."""
+    monkeypatch.setenv("CLOAKBROWSER_GPU_ACCEL", "1")
+    monkeypatch.setattr(sys, "platform", "darwin")
+    args = build_args(stealth_args=True, extra_args=None)
+    assert "--use-gl=egl" in args
+    assert "--enable-gpu-rasterization" in args
+    assert "--enable-features=VaapiVideoDecoder" not in args
+
+
+def test_gpu_accel_kwarg_adds_flags(monkeypatch):
+    """gpu_accel=True enables GPU flags without the environment variable."""
+    monkeypatch.delenv("CLOAKBROWSER_GPU_ACCEL", raising=False)
+    monkeypatch.setattr(sys, "platform", "linux")
+    args = build_args(stealth_args=True, extra_args=None, gpu_accel=True)
+    assert "--use-gl=egl" in args
+    assert "--enable-gpu-rasterization" in args
+    assert "--ignore-gpu-blocklist" in args
+    assert "--enable-features=VaapiVideoDecoder" in args
 
 
 def test_override_logs_debug(caplog):

--- a/tests/test_launch_context.py
+++ b/tests/test_launch_context.py
@@ -444,3 +444,61 @@ async def test_async_cancellation_closes_browser(mock_launch_async, _mock_bin):
         await launch_context_async()
 
     browser.close.assert_called_once()
+
+
+@patch("cloakbrowser.browser.ensure_binary", return_value="/fake/chrome")
+@patch("cloakbrowser.browser.launch")
+def test_gpu_accel_forwarded_to_launch(mock_launch, _mock_bin):
+    """launch_context(gpu_accel=True) propagates gpu_accel to launch()."""
+    browser, _ = _make_mock_browser()
+    mock_launch.return_value = browser
+
+    from cloakbrowser.browser import launch_context
+    launch_context(gpu_accel=True)
+
+    assert mock_launch.call_args.kwargs.get("gpu_accel") is True
+    assert "gpu_accel" not in browser.new_context.call_args.kwargs
+
+
+@patch("cloakbrowser.browser.ensure_binary", return_value="/fake/chrome")
+@patch("cloakbrowser.browser.launch")
+def test_gpu_accel_default_false(mock_launch, _mock_bin):
+    """launch_context() without gpu_accel passes gpu_accel=False."""
+    browser, _ = _make_mock_browser()
+    mock_launch.return_value = browser
+
+    from cloakbrowser.browser import launch_context
+    launch_context()
+
+    assert mock_launch.call_args.kwargs.get("gpu_accel") is False
+    assert "gpu_accel" not in browser.new_context.call_args.kwargs
+
+
+@pytest.mark.asyncio
+@patch("cloakbrowser.browser.ensure_binary", return_value="/fake/chrome")
+@patch("cloakbrowser.browser.launch_async")
+async def test_async_gpu_accel_forwarded_to_launch_async(mock_launch_async, _mock_bin):
+    """launch_context_async(gpu_accel=True) propagates gpu_accel to launch_async()."""
+    browser, _ = _make_mock_async_browser()
+    mock_launch_async.return_value = browser
+
+    from cloakbrowser.browser import launch_context_async
+    await launch_context_async(gpu_accel=True)
+
+    assert mock_launch_async.call_args.kwargs.get("gpu_accel") is True
+    assert "gpu_accel" not in browser.new_context.call_args.kwargs
+
+
+@pytest.mark.asyncio
+@patch("cloakbrowser.browser.ensure_binary", return_value="/fake/chrome")
+@patch("cloakbrowser.browser.launch_async")
+async def test_async_gpu_accel_default_false(mock_launch_async, _mock_bin):
+    """launch_context_async() without gpu_accel passes gpu_accel=False."""
+    browser, _ = _make_mock_async_browser()
+    mock_launch_async.return_value = browser
+
+    from cloakbrowser.browser import launch_context_async
+    await launch_context_async()
+
+    assert mock_launch_async.call_args.kwargs.get("gpu_accel") is False
+    assert "gpu_accel" not in browser.new_context.call_args.kwargs

--- a/tests/test_launch_context.py
+++ b/tests/test_launch_context.py
@@ -329,3 +329,62 @@ async def test_async_cancellation_closes_browser(mock_launch_async, _mock_bin):
         await launch_context_async()
 
     browser.close.assert_called_once()
+
+
+@patch("cloakbrowser.browser.ensure_binary", return_value="/fake/chrome")
+@patch("cloakbrowser.browser.launch")
+def test_gpu_accel_forwarded_to_launch(mock_launch, _mock_bin):
+    """launch_context(gpu_accel=True) propagates gpu_accel to launch()."""
+    browser, _ = _make_mock_browser()
+    mock_launch.return_value = browser
+
+    from cloakbrowser.browser import launch_context
+    launch_context(gpu_accel=True)
+
+    assert mock_launch.call_args.kwargs.get("gpu_accel") is True
+
+
+@patch("cloakbrowser.browser.ensure_binary", return_value="/fake/chrome")
+@patch("cloakbrowser.browser.launch")
+def test_gpu_accel_default_false(mock_launch, _mock_bin):
+    """launch_context() without gpu_accel passes gpu_accel=False (not via **kwargs)."""
+    browser, _ = _make_mock_browser()
+    mock_launch.return_value = browser
+
+    from cloakbrowser.browser import launch_context
+    launch_context()
+
+    assert mock_launch.call_args.kwargs.get("gpu_accel") is False
+    # Confirm it did NOT leak into new_context() kwargs
+    assert "gpu_accel" not in browser.new_context.call_args.kwargs
+
+
+@pytest.mark.asyncio
+@patch("cloakbrowser.browser.ensure_binary", return_value="/fake/chrome")
+@patch("cloakbrowser.browser.launch_async")
+async def test_async_gpu_accel_forwarded_to_launch_async(mock_launch_async, _mock_bin):
+    """launch_context_async(gpu_accel=True) propagates gpu_accel to launch_async()."""
+    browser = AsyncMock()
+    browser.new_context.return_value = MagicMock()
+    mock_launch_async.return_value = browser
+
+    from cloakbrowser.browser import launch_context_async
+    await launch_context_async(gpu_accel=True)
+
+    assert mock_launch_async.call_args.kwargs.get("gpu_accel") is True
+
+
+@pytest.mark.asyncio
+@patch("cloakbrowser.browser.ensure_binary", return_value="/fake/chrome")
+@patch("cloakbrowser.browser.launch_async")
+async def test_async_gpu_accel_default_false(mock_launch_async, _mock_bin):
+    """launch_context_async() without gpu_accel passes gpu_accel=False."""
+    browser = AsyncMock()
+    browser.new_context.return_value = MagicMock()
+    mock_launch_async.return_value = browser
+
+    from cloakbrowser.browser import launch_context_async
+    await launch_context_async()
+
+    assert mock_launch_async.call_args.kwargs.get("gpu_accel") is False
+    assert "gpu_accel" not in browser.new_context.call_args.kwargs


### PR DESCRIPTION
## Summary

Adds opt-in GPU acceleration for the Docker image. Setting `CLOAKBROWSER_GPU_ACCEL=1` (or passing `gpu_accel=True` in Python / `gpuAccel: true` in JS) appends `--use-gl=egl`, `--enable-gpu-rasterization`, and on Linux `--enable-features=VaapiVideoDecoder` to the Chrome args. Defaults stay unchanged.

## What changed

- `cloakbrowser/browser.py:954` — `build_args()` reads the env / kwarg and appends the GPU flags. VaapiVideoDecoder is Linux-gated.
- `js/src/args.ts` + `js/src/types.ts` — JS parity (`gpuAccel: true` option, same env var fallback).
- `examples/docker-compose.gpu.yml` — new example with NVIDIA Container Toolkit `deploy.resources.reservations.devices` config.
- README — short "GPU acceleration in Docker" section.
- Tests: `tests/test_build_args.py` covers env-on, env-off, Linux-only Vaapi, dedupe with existing user-supplied args. `js/tests/config.test.ts` covers the same matrix on the JS side.

## Why opt-in

The reporter [explicitly asked for opt-in](https://github.com/CloakHQ/CloakBrowser/issues/189) (`CLOAKBROWSER_GPU_ACCEL=1`) so users without a GPU container don't get destabilized.

## Testing

- Python: `pytest tests/test_build_args.py` — 26/26 passed; `python3 -m py_compile cloakbrowser/browser.py` clean
- JS: `npm test` and `npm run typecheck` couldn't run locally because `vitest`/`tsc` aren't in the sandbox. CI will exercise.

Fixes #189
