### PR TITLE
fix(browser): disable critical client hints to prevent proxy hangs #243

### DIFF
--- a/cloakbrowser/browser.py
+++ b/cloakbrowser/browser.py
@@ -958,17 +958,16 @@ def build_args(
     locale: str | None = None,
     headless: bool = True,
 ) -> list[str]:
-    """Combine stealth args with user-provided args and locale flags.
-
-    Deduplicates by flag key (everything before '=').
-    Priority: stealth defaults < user args < dedicated params (timezone/locale).
-    """
+    """Combine stealth args with user-provided args and locale flags."""
     seen: dict[str, str] = {}
 
     if stealth_args:
         for arg in get_default_stealth_args():
             seen[arg.split("=", 1)[0]] = arg
-
+    # disable Critical Client Hints to prevent hangs when geoips or proxies are used (#243)
+    client_hint_features = "ClientHintsMetaEquivalentHTTPEquivAcceptCH,CriticalClientHint,AcceptCHFrame"
+    seen["--disable-features"] = f"--disable-features={client_hint_features}"
+    
     # GPU blocklist bypass:
     # - Headed mode (all platforms): Chromium blocks WebGL on software GPUs
     #   in Docker/Xvfb. Flag lets SwiftShader serve WebGL. See issue #56.


### PR DESCRIPTION
# fix: add flags to prevent browser hang on proxy or geoip initialization (#243 )

## summary:
- adds --disable-features for Critical Client Hints and AcceptCH frames.
- resolves an issue where page.goto() hangs indefinitely on MacOS and Linux.

## justification:
chromium's internal retry logic for critical hints causes a deadlock with low-level fingerprinting patches during the initial proxy handshake. Disabling these features bypasses the problematic code path without impacting general automation functionality.