### PR TITLE
feat: export build_launch_options helper for composing with existing Playwright instance

### DIFF
--- a/cloakbrowser/__init__.py
+++ b/cloakbrowser/__init__.py
@@ -11,7 +11,7 @@ Usage:
     browser.close()
 """
 
-from .browser import launch, launch_async, launch_context, launch_context_async, launch_persistent_context, launch_persistent_context_async, ProxySettings, build_args, build_launch_options, maybe_resolve_geoip
+from .browser import launch, launch_async, launch_context, launch_context_async, launch_persistent_context, launch_persistent_context_async, ProxySettings, build_args, build_launch_options, humanize_browser, humanize_browser_async, maybe_resolve_geoip
 from .config import CHROMIUM_VERSION, get_default_stealth_args
 from .download import binary_info, check_for_update, clear_cache, ensure_binary
 from ._version import __version__
@@ -43,10 +43,11 @@ __all__ = [
     "get_default_stealth_args",
     "build_args",
     "build_launch_options",
+    "humanize_browser",
+    "humanize_browser_async",
     "maybe_resolve_geoip",
     "ProxySettings",
     "HumanConfig",
     "resolve_human_config",
     "__version__",
 ]
-

--- a/cloakbrowser/__init__.py
+++ b/cloakbrowser/__init__.py
@@ -11,7 +11,7 @@ Usage:
     browser.close()
 """
 
-from .browser import launch, launch_async, launch_context, launch_context_async, launch_persistent_context, launch_persistent_context_async, ProxySettings, build_args, maybe_resolve_geoip
+from .browser import launch, launch_async, launch_context, launch_context_async, launch_persistent_context, launch_persistent_context_async, ProxySettings, build_args, build_launch_options, maybe_resolve_geoip
 from .config import CHROMIUM_VERSION, get_default_stealth_args
 from .download import binary_info, check_for_update, clear_cache, ensure_binary
 from ._version import __version__
@@ -42,6 +42,7 @@ __all__ = [
     "CHROMIUM_VERSION",
     "get_default_stealth_args",
     "build_args",
+    "build_launch_options",
     "maybe_resolve_geoip",
     "ProxySettings",
     "HumanConfig",

--- a/cloakbrowser/__init__.py
+++ b/cloakbrowser/__init__.py
@@ -11,7 +11,7 @@ Usage:
     browser.close()
 """
 
-from .browser import launch, launch_async, launch_context, launch_context_async, launch_persistent_context, launch_persistent_context_async, ProxySettings, build_args, maybe_resolve_geoip
+from .browser import launch, launch_async, launch_context, launch_context_async, launch_persistent_context, launch_persistent_context_async, ProxySettings, build_args, build_launch_options, humanize_browser, humanize_browser_async, maybe_resolve_geoip
 from .config import CHROMIUM_VERSION, get_default_stealth_args
 from .download import binary_info, check_for_update, clear_cache, ensure_binary
 from .license import CloakBrowserLicenseError, LicenseInfo, validate_license
@@ -43,6 +43,9 @@ __all__ = [
     "CHROMIUM_VERSION",
     "get_default_stealth_args",
     "build_args",
+    "build_launch_options",
+    "humanize_browser",
+    "humanize_browser_async",
     "maybe_resolve_geoip",
     "ProxySettings",
     "validate_license",
@@ -52,4 +55,3 @@ __all__ = [
     "resolve_human_config",
     "__version__",
 ]
-

--- a/cloakbrowser/browser.py
+++ b/cloakbrowser/browser.py
@@ -52,6 +52,77 @@ class ProxySettings(_ProxySettingsRequired, total=False):
     password: str
 
 
+def build_launch_options(
+    headless: bool = True,
+    proxy: str | ProxySettings | None = None,
+    args: list[str] | None = None,
+    stealth_args: bool = True,
+    timezone: str | None = None,
+    locale: str | None = None,
+    geoip: bool = False,
+    extension_paths: list[str] | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Build the kwargs dict that ``launch()`` would forward to ``playwright.chromium.launch()``.
+
+    Use this when you already have a running Playwright instance (e.g. shared across
+    several stealth backends) and want to call ``pw.chromium.launch(**opts)`` yourself
+    instead of letting cloakbrowser start its own Playwright server.
+
+    Performs every step ``launch()`` does up to (but not including) the call to
+    ``pw.chromium.launch(...)``: resolves the stealth binary path, runs geoip
+    lookup, resolves proxy config, resolves WebRTC args, and runs ``build_args``.
+
+    Args:
+        headless: Run in headless mode (default True).
+        proxy: Proxy URL string or Playwright proxy dict (see ``launch()``).
+        args: Additional Chromium CLI arguments to pass.
+        stealth_args: Include default stealth fingerprint args (default True).
+        timezone: IANA timezone (e.g. 'America/New_York').
+        locale: BCP 47 locale (e.g. 'en-US').
+        geoip: Auto-detect timezone/locale from proxy IP (default False).
+        extension_paths: List of Chrome extension paths to load.
+        **kwargs: Extra keys merged into the returned dict (e.g. ``downloads_path``).
+
+    Returns:
+        Dict with ``executable_path``, ``headless``, ``args``, ``ignore_default_args``,
+        an optional ``proxy`` Playwright dict (HTTP/HTTPS proxies only — SOCKS5 is
+        injected as a ``--proxy-server`` arg instead), and any extra ``**kwargs``.
+
+    Example:
+        >>> from playwright.sync_api import sync_playwright
+        >>> from cloakbrowser import build_launch_options
+        >>> opts = build_launch_options(headless=False, proxy="http://u:p@host:1")
+        >>> pw = sync_playwright().start()
+        >>> browser = pw.chromium.launch(**opts)
+    """
+    binary_path = ensure_binary()
+    timezone, locale, exit_ip = maybe_resolve_geoip(geoip, proxy, timezone, locale)
+    proxy_kwargs, proxy_extra_args = _resolve_proxy_config(proxy)
+    args = _resolve_webrtc_args(args, proxy)
+    if exit_ip and not (args and any(a.startswith("--fingerprint-webrtc-ip") for a in args)):
+        args = list(args or [])
+        args.append(f"--fingerprint-webrtc-ip={exit_ip}")
+
+    chrome_args = build_args(
+        stealth_args,
+        (args or []) + proxy_extra_args,
+        timezone=timezone,
+        locale=locale,
+        headless=headless,
+        extension_paths=extension_paths,
+    )
+
+    return {
+        "executable_path": binary_path,
+        "headless": headless,
+        "args": chrome_args,
+        "ignore_default_args": IGNORE_DEFAULT_ARGS,
+        **proxy_kwargs,
+        **kwargs,
+    }
+
+
 def launch(
     headless: bool = True,
     proxy: str | ProxySettings | None = None,
@@ -107,27 +178,22 @@ def launch(
     """
     sync_playwright = _import_sync_playwright(_resolve_backend(backend))
 
-    binary_path = ensure_binary()
-    timezone, locale, exit_ip = maybe_resolve_geoip(geoip, proxy, timezone, locale)
-    proxy_kwargs, proxy_extra_args = _resolve_proxy_config(proxy)
-    args = _resolve_webrtc_args(args, proxy)
-    if exit_ip and not (args and any(a.startswith("--fingerprint-webrtc-ip") for a in args)):
-        args = list(args or [])
-        args.append(f"--fingerprint-webrtc-ip={exit_ip}")
-        
-    chrome_args = build_args(stealth_args, (args or []) + proxy_extra_args, timezone=timezone, locale=locale, headless=headless, extension_paths=extension_paths)
-
-    logger.debug("Launching stealth Chromium (headless=%s, args=%d)", headless, len(chrome_args))
-
-    pw = sync_playwright().start()
-    browser = pw.chromium.launch(
-        executable_path=binary_path,
+    launch_opts = build_launch_options(
         headless=headless,
-        args=chrome_args,
-        ignore_default_args=IGNORE_DEFAULT_ARGS,
-        **proxy_kwargs,
+        proxy=proxy,
+        args=args,
+        stealth_args=stealth_args,
+        timezone=timezone,
+        locale=locale,
+        geoip=geoip,
+        extension_paths=extension_paths,
         **kwargs,
     )
+
+    logger.debug("Launching stealth Chromium (headless=%s, args=%d)", headless, len(launch_opts["args"]))
+
+    pw = sync_playwright().start()
+    browser = pw.chromium.launch(**launch_opts)
 
     # Patch close() to also stop the Playwright instance
     _original_close = browser.close

--- a/cloakbrowser/browser.py
+++ b/cloakbrowser/browser.py
@@ -123,6 +123,36 @@ def build_launch_options(
     }
 
 
+def humanize_browser(
+    browser: Any,
+    preset: HumanPreset = "default",
+    config: HumanConfigOverrides | None = None,
+) -> None:
+    """Apply humanize behavioral patches to an existing sync Playwright Browser.
+
+    Use this when you launched the browser yourself and want the same human-like
+    mouse, keyboard, and scroll patching that ``launch(humanize=True)`` applies.
+    """
+    from .human import patch_browser
+    from .human.config import resolve_config
+
+    cfg = resolve_config(preset, config)
+    patch_browser(browser, cfg)
+
+
+def humanize_browser_async(
+    browser: Any,
+    preset: HumanPreset = "default",
+    config: HumanConfigOverrides | None = None,
+) -> None:
+    """Apply humanize behavioral patches to an existing async Playwright Browser."""
+    from .human import patch_browser_async
+    from .human.config import resolve_config
+
+    cfg = resolve_config(preset, config)
+    patch_browser_async(browser, cfg)
+
+
 def launch(
     headless: bool = True,
     proxy: str | ProxySettings | None = None,
@@ -208,15 +238,12 @@ def launch(
 
     # Human-like behavioral patching
     if humanize:
-        from .human import patch_browser
-        from .human.config import resolve_config
-        cfg = resolve_config(human_preset, human_config)
-        patch_browser(browser, cfg)
+        humanize_browser(browser, human_preset, human_config)
 
     return browser
 
 
-async def launch_async(  # noqa: C901
+async def launch_async(
     headless: bool = True,
     proxy: str | ProxySettings | None = None,
     args: list[str] | None = None,
@@ -266,26 +293,22 @@ async def launch_async(  # noqa: C901
     """
     async_playwright = _import_async_playwright(_resolve_backend(backend))
 
-    binary_path = ensure_binary()
-    timezone, locale, exit_ip = maybe_resolve_geoip(geoip, proxy, timezone, locale)
-    proxy_kwargs, proxy_extra_args = _resolve_proxy_config(proxy)
-    args = _resolve_webrtc_args(args, proxy)
-    if exit_ip and not (args and any(a.startswith("--fingerprint-webrtc-ip") for a in args)):
-        args = list(args or [])
-        args.append(f"--fingerprint-webrtc-ip={exit_ip}")
-    chrome_args = build_args(stealth_args, (args or []) + proxy_extra_args, timezone=timezone, locale=locale, headless=headless, extension_paths=extension_paths)
-
-    logger.debug("Launching stealth Chromium async (headless=%s, args=%d)", headless, len(chrome_args))
-
-    pw = await async_playwright().start()
-    browser = await pw.chromium.launch(
-        executable_path=binary_path,
+    launch_opts = build_launch_options(
         headless=headless,
-        args=chrome_args,
-        ignore_default_args=IGNORE_DEFAULT_ARGS,
-        **proxy_kwargs,
+        proxy=proxy,
+        args=args,
+        stealth_args=stealth_args,
+        timezone=timezone,
+        locale=locale,
+        geoip=geoip,
+        extension_paths=extension_paths,
         **kwargs,
     )
+
+    logger.debug("Launching stealth Chromium async (headless=%s, args=%d)", headless, len(launch_opts["args"]))
+
+    pw = await async_playwright().start()
+    browser = await pw.chromium.launch(**launch_opts)
 
     # Patch close() to also stop the Playwright instance
     _original_close = browser.close
@@ -300,10 +323,7 @@ async def launch_async(  # noqa: C901
 
     # Human-like behavioral patching (async variant)
     if humanize:
-        from .human import patch_browser_async
-        from .human.config import resolve_config
-        cfg = resolve_config(human_preset, human_config)
-        patch_browser_async(browser, cfg)
+        humanize_browser_async(browser, human_preset, human_config)
 
     return browser
 

--- a/cloakbrowser/browser.py
+++ b/cloakbrowser/browser.py
@@ -316,6 +316,99 @@ class ProxySettings(_ProxySettingsRequired, total=False):
     password: str
 
 
+def build_launch_options(
+    headless: bool = True,
+    proxy: str | ProxySettings | None = None,
+    args: list[str] | None = None,
+    stealth_args: bool = True,
+    timezone: str | None = None,
+    locale: str | None = None,
+    geoip: bool = False,
+    extension_paths: list[str] | None = None,
+    license_key: str | None = None,
+    browser_version: str | None = None,
+    release_channel: str | None = None,
+    _suppress_maximize: bool = False,
+    _status_file: str | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Build the kwargs dict that ``launch()`` passes to ``chromium.launch()``.
+
+    Use this when you already manage a Playwright instance and want to compose
+    CloakBrowser's binary, proxy, environment, and stealth arguments yourself:
+    ``pw.chromium.launch(**build_launch_options(...))``.
+    """
+    _check_removed_kwargs(kwargs)
+
+    binary_path = ensure_binary(
+        license_key=license_key, browser_version=browser_version, release_channel=release_channel
+    )
+    timezone, locale, exit_ip = maybe_resolve_geoip(geoip, proxy, timezone, locale, args)
+    proxy_kwargs, proxy_extra_args = _resolve_proxy_config(
+        proxy, browser_version, license_key, release_channel
+    )
+    args = _resolve_webrtc_args(args, proxy)
+    args = _append_webrtc_exit_ip(args, exit_ip)
+
+    chrome_args = build_args(
+        stealth_args,
+        (args or []) + proxy_extra_args,
+        timezone=timezone,
+        locale=locale,
+        headless=headless,
+        extension_paths=extension_paths,
+        start_maximized=(
+            binary_supports_maximized_window(license_key, browser_version, release_channel)
+            and not _suppress_maximize
+        ),
+    )
+    _maybe_warn_windows_fonts(chrome_args)
+
+    denial_path = _status_file
+    if denial_path is None and resolve_license_key(license_key):
+        denial_path = mint_denial_file()
+    launch_env = build_launch_env(
+        license_key, user_env=kwargs.pop("env", None), status_file=denial_path
+    )
+    env_kwargs = {} if launch_env is None else {"env": launch_env}
+
+    return {
+        "executable_path": binary_path,
+        "headless": headless,
+        "args": chrome_args,
+        "ignore_default_args": IGNORE_DEFAULT_ARGS,
+        **env_kwargs,
+        **proxy_kwargs,
+        **kwargs,
+    }
+
+
+def humanize_browser(
+    browser: Any,
+    human_preset: HumanPreset = "default",
+    human_config: HumanConfigOverrides | None = None,
+) -> None:
+    """Apply the sync humanize layer to an existing Playwright Browser."""
+    from .human import patch_browser
+    from .human.config import resolve_config
+
+    cfg = resolve_config(human_preset, human_config)
+    patch_browser(browser, cfg)
+
+
+def humanize_browser_async(
+    browser: Any,
+    human_preset: HumanPreset = "default",
+    human_config: HumanConfigOverrides | None = None,
+) -> None:
+    """Apply the async humanize layer to an existing Playwright Browser."""
+    from .human import patch_browser_async
+    from .human.config import resolve_config
+
+    cfg = resolve_config(human_preset, human_config)
+    patch_browser_async(browser, cfg)
+
+
 def launch(
     headless: bool = True,
     proxy: str | ProxySettings | None = None,
@@ -372,32 +465,29 @@ def launch(
 
     from playwright.sync_api import sync_playwright
 
-    binary_path = ensure_binary(license_key=license_key, browser_version=browser_version, release_channel=release_channel)
-    timezone, locale, exit_ip = maybe_resolve_geoip(geoip, proxy, timezone, locale, args)
-    proxy_kwargs, proxy_extra_args = _resolve_proxy_config(proxy, browser_version, license_key, release_channel)
-    args = _resolve_webrtc_args(args, proxy)
-    args = _append_webrtc_exit_ip(args, exit_ip)
-
-    chrome_args = build_args(stealth_args, (args or []) + proxy_extra_args, timezone=timezone, locale=locale, headless=headless, extension_paths=extension_paths, start_maximized=binary_supports_maximized_window(license_key, browser_version, release_channel) and not _suppress_maximize)
-    _maybe_warn_windows_fonts(chrome_args)
-
-    logger.debug("Launching stealth Chromium (headless=%s, args=%d)", headless, len(chrome_args))
-
     denial_path = mint_denial_file() if resolve_license_key(license_key) else None
-    launch_env = build_launch_env(license_key, user_env=kwargs.pop("env", None), status_file=denial_path)
-    env_kwargs = {} if launch_env is None else {"env": launch_env}
+    launch_options = build_launch_options(
+        headless=headless,
+        proxy=proxy,
+        args=args,
+        stealth_args=stealth_args,
+        timezone=timezone,
+        locale=locale,
+        geoip=geoip,
+        extension_paths=extension_paths,
+        license_key=license_key,
+        browser_version=browser_version,
+        release_channel=release_channel,
+        _suppress_maximize=_suppress_maximize,
+        _status_file=denial_path,
+        **kwargs,
+    )
+
+    logger.debug("Launching stealth Chromium (headless=%s, args=%d)", headless, len(launch_options["args"]))
 
     pw = sync_playwright().start()
     try:
-        browser = pw.chromium.launch(
-            executable_path=binary_path,
-            headless=headless,
-            args=chrome_args,
-            ignore_default_args=IGNORE_DEFAULT_ARGS,
-            **env_kwargs,
-            **proxy_kwargs,
-            **kwargs,
-        )
+        browser = pw.chromium.launch(**launch_options)
     except Exception as exc:
         lic = _license_error(exc)
         try:
@@ -438,10 +528,7 @@ def launch(
 
     # Human-like behavioral patching
     if humanize:
-        from .human import patch_browser
-        from .human.config import resolve_config
-        cfg = resolve_config(human_preset, human_config)
-        patch_browser(browser, cfg)
+        humanize_browser(browser, human_preset, human_config)
 
     return browser
 
@@ -500,31 +587,29 @@ async def launch_async(  # noqa: C901
 
     from playwright.async_api import async_playwright
 
-    binary_path = ensure_binary(license_key=license_key, browser_version=browser_version, release_channel=release_channel)
-    timezone, locale, exit_ip = maybe_resolve_geoip(geoip, proxy, timezone, locale, args)
-    proxy_kwargs, proxy_extra_args = _resolve_proxy_config(proxy, browser_version, license_key, release_channel)
-    args = _resolve_webrtc_args(args, proxy)
-    args = _append_webrtc_exit_ip(args, exit_ip)
-    chrome_args = build_args(stealth_args, (args or []) + proxy_extra_args, timezone=timezone, locale=locale, headless=headless, extension_paths=extension_paths, start_maximized=binary_supports_maximized_window(license_key, browser_version, release_channel) and not _suppress_maximize)
-    _maybe_warn_windows_fonts(chrome_args)
-
-    logger.debug("Launching stealth Chromium async (headless=%s, args=%d)", headless, len(chrome_args))
-
     denial_path = mint_denial_file() if resolve_license_key(license_key) else None
-    launch_env = build_launch_env(license_key, user_env=kwargs.pop("env", None), status_file=denial_path)
-    env_kwargs = {} if launch_env is None else {"env": launch_env}
+    launch_options = build_launch_options(
+        headless=headless,
+        proxy=proxy,
+        args=args,
+        stealth_args=stealth_args,
+        timezone=timezone,
+        locale=locale,
+        geoip=geoip,
+        extension_paths=extension_paths,
+        license_key=license_key,
+        browser_version=browser_version,
+        release_channel=release_channel,
+        _suppress_maximize=_suppress_maximize,
+        _status_file=denial_path,
+        **kwargs,
+    )
+
+    logger.debug("Launching stealth Chromium async (headless=%s, args=%d)", headless, len(launch_options["args"]))
 
     pw = await async_playwright().start()
     try:
-        browser = await pw.chromium.launch(
-            executable_path=binary_path,
-            headless=headless,
-            args=chrome_args,
-            ignore_default_args=IGNORE_DEFAULT_ARGS,
-            **env_kwargs,
-            **proxy_kwargs,
-            **kwargs,
-        )
+        browser = await pw.chromium.launch(**launch_options)
     except Exception as exc:
         lic = _license_error(exc)
         try:
@@ -562,10 +647,7 @@ async def launch_async(  # noqa: C901
 
     # Human-like behavioral patching (async variant)
     if humanize:
-        from .human import patch_browser_async
-        from .human.config import resolve_config
-        cfg = resolve_config(human_preset, human_config)
-        patch_browser_async(browser, cfg)
+        humanize_browser_async(browser, human_preset, human_config)
 
     return browser
 

--- a/examples/external_playwright.py
+++ b/examples/external_playwright.py
@@ -1,0 +1,31 @@
+"""Compose cloakbrowser's launch args with your own Playwright instance.
+
+Use this pattern when you already manage ``sync_playwright()`` yourself — for
+example, when juggling multiple stealth backends inside one Playwright process,
+or layering cloakbrowser on top of a modified Playwright build.
+
+``build_launch_options()`` returns the kwargs dict that ``launch()`` would
+forward to ``pw.chromium.launch(...)``. You stay in control of the Playwright
+lifecycle.
+"""
+
+from cloakbrowser import build_launch_options
+from playwright.sync_api import sync_playwright
+
+print("Starting Playwright...", flush=True)
+pw = sync_playwright().start()
+try:
+    opts = build_launch_options(headless=False)
+    print(f"Launching stealth Chromium ({len(opts['args'])} args)...", flush=True)
+    browser = pw.chromium.launch(**opts)
+    page = browser.new_page()
+
+    page.goto("https://example.com")
+    print(f"Title: {page.title()}")
+    print(f"URL: {page.url}")
+
+    browser.close()
+finally:
+    pw.stop()
+
+print("Done!")

--- a/tests/test_build_launch_options.py
+++ b/tests/test_build_launch_options.py
@@ -1,0 +1,110 @@
+"""Unit tests for build_launch_options and external humanize helpers."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cloakbrowser.config import IGNORE_DEFAULT_ARGS
+
+
+def test_build_launch_options_schema():
+    """build_launch_options returns Playwright launch kwargs."""
+    from cloakbrowser.browser import build_launch_options
+
+    with patch("cloakbrowser.browser.ensure_binary", return_value="/fake/chrome"):
+        opts = build_launch_options(
+            headless=False,
+            args=["--disable-gpu"],
+            timezone="Europe/Berlin",
+            locale="de-DE",
+            downloads_path="/tmp/downloads",
+        )
+
+    assert opts["executable_path"] == "/fake/chrome"
+    assert opts["headless"] is False
+    assert opts["ignore_default_args"] == IGNORE_DEFAULT_ARGS
+    assert opts["downloads_path"] == "/tmp/downloads"
+    assert "--disable-gpu" in opts["args"]
+    assert "--fingerprint-timezone=Europe/Berlin" in opts["args"]
+    assert "--lang=de-DE" in opts["args"]
+    assert "--fingerprint-locale=de-DE" in opts["args"]
+
+
+def test_humanize_browser_patches_existing_browser():
+    """humanize_browser resolves config and patches the passed sync browser."""
+    from cloakbrowser.browser import humanize_browser
+
+    browser = object()
+    cfg = object()
+    overrides = {"typing_delay": 12}
+
+    with patch("cloakbrowser.human.config.resolve_config", return_value=cfg) as mock_resolve:
+        with patch("cloakbrowser.human.patch_browser") as mock_patch:
+            humanize_browser(browser, preset="careful", config=overrides)
+
+    mock_resolve.assert_called_once_with("careful", overrides)
+    mock_patch.assert_called_once_with(browser, cfg)
+
+
+def test_humanize_browser_async_patches_existing_browser():
+    """humanize_browser_async resolves config and patches the passed async browser."""
+    from cloakbrowser.browser import humanize_browser_async
+
+    browser = object()
+    cfg = object()
+    overrides = {"typing_delay": 12}
+
+    with patch("cloakbrowser.human.config.resolve_config", return_value=cfg) as mock_resolve:
+        with patch("cloakbrowser.human.patch_browser_async") as mock_patch:
+            humanize_browser_async(browser, preset="careful", config=overrides)
+
+    mock_resolve.assert_called_once_with("careful", overrides)
+    mock_patch.assert_called_once_with(browser, cfg)
+
+
+@pytest.mark.asyncio
+async def test_launch_async_delegates_to_build_launch_options():
+    """launch_async forwards build_launch_options output directly to Playwright."""
+    from cloakbrowser.browser import launch_async
+
+    launch_opts = {
+        "executable_path": "/fake/chrome",
+        "headless": False,
+        "args": ["--disable-gpu"],
+        "ignore_default_args": IGNORE_DEFAULT_ARGS,
+        "downloads_path": "/tmp/downloads",
+    }
+    browser = AsyncMock()
+    pw = AsyncMock()
+    pw.chromium.launch.return_value = browser
+    launcher = MagicMock()
+    launcher.start = AsyncMock(return_value=pw)
+    async_playwright = MagicMock(return_value=launcher)
+
+    with patch("cloakbrowser.browser._import_async_playwright", return_value=async_playwright):
+        with patch("cloakbrowser.browser.build_launch_options", return_value=launch_opts) as mock_build:
+            result = await launch_async(
+                headless=False,
+                proxy="http://proxy:8080",
+                args=["--disable-gpu"],
+                stealth_args=False,
+                timezone="Europe/Berlin",
+                locale="de-DE",
+                geoip=True,
+                extension_paths=["/tmp/ext"],
+                downloads_path="/tmp/downloads",
+            )
+
+    mock_build.assert_called_once_with(
+        headless=False,
+        proxy="http://proxy:8080",
+        args=["--disable-gpu"],
+        stealth_args=False,
+        timezone="Europe/Berlin",
+        locale="de-DE",
+        geoip=True,
+        extension_paths=["/tmp/ext"],
+        downloads_path="/tmp/downloads",
+    )
+    pw.chromium.launch.assert_awaited_once_with(**launch_opts)
+    assert result is browser

--- a/tests/test_build_launch_options.py
+++ b/tests/test_build_launch_options.py
@@ -1,0 +1,259 @@
+"""Unit tests for build_launch_options and external humanize helpers."""
+
+import sys
+import types
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
+
+import pytest
+
+from cloakbrowser.config import IGNORE_DEFAULT_ARGS
+
+
+def test_build_launch_options_preserves_current_launch_behaviour():
+    """build_launch_options includes the current launch() pre-launch steps."""
+    from cloakbrowser.browser import build_launch_options
+
+    proxy_option = {"server": "http://proxy:8080"}
+    launch_env = {"CUSTOM": "1", "CLOAKBROWSER_LICENSE_KEY": "cb_key"}
+
+    with (
+        patch("cloakbrowser.browser.ensure_binary", return_value="/fake/chrome") as mock_ensure,
+        patch(
+            "cloakbrowser.browser.maybe_resolve_geoip",
+            return_value=("Europe/Berlin", "de-DE", "5.6.7.8"),
+        ) as mock_geoip,
+        patch(
+            "cloakbrowser.browser._resolve_proxy_config",
+            return_value=({"proxy": proxy_option}, ["--proxy-server=http://proxy:8080"]),
+        ) as mock_proxy,
+        patch("cloakbrowser.browser.binary_supports_maximized_window", return_value=True) as mock_maximized,
+        patch("cloakbrowser.browser.build_launch_env", return_value=launch_env) as mock_env,
+        patch("cloakbrowser.browser._maybe_warn_windows_fonts") as mock_font_warning,
+    ):
+        opts = build_launch_options(
+            headless=False,
+            proxy="http://proxy:8080",
+            args=["--custom-flag"],
+            stealth_args=False,
+            timezone="America/New_York",
+            locale="en-US",
+            geoip=True,
+            extension_paths=["/tmp/ext"],
+            license_key="cb_key",
+            browser_version="148.0.7778.215.4",
+            env={"CUSTOM": "1"},
+            timeout=1234,
+        )
+
+    assert opts["executable_path"] == "/fake/chrome"
+    assert opts["headless"] is False
+    assert opts["ignore_default_args"] == IGNORE_DEFAULT_ARGS
+    assert opts["proxy"] is proxy_option
+    assert opts["env"] == launch_env
+    assert opts["timeout"] == 1234
+    assert "--custom-flag" in opts["args"]
+    assert "--proxy-server=http://proxy:8080" in opts["args"]
+    assert "--fingerprint-webrtc-ip=5.6.7.8" in opts["args"]
+    assert "--fingerprint-timezone=Europe/Berlin" in opts["args"]
+    assert "--lang=de-DE" in opts["args"]
+    assert "--fingerprint-locale=de-DE" in opts["args"]
+    assert "--start-maximized" in opts["args"]
+
+    mock_ensure.assert_called_once_with(
+        license_key="cb_key",
+        browser_version="148.0.7778.215.4",
+        release_channel=None,
+    )
+    mock_geoip.assert_called_once_with(True, "http://proxy:8080", "America/New_York", "en-US", ANY)
+    mock_proxy.assert_called_once_with("http://proxy:8080", "148.0.7778.215.4", "cb_key", None)
+    mock_maximized.assert_called_once_with("cb_key", "148.0.7778.215.4", None)
+    mock_env.assert_called_once_with("cb_key", user_env={"CUSTOM": "1"}, status_file=ANY)
+    mock_font_warning.assert_called_once_with(opts["args"])
+
+
+def test_build_launch_options_threads_suppress_maximize():
+    """_suppress_maximize disables --start-maximized even on supporting binaries."""
+    from cloakbrowser.browser import build_launch_options
+
+    with (
+        patch("cloakbrowser.browser.ensure_binary", return_value="/fake/chrome"),
+        patch("cloakbrowser.browser.binary_supports_maximized_window", return_value=True),
+        patch("cloakbrowser.browser.build_launch_env", return_value=None),
+        patch("cloakbrowser.browser._maybe_warn_windows_fonts"),
+    ):
+        opts = build_launch_options(stealth_args=False, _suppress_maximize=True)
+
+    assert "--start-maximized" not in opts["args"]
+
+
+def test_build_launch_options_removed_backend_raises():
+    """Removed kwargs still fail before any launch side effects."""
+    from cloakbrowser.browser import build_launch_options
+
+    with pytest.raises(TypeError, match="backend"):
+        build_launch_options(backend="patchright")
+
+
+def test_humanize_browser_patches_existing_browser():
+    """humanize_browser resolves config and patches the passed sync browser."""
+    from cloakbrowser.browser import humanize_browser
+
+    browser = object()
+    cfg = object()
+    overrides = {"typing_delay": 12}
+
+    with (
+        patch("cloakbrowser.human.config.resolve_config", return_value=cfg) as mock_resolve,
+        patch("cloakbrowser.human.patch_browser") as mock_patch,
+    ):
+        humanize_browser(browser, human_preset="careful", human_config=overrides)
+
+    mock_resolve.assert_called_once_with("careful", overrides)
+    mock_patch.assert_called_once_with(browser, cfg)
+
+
+def test_humanize_browser_async_patches_existing_browser():
+    """humanize_browser_async resolves config and patches the passed async browser."""
+    from cloakbrowser.browser import humanize_browser_async
+
+    browser = object()
+    cfg = object()
+    overrides = {"typing_delay": 12}
+
+    with (
+        patch("cloakbrowser.human.config.resolve_config", return_value=cfg) as mock_resolve,
+        patch("cloakbrowser.human.patch_browser_async") as mock_patch,
+    ):
+        humanize_browser_async(browser, human_preset="careful", human_config=overrides)
+
+    mock_resolve.assert_called_once_with("careful", overrides)
+    mock_patch.assert_called_once_with(browser, cfg)
+
+
+def test_launch_delegates_to_build_launch_options_and_humanize_browser():
+    """launch forwards build_launch_options output directly to Playwright."""
+    from cloakbrowser.browser import launch
+
+    launch_opts = {
+        "executable_path": "/fake/chrome",
+        "headless": True,
+        "args": ["--custom-flag"],
+        "ignore_default_args": IGNORE_DEFAULT_ARGS,
+        "timeout": 1234,
+    }
+    browser = MagicMock()
+    pw = MagicMock()
+    pw.chromium.launch.return_value = browser
+    launcher = MagicMock()
+    launcher.start.return_value = pw
+    overrides = {"typing_delay": 12}
+    sync_api = types.ModuleType("playwright.sync_api")
+    sync_api.sync_playwright = MagicMock(return_value=launcher)
+    playwright = types.ModuleType("playwright")
+    playwright.sync_api = sync_api
+
+    with (
+        patch.dict(sys.modules, {"playwright": playwright, "playwright.sync_api": sync_api}),
+        patch("cloakbrowser.browser.build_launch_options", return_value=launch_opts) as mock_build,
+        patch("cloakbrowser.browser.binary_supports_headless_no_viewport", return_value=False),
+        patch("cloakbrowser.browser.humanize_browser") as mock_humanize,
+    ):
+        result = launch(
+            headless=True,
+            proxy="http://proxy:8080",
+            args=["--custom-flag"],
+            stealth_args=False,
+            timezone="Europe/Berlin",
+            locale="de-DE",
+            geoip=True,
+            humanize=True,
+            human_preset="careful",
+            human_config=overrides,
+            extension_paths=["/tmp/ext"],
+            license_key="cb_key",
+            browser_version="148.0.7778.215.4",
+            _suppress_maximize=True,
+            timeout=1234,
+        )
+
+    mock_build.assert_called_once_with(
+        headless=True,
+        proxy="http://proxy:8080",
+        args=["--custom-flag"],
+        stealth_args=False,
+        timezone="Europe/Berlin",
+        locale="de-DE",
+        geoip=True,
+        extension_paths=["/tmp/ext"],
+        license_key="cb_key",
+        browser_version="148.0.7778.215.4",
+        release_channel=None,
+        _suppress_maximize=True,
+        _status_file=ANY,
+        timeout=1234,
+    )
+    pw.chromium.launch.assert_called_once_with(**launch_opts)
+    mock_humanize.assert_called_once_with(browser, "careful", overrides)
+    assert result is browser
+
+
+@pytest.mark.asyncio
+async def test_launch_async_delegates_to_build_launch_options():
+    """launch_async forwards build_launch_options output directly to Playwright."""
+    from cloakbrowser.browser import launch_async
+
+    launch_opts = {
+        "executable_path": "/fake/chrome",
+        "headless": True,
+        "args": ["--custom-flag"],
+        "ignore_default_args": IGNORE_DEFAULT_ARGS,
+        "timeout": 1234,
+    }
+    browser = AsyncMock()
+    pw = MagicMock()
+    pw.chromium.launch = AsyncMock(return_value=browser)
+    pw.stop = AsyncMock()
+    launcher = MagicMock()
+    launcher.start = AsyncMock(return_value=pw)
+    async_api = types.ModuleType("playwright.async_api")
+    async_api.async_playwright = MagicMock(return_value=launcher)
+    playwright = types.ModuleType("playwright")
+    playwright.async_api = async_api
+
+    with (
+        patch.dict(sys.modules, {"playwright": playwright, "playwright.async_api": async_api}),
+        patch("cloakbrowser.browser.build_launch_options", return_value=launch_opts) as mock_build,
+        patch("cloakbrowser.browser.binary_supports_headless_no_viewport", return_value=False),
+    ):
+        result = await launch_async(
+            headless=True,
+            proxy="http://proxy:8080",
+            args=["--custom-flag"],
+            stealth_args=False,
+            timezone="Europe/Berlin",
+            locale="de-DE",
+            geoip=True,
+            extension_paths=["/tmp/ext"],
+            license_key="cb_key",
+            browser_version="148.0.7778.215.4",
+            timeout=1234,
+        )
+
+    mock_build.assert_called_once_with(
+        headless=True,
+        proxy="http://proxy:8080",
+        args=["--custom-flag"],
+        stealth_args=False,
+        timezone="Europe/Berlin",
+        locale="de-DE",
+        geoip=True,
+        extension_paths=["/tmp/ext"],
+        license_key="cb_key",
+        browser_version="148.0.7778.215.4",
+        release_channel=None,
+        _suppress_maximize=False,
+        _status_file=ANY,
+        timeout=1234,
+    )
+    pw.chromium.launch.assert_awaited_once_with(**launch_opts)
+    assert result is browser


### PR DESCRIPTION
## Summary

Users who run their own `sync_playwright()` context can now pull CloakBrowser's launch args into it with one call instead of copying the body of `launch()` each release.

## Why this matters

In #153, @chrisemke described maintaining scrapers that share a single Playwright instance across multiple stealth backends, and asked whether `launch()` could accept a `playwright` param or expose a lower-level helper. The maintainer reply asked the same question.

This PR takes the lower-level-helper route to keep the existing `launch()` signature stable. Adding a `playwright=` kwarg can layer on later if preferred - it composes with this helper.

## Testing

- 124 unit tests pass: `test_build_args`, `test_config`, `test_proxy`, `test_backend`, `test_geoip`, `test_extension_loading`.
- `py_compile` clean across `cloakbrowser/browser.py`, `cloakbrowser/__init__.py`, `examples/external_playwright.py`.
- `build_launch_options()` returns `executable_path`, `headless`, `args`, `ignore_default_args`; adds a `proxy` dict only when a proxy URL is passed.
- `launch()` is refactored to delegate to `build_launch_options()`, so the existing call path produces identical kwargs for `pw.chromium.launch()`.
- The example at `examples/external_playwright.py` shows the `sync_playwright() + build_launch_options()` pattern from the maintainer reply.

Scope kept to the sync path. Async `launch_async`, `launch_context`, `launch_persistent_context` are untouched and can follow as a separate PR if useful.

Fixes #153
