### PR TITLE
docs: add macOS per-profile launcher example

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,7 @@ browser = launch(args=[
 **Python** — see [`examples/`](examples/):
 - [`basic.py`](examples/basic.py) — Launch and load a page
 - [`persistent_context.py`](examples/persistent_context.py) — Persistent profile with cookie/localStorage persistence
+- [`macos_profile_launcher.py`](examples/macos_profile_launcher.py) — Per-profile macOS desktop launcher pattern (one .app shortcut per profile, fixed fingerprint seed)
 - [`recaptcha_score.py`](examples/recaptcha_score.py) — Check your reCAPTCHA v3 score
 - [`stealth_test.py`](examples/stealth_test.py) — Run against 6 detection sites
 - [`fingerprint_scan_test.py`](examples/fingerprint_scan_test.py) — Test against fingerprint-scan.com and CreepJS

--- a/examples/macos_profile_launcher.py
+++ b/examples/macos_profile_launcher.py
@@ -1,0 +1,42 @@
+"""Per-profile macOS desktop launcher: one .app shortcut per CloakBrowser profile.
+
+Use this when you want native macOS double-click launchers for each profile
+(e.g. ``Cloak Profile A.app``, ``Cloak Profile B.app``) that open the browser
+directly with a fixed fingerprint seed and persistent profile dir — bypassing
+the Manager web UI.
+
+Setup (per profile):
+
+  1. Copy this file to e.g. ``~/cloak-profiles/launch-profile-a.py`` and edit
+     PROFILE_NAME / PROFILE_SEED below.
+  2. Open Automator → New → "Application" → search "Run Shell Script" and add::
+
+         cd ~/cloak-profiles && /usr/bin/env python3 launch-profile-a.py
+
+  3. Save to Desktop as ``Cloak Profile A.app``.
+  4. Double-click the .app to launch this profile.
+
+The fixed PROFILE_SEED makes the fingerprint deterministic across runs — the
+same ``--fingerprint=<seed>`` value is rebuilt every launch — and the
+persistent profile dir keeps cookies, localStorage, and cache between sessions.
+"""
+
+from cloakbrowser import launch_persistent_context
+
+PROFILE_NAME = "profile-a"
+PROFILE_SEED = 12345  # stable across runs; change per profile for a distinct identity
+
+PROFILE_DIR = f"./cloak-{PROFILE_NAME}"
+
+print(f"Launching CloakBrowser profile '{PROFILE_NAME}' (seed={PROFILE_SEED})...", flush=True)
+ctx = launch_persistent_context(
+    PROFILE_DIR,
+    headless=False,
+    args=[f"--fingerprint={PROFILE_SEED}"],
+)
+page = ctx.pages[0] if ctx.pages else ctx.new_page()
+page.goto("https://example.com")
+
+# Keep the browser open until the user closes it.
+page.wait_for_event("close", timeout=0)
+ctx.close()


### PR DESCRIPTION
## Summary

Adds a runnable per-profile macOS launcher example so users can ship one `.app` shortcut per CloakBrowser profile (fixed fingerprint seed, persistent profile dir) without reading through #246 to reconstruct the pattern.

## Why this matters

In #246, @webparadoxer asked how to create native macOS desktop launchers per profile (e.g. `Cloak Profile A.app`, `Cloak Profile B.app`) that open the browser directly with a stable fingerprint, not the Manager web UI. The maintainer's reply walks through a complete `launch_persistent_context` + Automator pattern. Right now that pattern is only discoverable by finding and reading the issue thread.

This codifies the maintainer's reply as a small example file.

## Testing

- `python3 -m py_compile examples/macos_profile_launcher.py` passes.
- `grep "examples/macos_profile_launcher.py" README.md` returns 1 (link present, no broken markdown).
- Uses the same `launch_persistent_context` import path as `examples/persistent_context.py`, so future API renames pick it up consistently.
- `PROFILE_NAME` and `PROFILE_SEED` constants at the top of the file make per-profile copies a one-edit affair. The header comment block describes the two-step Automator wrap.
- No code under `cloakbrowser/` changes. No new dependencies.

Fixes #246
