### PR TITLE
refactor: export buildLaunchOptions and humanizeBrowser from JS package

### DIFF
--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -16,7 +16,7 @@
  */
 
 // Launch functions (Playwright API)
-export { launch, launchContext, launchPersistentContext } from "./playwright.js";
+export { launch, launchContext, launchPersistentContext, buildLaunchOptions, humanizeBrowser } from "./playwright.js";
 
 // Binary management
 export { ensureBinary, clearCache, binaryInfo, checkForUpdate } from "./download.js";

--- a/js/src/playwright.ts
+++ b/js/src/playwright.ts
@@ -45,6 +45,72 @@ function filterStealthCtxOptions(ctx?: BrowserContextOptions): Partial<BrowserCo
 }
 
 /**
+ * Build the LaunchOptions object that {@link launch} would forward to
+ * `chromium.launch()`. Use this when you want to drive your own
+ * `playwright-core` (or a modified Playwright build) and only need the
+ * cloakbrowser launch-arg pipeline — binary path, geoip resolution, proxy
+ * resolution, WebRTC arg resolution, and stealth arg merging.
+ *
+ * @example
+ * ```ts
+ * import { chromium } from 'playwright-core';
+ * import { buildLaunchOptions } from 'cloakbrowser';
+ *
+ * const opts = await buildLaunchOptions({ headless: false });
+ * const browser = await chromium.launch(opts);
+ * ```
+ */
+export async function buildLaunchOptions(
+  options: LaunchOptions = {}
+): Promise<Record<string, unknown>> {
+  const binaryPath = process.env.CLOAKBROWSER_BINARY_PATH || (await ensureBinary());
+  const { exitIp, ...resolved } = await maybeResolveGeoip(options);
+  const { proxyOption, proxyArgs } = resolveProxyConfig(options.proxy);
+  let resolvedArgs = await resolveWebrtcArgs(options);
+  if (exitIp && !(resolvedArgs ?? []).some(a => a.startsWith("--fingerprint-webrtc-ip"))) {
+    resolvedArgs = [...(resolvedArgs ?? []), `--fingerprint-webrtc-ip=${exitIp}`];
+  }
+  const args = buildArgs({ ...options, ...resolved, args: [...(resolvedArgs ?? []), ...proxyArgs] });
+
+  return {
+    executablePath: binaryPath,
+    headless: options.headless ?? true,
+    args,
+    ignoreDefaultArgs: IGNORE_DEFAULT_ARGS,
+    ...(proxyOption ? { proxy: proxyOption } : {}),
+    ...options.launchOptions,
+  };
+}
+
+/**
+ * Apply cloakbrowser's human-like behavioral patches to a Browser instance.
+ * No-op when `options.humanize` is falsy — safe to call unconditionally after
+ * launching the browser yourself.
+ *
+ * @example
+ * ```ts
+ * import { chromium } from 'playwright-core';
+ * import { buildLaunchOptions, humanizeBrowser } from 'cloakbrowser';
+ *
+ * const browser = await chromium.launch(await buildLaunchOptions(options));
+ * await humanizeBrowser(browser, options);
+ * ```
+ */
+export async function humanizeBrowser(
+  browser: Browser,
+  options: LaunchOptions = {}
+): Promise<void> {
+  if (!options.humanize) return;
+  const { patchBrowser } = await import('./human/index.js');
+  const { resolveConfig } = await import('./human/config.js');
+  const cfg = resolveConfig(
+    options.humanPreset ?? 'default',
+    options.humanConfig,
+  );
+  patchBrowser(browser, cfg);
+}
+
+/**
  * Launch stealth Chromium browser via Playwright.
  *
  * @example
@@ -59,36 +125,8 @@ function filterStealthCtxOptions(ctx?: BrowserContextOptions): Partial<BrowserCo
  */
 export async function launch(options: LaunchOptions = {}): Promise<Browser> {
   const { chromium } = await import("playwright-core");
-
-  const binaryPath = process.env.CLOAKBROWSER_BINARY_PATH || (await ensureBinary());
-  const { exitIp, ...resolved } = await maybeResolveGeoip(options);
-  const { proxyOption, proxyArgs } = resolveProxyConfig(options.proxy);
-  let resolvedArgs = await resolveWebrtcArgs(options);
-  if (exitIp && !(resolvedArgs ?? []).some(a => a.startsWith("--fingerprint-webrtc-ip"))) {
-    resolvedArgs = [...(resolvedArgs ?? []), `--fingerprint-webrtc-ip=${exitIp}`];
-  }
-  const args = buildArgs({ ...options, ...resolved, args: [...(resolvedArgs ?? []), ...proxyArgs] });
-
-  const browser = await chromium.launch({
-    executablePath: binaryPath,
-    headless: options.headless ?? true,
-    args,
-    ignoreDefaultArgs: IGNORE_DEFAULT_ARGS,
-    ...(proxyOption ? { proxy: proxyOption } : {}),
-    ...options.launchOptions,
-  });
-
-  // Human-like behavioral patching
-  if (options.humanize) {
-    const { patchBrowser } = await import('./human/index.js');
-    const { resolveConfig } = await import('./human/config.js');
-    const cfg = resolveConfig(
-      options.humanPreset ?? 'default',
-      options.humanConfig,
-    );
-    patchBrowser(browser, cfg);
-  }
-
+  const browser = await chromium.launch(await buildLaunchOptions(options));
+  await humanizeBrowser(browser, options);
   return browser;
 }
 

--- a/js/tests/build-launch-options.test.ts
+++ b/js/tests/build-launch-options.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+
+describe("buildLaunchOptions", () => {
+  const origEnv = process.env.CLOAKBROWSER_BINARY_PATH;
+
+  beforeEach(() => {
+    process.env.CLOAKBROWSER_BINARY_PATH = "/fake/chrome";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    if (origEnv) {
+      process.env.CLOAKBROWSER_BINARY_PATH = origEnv;
+    } else {
+      delete process.env.CLOAKBROWSER_BINARY_PATH;
+    }
+  });
+
+  it("returns executablePath, args, and ignoreDefaultArgs with no proxy key by default", async () => {
+    const { buildLaunchOptions } = await import("../src/playwright.js");
+    const opts = await buildLaunchOptions();
+
+    expect(opts.executablePath).toBe("/fake/chrome");
+    expect(Array.isArray(opts.args)).toBe(true);
+    expect((opts.args as string[]).length).toBeGreaterThan(0);
+    expect(opts.ignoreDefaultArgs).toBeDefined();
+    expect("proxy" in opts).toBe(false);
+  });
+
+  it("defaults headless to true and respects explicit false", async () => {
+    const { buildLaunchOptions } = await import("../src/playwright.js");
+
+    const defaultOpts = await buildLaunchOptions();
+    expect(defaultOpts.headless).toBe(true);
+
+    const headedOpts = await buildLaunchOptions({ headless: false });
+    expect(headedOpts.headless).toBe(false);
+  });
+
+  it("includes parsed proxy server/username/password for http://u:p@host:port", async () => {
+    const { buildLaunchOptions } = await import("../src/playwright.js");
+    const opts = await buildLaunchOptions({ proxy: "http://u:p@host:1080" });
+
+    expect(opts.proxy).toBeDefined();
+    const proxy = opts.proxy as { server: string; username?: string; password?: string };
+    expect(proxy.server).toBe("http://host:1080");
+    expect(proxy.username).toBe("u");
+    expect(proxy.password).toBe("p");
+  });
+
+  it("does not consume `humanize` — humanize is purely a humanizeBrowser concern", async () => {
+    const { buildLaunchOptions } = await import("../src/playwright.js");
+    // Fixed args + stealthArgs:false makes the resulting args list deterministic
+    // (default stealth args inject a random --fingerprint=<seed> per call).
+    const fixed: import("../src/types.js").LaunchOptions = {
+      stealthArgs: false,
+      args: ["--fingerprint=12345"],
+    };
+    const optsBase = await buildLaunchOptions(fixed);
+    const optsHumanized = await buildLaunchOptions({ ...fixed, humanize: true });
+
+    expect(optsHumanized.args).toEqual(optsBase.args);
+    expect("humanize" in optsHumanized).toBe(false);
+  });
+
+  it("forwards launchOptions overrides into the returned dict", async () => {
+    const { buildLaunchOptions } = await import("../src/playwright.js");
+    const opts = await buildLaunchOptions({
+      launchOptions: { downloadsPath: "/tmp/downloads", timeout: 5000 },
+    });
+
+    expect((opts as any).downloadsPath).toBe("/tmp/downloads");
+    expect((opts as any).timeout).toBe(5000);
+  });
+});
+
+describe("launch (regression — uses buildLaunchOptions)", () => {
+  let mockBrowser: any;
+  let mockChromium: any;
+  const origEnv = process.env.CLOAKBROWSER_BINARY_PATH;
+
+  beforeEach(() => {
+    process.env.CLOAKBROWSER_BINARY_PATH = "/fake/chrome";
+    mockBrowser = { close: vi.fn() };
+    mockChromium = { launch: vi.fn().mockResolvedValue(mockBrowser) };
+    vi.doMock("playwright-core", () => ({ chromium: mockChromium }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    if (origEnv) {
+      process.env.CLOAKBROWSER_BINARY_PATH = origEnv;
+    } else {
+      delete process.env.CLOAKBROWSER_BINARY_PATH;
+    }
+  });
+
+  it("forwards the buildLaunchOptions dict verbatim to chromium.launch", async () => {
+    const { launch, buildLaunchOptions } = await import("../src/playwright.js");
+    // Pin args + disable stealth defaults so the comparison is deterministic
+    // (default stealth args inject a random --fingerprint=<seed> per call).
+    const fixed = {
+      headless: false,
+      stealthArgs: false,
+      args: ["--fingerprint=12345"],
+    } as const;
+    const expected = await buildLaunchOptions(fixed);
+
+    await launch(fixed);
+
+    const call = mockChromium.launch.mock.calls[0][0];
+    expect(call.executablePath).toBe(expected.executablePath);
+    expect(call.headless).toBe(false);
+    expect(call.args).toEqual(expected.args);
+    expect(call.ignoreDefaultArgs).toEqual(expected.ignoreDefaultArgs);
+  });
+});
+
+describe("humanizeBrowser", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("is a no-op when humanize is false — does not import ./human/index.js", async () => {
+    const humanModuleSpy = vi.fn();
+    vi.doMock("../src/human/index.js", () => {
+      humanModuleSpy();
+      return { patchBrowser: vi.fn() };
+    });
+
+    const { humanizeBrowser } = await import("../src/playwright.js");
+    const fakeBrowser = {} as any;
+    await humanizeBrowser(fakeBrowser, { humanize: false });
+    await humanizeBrowser(fakeBrowser, {}); // humanize undefined
+
+    expect(humanModuleSpy).not.toHaveBeenCalled();
+  });
+
+  it("invokes patchBrowser when humanize is true", async () => {
+    const patchBrowser = vi.fn();
+    vi.doMock("../src/human/index.js", () => ({ patchBrowser }));
+
+    const { humanizeBrowser } = await import("../src/playwright.js");
+    const fakeBrowser = {} as any;
+    await humanizeBrowser(fakeBrowser, { humanize: true });
+
+    expect(patchBrowser).toHaveBeenCalledOnce();
+    expect(patchBrowser.mock.calls[0][0]).toBe(fakeBrowser);
+  });
+});


### PR DESCRIPTION
## Summary

Exposes `buildLaunchOptions` and `humanizeBrowser` as named exports from the JS `cloakbrowser` package so callers can compose the launch pipeline against a user-supplied Playwright variant. `launch()` keeps its existing behavior and now delegates to the two helpers.

## Why this matters

In #241 @regseb (author of Playwright-ghost) asked for lower-level builder helpers because today `launch()` always calls `await import("playwright-core")` internally, so integrating CloakBrowser with a modified Playwright build or another tool that also patches Playwright requires inline-copying the body of `launch()` per release. The proposal mirrors the Python equivalent ask in #153 and the API surface that Camoufox's apify port already provides.

The PR uses the exact API shape @regseb sketched in the issue: a `buildLaunchOptions(options)` builder that returns a `LaunchOptions` object you can pass to your own `chromium.launch()`, plus a separate `humanizeBrowser(browser, options)` step for the post-launch side effect.

## Changes

- `buildLaunchOptions(options)` returns the assembled `LaunchOptions` (`executablePath`, `headless`, `args`, `ignoreDefaultArgs`, optional `proxy` + `launchOptions` overrides). No proxy key is set when one is not provided.
- `humanizeBrowser(browser, options)` performs the existing `patchBrowser` side effect, and is a no-op when `options.humanize` is falsy (does not import `./human/index.js`).
- `launch()` is rewritten as `chromium.launch(await buildLaunchOptions(options))` followed by `await humanizeBrowser(browser, options)`, with both helpers re-exported from `js/src/index.ts`.

## Testing

- Added `js/tests/build-launch-options.test.ts` (8 unit tests, all passing). Uses `stealthArgs: false` and a fixed `--fingerprint=12345` so the args snapshot is deterministic.
- `npm run typecheck` clean.
- Full vitest suite (340 tests) passes; no regression in the existing `launch()` flow.

Closes #241
