### PR TITLE
feat(js): export composable context helpers

### DIFF
--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -16,7 +16,16 @@
  */
 
 // Launch functions (Playwright API)
-export { launch, launchContext, launchPersistentContext, buildLaunchOptions, humanizeBrowser } from "./playwright.js";
+export {
+  launch,
+  launchContext,
+  launchPersistentContext,
+  buildLaunchOptions,
+  humanizeBrowser,
+  buildContextOptions,
+  humanizeContext,
+  buildPersistentContextOptions,
+} from "./playwright.js";
 
 // Binary management
 export { ensureBinary, clearCache, binaryInfo, checkForUpdate } from "./download.js";

--- a/js/src/playwright.ts
+++ b/js/src/playwright.ts
@@ -91,6 +91,40 @@ export async function humanizeBrowser(
 }
 
 /**
+ * Build Playwright browser context options for CloakBrowser without creating a context.
+ */
+export function buildContextOptions(
+  options: LaunchContextOptions = {}
+): BrowserContextOptions {
+  return {
+    // contextOptions first — explicit wrapper fields below override it.
+    // filterStealthCtxOptions strips locale/timezoneId to prevent CDP detection.
+    ...filterStealthCtxOptions(options.contextOptions),
+    ...(options.userAgent ? { userAgent: options.userAgent } : {}),
+    viewport: options.viewport === undefined ? DEFAULT_VIEWPORT : options.viewport,
+    ...(options.colorScheme ? { colorScheme: options.colorScheme } : {}),
+  };
+}
+
+/**
+ * Apply CloakBrowser's human-like behavioral layer to an existing Playwright context.
+ */
+export async function humanizeContext(
+  context: BrowserContext,
+  options: LaunchContextOptions = {}
+): Promise<void> {
+  if (!options.humanize) return;
+
+  const { patchContext } = await import('./human/index.js');
+  const { resolveConfig } = await import('./human/config.js');
+  const cfg = resolveConfig(
+    options.humanPreset ?? 'default',
+    options.humanConfig,
+  );
+  patchContext(context, cfg);
+}
+
+/**
  * Launch stealth Chromium browser via Playwright.
  *
  * @example
@@ -144,14 +178,7 @@ export async function launchContext(
 
   let context: BrowserContext;
   try {
-    context = await browser.newContext({
-      // contextOptions first — explicit wrapper fields below override it.
-      // filterStealthCtxOptions strips locale/timezoneId to prevent CDP detection.
-      ...filterStealthCtxOptions(options.contextOptions),
-      ...(options.userAgent ? { userAgent: options.userAgent } : {}),
-      viewport: options.viewport === undefined ? DEFAULT_VIEWPORT : options.viewport,
-      ...(options.colorScheme ? { colorScheme: options.colorScheme } : {}),
-    });
+    context = await browser.newContext(buildContextOptions(options));
   } catch (err) {
     await browser.close();
     throw err;
@@ -164,16 +191,7 @@ export async function launchContext(
     await browser.close();
   };
 
-  // Human-like behavioral patching
-  if (options.humanize) {
-    const { patchContext } = await import('./human/index.js');
-    const { resolveConfig } = await import('./human/config.js');
-    const cfg = resolveConfig(
-      options.humanPreset ?? 'default',
-      options.humanConfig,
-    );
-    patchContext(context, cfg);
-  }
+  await humanizeContext(context, options);
 
   return context;
 }
@@ -199,12 +217,9 @@ export async function launchContext(
  * await context.close();
  * ```
  */
-export async function launchPersistentContext(
+export async function buildPersistentContextOptions(
   options: LaunchPersistentContextOptions
-): Promise<BrowserContext> {
-  options = resolveTimezone(options);
-  const { chromium } = await import("playwright-core");
-
+): Promise<PlaywrightLaunchOptions & BrowserContextOptions> {
   const binaryPath = process.env.CLOAKBROWSER_BINARY_PATH || (await ensureBinary());
   const { exitIp, ...resolved } = await maybeResolveGeoip(options);
   const { proxyOption, proxyArgs } = resolveProxyConfig(options.proxy);
@@ -214,9 +229,7 @@ export async function launchPersistentContext(
   }
   const args = buildArgs({ ...options, ...resolved, args: [...(resolvedArgs ?? []), ...proxyArgs] });
 
-  // locale and timezone are set via binary flags (--lang, --fingerprint-timezone)
-  // — NOT via Playwright context kwargs which use detectable CDP emulation.
-  const context = await chromium.launchPersistentContext(options.userDataDir, {
+  return {
     executablePath: binaryPath,
     headless: options.headless ?? true,
     args,
@@ -229,18 +242,21 @@ export async function launchPersistentContext(
     viewport: options.viewport === undefined ? DEFAULT_VIEWPORT : options.viewport,
     ...(options.colorScheme ? { colorScheme: options.colorScheme } : {}),
     ...options.launchOptions,
-  });
+  } as PlaywrightLaunchOptions & BrowserContextOptions;
+}
 
-  // Human-like behavioral patching
-  if (options.humanize) {
-    const { patchContext } = await import('./human/index.js');
-    const { resolveConfig } = await import('./human/config.js');
-    const cfg = resolveConfig(
-      options.humanPreset ?? 'default',
-      options.humanConfig,
-    );
-    patchContext(context, cfg);
-  }
+export async function launchPersistentContext(
+  options: LaunchPersistentContextOptions
+): Promise<BrowserContext> {
+  options = resolveTimezone(options);
+  const { chromium } = await import("playwright-core");
+
+  const context = await chromium.launchPersistentContext(
+    options.userDataDir,
+    await buildPersistentContextOptions(options),
+  );
+
+  await humanizeContext(context, options);
 
   return context;
 }

--- a/js/tests/launch.test.ts
+++ b/js/tests/launch.test.ts
@@ -39,11 +39,14 @@ describe("composable Playwright launch helpers", () => {
     }
   });
 
-  it("exports buildLaunchOptions and humanizeBrowser from the package entrypoint", async () => {
+  it("exports composable Playwright helpers from the package entrypoint", async () => {
     const entry = await import("../src/index.js");
 
     expect(entry.buildLaunchOptions).toBeTypeOf("function");
     expect(entry.humanizeBrowser).toBeTypeOf("function");
+    expect(entry.buildContextOptions).toBeTypeOf("function");
+    expect(entry.humanizeContext).toBeTypeOf("function");
+    expect(entry.buildPersistentContextOptions).toBeTypeOf("function");
   });
 
   it("buildLaunchOptions returns Playwright options without launching a browser", async () => {
@@ -68,6 +71,26 @@ describe("composable Playwright launch helpers", () => {
     expect(options.timeout).toBe(1234);
   });
 
+  it("buildContextOptions returns Playwright context options without creating a context", async () => {
+    const { buildContextOptions } = await import("../src/index.js");
+
+    const options = buildContextOptions({
+      userAgent: "Explicit/1.0",
+      viewport: { width: 1280, height: 720 },
+      colorScheme: "dark",
+      contextOptions: {
+        userAgent: "ShouldBeOverridden/9.9",
+        viewport: { width: 9999, height: 9999 },
+        permissions: ["geolocation"],
+      },
+    });
+
+    expect(options.userAgent).toBe("Explicit/1.0");
+    expect(options.viewport).toEqual({ width: 1280, height: 720 });
+    expect(options.colorScheme).toBe("dark");
+    expect(options.permissions).toEqual(["geolocation"]);
+  });
+
   it("humanizeBrowser patches an existing browser only when requested", async () => {
     const { humanizeBrowser } = await import("../src/index.js");
     const browser = {
@@ -82,6 +105,42 @@ describe("composable Playwright launch helpers", () => {
 
     await humanizeBrowser(browser as any, { humanize: true });
     expect(browser.newContext).not.toBe(originalNewContext);
+  });
+
+  it("humanizeContext is a no-op when humanize is undefined or false", async () => {
+    const { humanizeContext } = await import("../src/index.js");
+    const context = {
+      pages: vi.fn(() => []),
+      on: vi.fn(),
+      newPage: vi.fn(async () => ({})),
+    };
+    const originalNewPage = context.newPage;
+
+    await humanizeContext(context as any);
+    expect(context.newPage).toBe(originalNewPage);
+
+    await humanizeContext(context as any, { humanize: false });
+    expect(context.newPage).toBe(originalNewPage);
+  });
+
+  it("buildPersistentContextOptions returns launchPersistentContext options without launching", async () => {
+    const { buildPersistentContextOptions } = await import("../src/index.js");
+
+    const options = await buildPersistentContextOptions({
+      userDataDir: "/tmp/profile",
+      headless: false,
+      args: ["--custom-flag"],
+      timezone: "Asia/Tokyo",
+      launchOptions: { timeout: 1234 },
+    });
+
+    expect(options.executablePath).toBe("/fake/chrome");
+    expect(options.headless).toBe(false);
+    expect(options.args).toContain("--custom-flag");
+    expect(options.args).toContain("--fingerprint-timezone=Asia/Tokyo");
+    expect(options.ignoreDefaultArgs).toContain("--enable-automation");
+    expect(options.viewport).toEqual(DEFAULT_VIEWPORT);
+    expect(options.timeout).toBe(1234);
   });
 });
 


### PR DESCRIPTION
Mirrors the composable launch helpers from #244 for the context layer. Surface change:

- `buildContextOptions(options)` returns the `BrowserContextOptions` object that `launchContext()` previously assembled inline.
- `humanizeContext(context, options)` applies the human-like layer to an existing context (counterpart to `humanizeBrowser`).
- `buildPersistentContextOptions(options)` returns the merged options object passed to `chromium.launchPersistentContext()`.

`launchContext` and `launchPersistentContext` are refactored to use the new helpers. Observable behavior is unchanged.

Follow-up to @regseb's suggestion on #257. Three new tests in `js/tests/launch.test.ts` cover the new helpers; `npm run typecheck`, `npm run build`, and `npm test` (327 passing, 11 skipped) all clean locally.