### PR TITLE
docs: fix README wording in deployment parity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,7 +917,7 @@ CMD ["python", "/app/your_script.py"]
 docker build -t cloakbrowser .
 ```
 
-CloakBrowser works identically local, in Docker, and on VPS. No environment-specific config needed.
+CloakBrowser works identically locally, in Docker, and on VPS. No environment-specific config needed.
 
 **Note:** If you run CloakBrowser inside a web server with uvloop (e.g., `uvicorn[standard]`), use `--loop asyncio` to avoid subprocess pipe hangs.
 


### PR DESCRIPTION
## Summary
- change `local` to `locally` in another README sentence about deployment parity
- keep the meaning unchanged while making the wording more natural

## Testing
- not needed (documentation-only change)
