### PR TITLE
feat(cli): add agent-friendly CLI subcommands for automation workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changes are tagged: **[wrapper]** for Python/JS wrapper, **[binary]** for Chromi
 
 ## [Unreleased]
 
+- **[wrapper]** **New**: agent-friendly CLI subcommands — `doctor`, `profile list/path`, `screenshot`, `dump`, `eval`, `open` with `--json` output for automation workflows (#274, #275)
+
 ## [0.3.28] — 2026-05-11
 
 - **[wrapper]** **Security**: `cloakserve` — sanitize fingerprint seed to prevent path traversal, bind to `127.0.0.1` on bare metal, detect Podman containers (#217)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changes are tagged: **[wrapper]** for Python/JS wrapper, **[binary]** for Chromi
 
 ## [Unreleased]
 
+- **[wrapper]** **New**: agent-friendly CLI subcommands — `doctor`, `profile list/path`, `screenshot`, `dump`, `eval`, `open` with `--json` output for automation workflows (#274, #275)
+
 ## [0.3.30] — 2026-05-21
 
 - **[binary]** New build 146.0.7680.177.5 for Linux x64 + Windows x64 — 58 source-level fingerprint patches (up from 57)

--- a/cloakbrowser/__main__.py
+++ b/cloakbrowser/__main__.py
@@ -84,6 +84,21 @@ def main() -> None:
     sub.add_parser("update", help="Check for and download a newer binary")
     sub.add_parser("clear-cache", help="Remove all cached binaries")
 
+    # Agent-friendly subcommands
+    from .cli.doctor import add_subparser as _add_doctor
+    from .cli.profile import add_subparser as _add_profile
+    from .cli.screenshot import add_subparser as _add_screenshot
+    from .cli.dump import add_subparser as _add_dump
+    from .cli.eval import add_subparser as _add_eval
+    from .cli.open import add_subparser as _add_open
+
+    _add_doctor(sub)
+    _add_profile(sub)
+    _add_screenshot(sub)
+    _add_dump(sub)
+    _add_eval(sub)
+    _add_open(sub)
+
     args = parser.parse_args()
     if not args.command:
         parser.print_help()
@@ -99,7 +114,13 @@ def main() -> None:
     }
 
     try:
-        commands[args.command](args)
+        if args.command in commands:
+            commands[args.command](args)
+        elif hasattr(args, "func"):
+            args.func(args)
+        else:
+            print(f"Unknown command: {args.command}", file=sys.stderr)
+            sys.exit(2)
     except KeyboardInterrupt:
         sys.exit(130)
     except Exception as e:

--- a/cloakbrowser/cli/__init__.py
+++ b/cloakbrowser/cli/__init__.py
@@ -1,0 +1,31 @@
+"""Agent-friendly CLI utilities for cloakbrowser."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def output(data: Any, as_json: bool = False) -> None:
+    """Print data as JSON or human-readable text."""
+    if as_json:
+        json.dump(data, sys.stdout, indent=2, default=str)
+        sys.stdout.write("\n")
+    else:
+        if isinstance(data, str):
+            print(data)
+        elif isinstance(data, dict):
+            for k, v in data.items():
+                print(f"{k}: {v}")
+        elif isinstance(data, list):
+            for item in data:
+                print(item)
+        else:
+            print(data)
+
+
+def fail(msg: str, exit_code: int = 1) -> None:
+    """Print error to stderr and exit."""
+    print(f"Error: {msg}", file=sys.stderr)
+    sys.exit(exit_code)

--- a/cloakbrowser/cli/_launch.py
+++ b/cloakbrowser/cli/_launch.py
@@ -1,0 +1,32 @@
+"""Shared browser-launch helpers for the agent CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def launch_for_cli(
+    profile: str | None = None,
+    url: str | None = None,
+    headless: bool = True,
+    timeout: int = 30,
+    profiles_dir: Path | None = None,
+) -> tuple[Any, Any]:  # (context or browser, page)
+    """Launch cloakbrowser and navigate to URL. Returns (context_or_browser, page)."""
+    from ..browser import launch, launch_persistent_context
+
+    if profile:
+        d = (profiles_dir or Path.home() / ".cloakbrowser" / "profiles") / profile
+        d.mkdir(parents=True, exist_ok=True)
+        context = launch_persistent_context(str(d), headless=headless)
+        page = context.new_page() if context.pages else context.pages[0]
+    else:
+        browser = launch(headless=headless)
+        context = browser.new_context()
+        page = context.new_page()
+
+    if url:
+        page.goto(url, timeout=timeout * 1000)
+
+    return context, page

--- a/cloakbrowser/cli/doctor.py
+++ b/cloakbrowser/cli/doctor.py
@@ -1,0 +1,46 @@
+"""cloakbrowser doctor — check binary health, version, environment."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def add_subparser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("doctor", help="Check binary health and environment")
+    p.add_argument("--json", action="store_true", help="Machine-readable JSON output")
+    p.set_defaults(func=cmd_doctor)
+
+
+def cmd_doctor(args: argparse.Namespace) -> None:
+    from ..cli import output, fail
+    from ..config import get_cache_dir, get_local_binary_override
+    from ..download import binary_info, ensure_binary
+
+    info = binary_info()
+    override = get_local_binary_override()
+
+    # Try to ensure binary is installed
+    error_msg = ""
+    try:
+        path = ensure_binary()
+        ready = True
+    except Exception as e:
+        path = None
+        ready = False
+        error_msg = str(e)
+
+    result = {
+        "ready": ready,
+        "version": info["version"],
+        "platform": info["platform"],
+        "binary_path": str(path) if path else info["binary_path"],
+        "installed": info["installed"],
+        "cache_dir": str(info["cache_dir"]),
+        "override": override or None,
+    }
+    if not ready:
+        result["error"] = error_msg
+
+    output(result, as_json=args.json)
+    sys.exit(0 if ready else 1)

--- a/cloakbrowser/cli/dump.py
+++ b/cloakbrowser/cli/dump.py
@@ -1,0 +1,113 @@
+"""cloakbrowser dump — extract structured data from a page."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def add_subparser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("dump", help="Dump page elements as structured data")
+    p.add_argument("mode", choices=["inputs", "buttons", "text", "links", "all"], help="What to dump")
+    p.add_argument("--url", required=True, help="URL to analyze")
+    p.add_argument("--profile", default=None, help="Profile name for persistent context")
+    p.add_argument("--timeout", type=int, default=30, help="Page load timeout in seconds (default: 30)")
+    p.add_argument("--json", action="store_true", help="Output as JSON (default for agent use)")
+    p.add_argument("--selector", default=None, help="CSS selector to scope the dump")
+    p.set_defaults(func=cmd_dump)
+
+
+_DUMP_JS = """
+(mode, scope) => {
+    const results = [];
+    const root = scope ? document.querySelector(scope) : document;
+
+    const visible = (el) => {
+        if (!el) return false;
+        const style = window.getComputedStyle(el);
+        return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+    };
+
+    if (mode === 'inputs' || mode === 'all') {
+        const inputs = (root || document).querySelectorAll('input, textarea, select, [contenteditable="true"]');
+        for (const el of inputs) {
+            if (!visible(el)) continue;
+            results.push({
+                type: 'input',
+                tag: el.tagName.toLowerCase(),
+                name: el.name || el.id || el.getAttribute('aria-label') || '',
+                placeholder: el.placeholder || '',
+                value: el.value ? el.value.substring(0, 200) : '',
+                selector: el.id ? '#' + el.id : (el.name ? `[name="${el.name}"]` : ''),
+                visible: true
+            });
+        }
+    }
+    if (mode === 'buttons' || mode === 'all') {
+        const buttons = (root || document).querySelectorAll('button, a[href], [role="button"], input[type="submit"], input[type="button"]');
+        for (const el of buttons) {
+            if (!visible(el)) continue;
+            const text = (el.textContent || el.value || '').trim().substring(0, 100);
+            if (!text) continue;
+            results.push({
+                type: 'button',
+                tag: el.tagName.toLowerCase(),
+                text: text,
+                href: el.href || '',
+                selector: el.id ? '#' + el.id : '',
+                visible: true
+            });
+        }
+    }
+    if (mode === 'links' || mode === 'all') {
+        const links = (root || document).querySelectorAll('a[href]');
+        for (const el of links) {
+            if (!visible(el)) continue;
+            const text = (el.textContent || '').trim().substring(0, 150);
+            if (!text || el.href.startsWith('javascript:')) continue;
+            results.push({
+                type: 'link',
+                text: text,
+                href: el.href,
+                selector: el.id ? '#' + el.id : '',
+                visible: true
+            });
+        }
+    }
+    if (mode === 'text' || mode === 'all') {
+        const body = (root || document).body;
+        if (body) {
+            const text = body.innerText.trim().substring(0, 10000);
+            results.push({ type: 'text', content: text });
+        }
+    }
+    return results;
+}
+"""
+
+
+def cmd_dump(args: argparse.Namespace) -> None:
+    from ..cli import output, fail
+    from ._launch import launch_for_cli
+
+    try:
+        context, page = launch_for_cli(
+            profile=args.profile,
+            url=args.url,
+            timeout=args.timeout,
+        )
+        data = page.evaluate(_DUMP_JS, args.mode, args.selector)
+        context.close()
+
+        result: dict[str, Any] = {
+            "url": args.url,
+            "mode": args.mode,
+            "count": len(data) if isinstance(data, list) else 1,
+            "elements": data,
+        }
+        output(result, as_json=True if args.json else False)  # JSON default for agents
+    except Exception as e:
+        fail(str(e))

--- a/cloakbrowser/cli/eval.py
+++ b/cloakbrowser/cli/eval.py
@@ -1,0 +1,45 @@
+"""cloakbrowser eval — evaluate JavaScript against a page and return JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def add_subparser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("eval", help="Evaluate JavaScript on a page and return JSON")
+    p.add_argument("--url", required=True, help="URL to load before evaluating")
+    p.add_argument("--js-file", type=Path, default=None, help="JavaScript file to evaluate")
+    p.add_argument("--js", default=None, help="Inline JavaScript to evaluate")
+    p.add_argument("--profile", default=None, help="Profile name for persistent context")
+    p.add_argument("--timeout", type=int, default=30, help="Page load timeout in seconds (default: 30)")
+    p.add_argument("--json", action="store_true", help="Output as JSON")
+    p.set_defaults(func=cmd_eval)
+
+
+def cmd_eval(args: argparse.Namespace) -> None:
+    from ..cli import output, fail
+    from ._launch import launch_for_cli
+
+    if not args.js_file and not args.js:
+        fail("Either --js-file or --js is required")
+
+    try:
+        if args.js_file:
+            script = args.js_file.read_text()
+        else:
+            script = args.js
+
+        context, page = launch_for_cli(
+            profile=args.profile,
+            url=args.url,
+            timeout=args.timeout,
+        )
+        result = page.evaluate(script)
+        context.close()
+
+        output(result, as_json=args.json)
+    except Exception as e:
+        fail(str(e))

--- a/cloakbrowser/cli/open.py
+++ b/cloakbrowser/cli/open.py
@@ -1,0 +1,54 @@
+"""cloakbrowser open — launch a URL in the browser."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def add_subparser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("open", help="Open a URL in the stealth browser")
+    p.add_argument("--url", required=True, help="URL to open")
+    p.add_argument("--profile", default=None, help="Profile name for persistent context")
+    p.add_argument("--timeout", type=int, default=30, help="Page load timeout in seconds (default: 30)")
+    p.add_argument("--json", action="store_true", help="Output result as JSON")
+    p.set_defaults(func=cmd_open)
+
+
+def cmd_open(args: argparse.Namespace) -> None:
+    from ..cli import output, fail
+    from ._launch import launch_for_cli
+
+    context = None
+    try:
+        context, page = launch_for_cli(
+            profile=args.profile,
+            url=args.url,
+            headless=False,  # "open" implies visible browser
+            timeout=args.timeout,
+        )
+        title = page.title()
+
+        result = {
+            "url": args.url,
+            "title": title,
+            "profile": args.profile,
+        }
+        output(result, as_json=args.json)
+
+        print("\nBrowser is open. Press Ctrl+C to close.", file=sys.stderr)
+        try:
+            import signal
+            signal.pause()
+        except AttributeError:
+            input()
+    except KeyboardInterrupt:
+        pass
+    except Exception as e:
+        fail(str(e))
+    finally:
+        if context is not None:
+            try:
+                context.close()
+            except Exception:
+                pass

--- a/cloakbrowser/cli/profile.py
+++ b/cloakbrowser/cli/profile.py
@@ -1,0 +1,66 @@
+"""cloakbrowser profile — list and resolve persistent browser profiles."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+def add_subparser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("profile", help="Manage browser profiles")
+    sub = p.add_subparsers(dest="profile_command")
+
+    lst = sub.add_parser("list", help="List saved profiles")
+    lst.add_argument("--json", action="store_true")
+    lst.add_argument("--dir", type=Path, default=None, help="Profiles directory (default: ~/.cloakbrowser/profiles)")
+    lst.set_defaults(func=cmd_profile_list)
+
+    path = sub.add_parser("path", help="Resolve profile path")
+    path.add_argument("name", help="Profile name")
+    path.add_argument("--json", action="store_true")
+    path.add_argument("--dir", type=Path, default=None, help="Profiles directory (default: ~/.cloakbrowser/profiles)")
+    path.set_defaults(func=cmd_profile_path)
+
+
+def _profiles_dir(dir_override: Path | None = None) -> Path:
+    if dir_override:
+        return dir_override.expanduser().resolve()
+    return Path.home() / ".cloakbrowser" / "profiles"
+
+
+def cmd_profile_list(args: argparse.Namespace) -> None:
+    from ..cli import output
+
+    d = _profiles_dir(args.dir)
+    if not d.exists():
+        output([], as_json=args.json)
+        return
+
+    profiles = sorted(
+        [p.name for p in d.iterdir() if p.is_dir()],
+        key=str.lower,
+    )
+    output(profiles, as_json=args.json)
+
+
+def cmd_profile_path(args: argparse.Namespace) -> None:
+    from ..cli import output, fail
+
+    d = _profiles_dir(args.dir)
+    profile_path = d / args.name
+
+    result = {
+        "name": args.name,
+        "path": str(profile_path.resolve()),
+        "exists": profile_path.is_dir(),
+    }
+    if profile_path.is_dir():
+        entries = sorted(
+            [p.name for p in profile_path.iterdir()],
+            key=str.lower,
+        )
+        result["entries"] = entries[:20]  # don't dump thousands of files
+    output(result, as_json=args.json)
+    sys.exit(0 if result["exists"] else 1)

--- a/cloakbrowser/cli/screenshot.py
+++ b/cloakbrowser/cli/screenshot.py
@@ -1,0 +1,41 @@
+"""cloakbrowser screenshot — take a screenshot of a URL."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def add_subparser(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("screenshot", help="Take a screenshot of a URL")
+    p.add_argument("--url", required=True, help="URL to capture")
+    p.add_argument("--out", type=Path, required=True, help="Output file path (.png)")
+    p.add_argument("--profile", default=None, help="Profile name for persistent context")
+    p.add_argument("--timeout", type=int, default=30, help="Page load timeout in seconds (default: 30)")
+    p.add_argument("--full-page", action="store_true", help="Capture full scrollable page")
+    p.add_argument("--json", action="store_true", help="Output result as JSON")
+    p.set_defaults(func=cmd_screenshot)
+
+
+def cmd_screenshot(args: argparse.Namespace) -> None:
+    from ..cli import output, fail
+    from ._launch import launch_for_cli
+
+    try:
+        context, page = launch_for_cli(
+            profile=args.profile,
+            url=args.url,
+            timeout=args.timeout,
+        )
+        page.screenshot(path=str(args.out), full_page=args.full_page)
+        context.close()
+
+        result = {
+            "url": args.url,
+            "output": str(args.out.resolve()),
+            "size_bytes": args.out.stat().st_size if args.out.exists() else 0,
+        }
+        output(result, as_json=args.json)
+    except Exception as e:
+        fail(str(e))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,93 @@
+"""Tests for the agent-friendly CLI subcommands."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess:
+    """Run cloakbrowser CLI and return completed process."""
+    return subprocess.run(
+        [sys.executable, "-m", "cloakbrowser", *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+class TestDoctor:
+    def test_doctor_json(self):
+        result = run_cli("doctor", "--json")
+        data = json.loads(result.stdout)
+        assert isinstance(data, dict)
+        assert "ready" in data
+        assert "version" in data
+        assert "platform" in data
+        assert "binary_path" in data
+        assert "installed" in data
+        assert "cache_dir" in data
+
+    def test_doctor_text(self):
+        result = run_cli("doctor")
+        assert result.returncode == 0
+        assert "ready" in result.stdout.lower() or "true" in result.stdout.lower()
+
+
+class TestProfile:
+    def test_profile_list_json(self):
+        result = run_cli("profile", "list", "--json")
+        data = json.loads(result.stdout)
+        assert isinstance(data, list)
+
+    def test_profile_list_text(self):
+        result = run_cli("profile", "list")
+        assert result.returncode == 0
+
+    def test_profile_path_json(self, tmp_path):
+        profile_dir = tmp_path / "test-profile"
+        profile_dir.mkdir()
+        result = run_cli("profile", "path", "test-profile", "--json", "--dir", str(tmp_path))
+        data = json.loads(result.stdout)
+        assert data["name"] == "test-profile"
+        assert data["exists"] is True
+
+    def test_profile_path_nonexistent(self, tmp_path):
+        result = run_cli("profile", "path", "nonexistent", "--json", "--dir", str(tmp_path))
+        assert result.returncode == 1
+        data = json.loads(result.stdout)
+        assert data["exists"] is False
+
+
+class TestDumpJS:
+    """Test the dump JavaScript function independently (no browser needed)."""
+
+    def test_dump_js_imports(self):
+        """Verify the dump JS is valid and doesn't throw on load."""
+        from cloakbrowser.cli.dump import _DUMP_JS
+        assert "mode" in _DUMP_JS
+        assert "inputs" in _DUMP_JS
+        assert "buttons" in _DUMP_JS
+        assert "text" in _DUMP_JS
+        assert "links" in _DUMP_JS
+
+
+class TestHelp:
+    def test_help_shows_new_commands(self):
+        result = run_cli("--help")
+        assert "doctor" in result.stdout
+        assert "profile" in result.stdout
+        assert "screenshot" in result.stdout
+        assert "dump" in result.stdout
+        assert "eval" in result.stdout
+        assert "open" in result.stdout
+
+    def test_doctor_help(self):
+        result = run_cli("doctor", "--help")
+        assert "--json" in result.stdout
+
+    def test_dump_help(self):
+        result = run_cli("dump", "--help")
+        assert "inputs" in result.stdout
+        assert "buttons" in result.stdout
+        assert "text" in result.stdout


### PR DESCRIPTION
## What

Adds 6 new CLI subcommands designed for AI agents and automation pipelines, as requested in #274.

```
cloakbrowser doctor --json          # binary health, version, paths
cloakbrowser profile list            # enumerate saved profiles
cloakbrowser profile path <name>     # resolve profile path
cloakbrowser screenshot --url --out  # capture screenshot
cloakbrowser dump inputs|buttons|text|links --url --json  # extract structured page data
cloakbrowser eval --url --js-file    # evaluate JS and return result
cloakbrowser open --url --profile    # launch in visible browser
```

## Why

Agents and automation pipelines currently need custom Python glue for common browser tasks. A thin, stable CLI with `--json` output makes these primitives composable without writing scripts each time.

## Design

- Intentional minimal scope — no DSL, no workflow engine, no site-specific logic
- `--json` flag on all commands for machine-readable output
- `--timeout` for page load control
- `--profile` for persistent context reuse across sessions
- Reuses existing `launch()` / `launch_persistent_context()` internals — no new browser logic

## Files

- `cloakbrowser/cli/` — 7 new modules (init, _launch, doctor, profile, screenshot, dump, eval, open)
- `cloakbrowser/__main__.py` — wired new subcommands into argparse
- `tests/test_cli.py` — 10 tests for CLI, doctor, profile, dump JS, and help output

## Testing

```
10 passed in test_cli.py
171 passed in existing suite (1 pre-existing playwright import failure)
```

Closes #274