### PR TITLE
fix(docker): clean up stale Xvfb lock so container survives restarts

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# Clean up any stale Xvfb lock left behind by a previous container instance.
+# `/tmp` is not a tmpfs in this image, so on `docker restart` the previous
+# container's `/tmp/.X99-lock` survives, and Xvfb refuses to start with an
+# existing lock — leaving the container with no X server, every Chrome
+# launch dying with "Missing X server or $DISPLAY", and `cloakserve`
+# returning 502 forever. See CloakHQ/CloakBrowser#283.
+rm -f /tmp/.X99-lock /tmp/.X11-unix/X99
+
 # Start Xvfb for headed mode (Turnstile, CAPTCHAs), then run user command
 Xvfb :99 -screen 0 1920x1080x24 -nolisten tcp &
 sleep 1


### PR DESCRIPTION
Fixes #283.

## What this changes

One line in `bin/docker-entrypoint.sh`: remove any stale `/tmp/.X99-lock` (and `/tmp/.X11-unix/X99` socket file) before starting Xvfb.

## Why

`/tmp` is not a tmpfs in the official image, so on `docker restart` the previous container's `/tmp/.X99-lock` survives into the new container. The new Xvfb sees the existing lock, assumes another X server owns display `:99`, and refuses to start. The container then has no X server, every Chrome launch dies with `Missing X server or $DISPLAY`, and `cloakserve` returns 502 from `/json/version` forever.

Combined with the README-recommended `restart: always` + healthcheck pattern (or an autoheal sidecar), this turns into a permanent restart loop: every restart hits the same broken state.

See [#283](https://github.com/CloakHQ/CloakBrowser/issues/283) for full root cause analysis, repro steps, and in-container diagnostics.

## Validation

Verified end-to-end in our production setup:

1. Pre-fix: `docker compose restart cloakbrowser` → container "healthy" per HTTP but Chrome launches fail → autoheal restart loop within ~3 minutes.
2. Post-fix (with this patch applied via an `entrypoint:` override locally): triggered multiple healthcheck-driven restarts → each restart Xvfb starts cleanly → Chrome launches succeed → container stays healthy. No restart loops.

The fix is minimal and behaviorally equivalent to a fresh `docker run` on every restart.

## Alternatives considered

- **`tini` / `dumb-init` as PID 1** so Xvfb is properly reaped on container stop and the lock gets cleaned up by the kernel: cleaner long-term but a bigger change (new dependency, entrypoint restructure). Happy to follow up with that if maintainers prefer.
- **Mount `/tmp` as tmpfs in the README's compose example**: works but wastes RAM and isn't an upstream fix.

This PR takes the minimal-risk approach. Open to either alternative if you'd rather land that.
