### PR TITLE
[security] fix(download): contain archive extraction paths

### DIFF
--- a/cloakbrowser/download.py
+++ b/cloakbrowser/download.py
@@ -179,12 +179,16 @@ def _verify_download_checksum(file_path: Path, version: str | None = None) -> No
     tarball_name = get_archive_name()
 
     if checksums is None:
-        logger.warning("SHA256SUMS not available for this release — skipping checksum verification")
+        logger.warning(
+            "SHA256SUMS not available for this release — skipping checksum verification"
+        )
         return
 
     expected = checksums.get(tarball_name)
     if expected is None:
-        logger.warning("SHA256SUMS found but no entry for %s — skipping verification", tarball_name)
+        logger.warning(
+            "SHA256SUMS found but no entry for %s — skipping verification", tarball_name
+        )
         return
 
     _verify_checksum(file_path, expected)
@@ -247,7 +251,9 @@ def _download_file(url: str, dest: Path) -> None:
     """Download a file with progress logging."""
     logger.info("Downloading from %s", url)
 
-    with httpx.stream("GET", url, follow_redirects=True, timeout=DOWNLOAD_TIMEOUT) as response:
+    with httpx.stream(
+        "GET", url, follow_redirects=True, timeout=DOWNLOAD_TIMEOUT
+    ) as response:
         response.raise_for_status()
 
         total = int(response.headers.get("content-length", 0))
@@ -283,6 +289,7 @@ def _extract_archive(
     # Clean existing dir if partial download existed
     if dest_dir.exists():
         import shutil
+
         shutil.rmtree(dest_dir)
 
     dest_dir.mkdir(parents=True, exist_ok=True)
@@ -310,21 +317,38 @@ def _extract_archive(
         logger.info("Binary ready: %s", bp)
 
 
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    """Return whether path is contained by parent after resolution."""
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
 def _extract_tar(archive_path: Path, dest_dir: Path) -> None:
     """Extract tar.gz archive with path traversal protection."""
+    resolved_dest = dest_dir.resolve()
     with tarfile.open(archive_path, "r:gz") as tar:
         safe_members = []
         for member in tar.getmembers():
+            member_path = (dest_dir / member.name).resolve()
+            if not _is_relative_to(member_path, resolved_dest):
+                raise RuntimeError(f"Archive contains path traversal: {member.name}")
+
             # Allow symlinks — macOS .app bundles require them (Framework layout)
             if member.issym() or member.islnk():
                 link_target = member.linkname
-                if os.path.isabs(link_target) or ".." in link_target.split("/"):
-                    logger.warning("Skipping suspicious symlink: %s -> %s", member.name, link_target)
+                link_path = (member_path.parent / link_target).resolve()
+                if os.path.isabs(link_target) or not _is_relative_to(
+                    link_path, resolved_dest
+                ):
+                    logger.warning(
+                        "Skipping suspicious symlink: %s -> %s",
+                        member.name,
+                        link_target,
+                    )
                     continue
-            else:
-                member_path = (dest_dir / member.name).resolve()
-                if not str(member_path).startswith(str(dest_dir.resolve())):
-                    raise RuntimeError(f"Archive contains path traversal: {member.name}")
             safe_members.append(member)
 
         tar.extractall(dest_dir, members=safe_members)
@@ -334,10 +358,11 @@ def _extract_zip(archive_path: Path, dest_dir: Path) -> None:
     """Extract zip archive with path traversal protection."""
     import zipfile
 
+    resolved_dest = dest_dir.resolve()
     with zipfile.ZipFile(archive_path, "r") as zf:
         for info in zf.infolist():
             member_path = (dest_dir / info.filename).resolve()
-            if not str(member_path).startswith(str(dest_dir.resolve())):
+            if not _is_relative_to(member_path, resolved_dest):
                 raise RuntimeError(f"Archive contains path traversal: {info.filename}")
         zf.extractall(dest_dir)
 
@@ -419,6 +444,7 @@ def binary_info() -> dict:
 # Auto-update
 # ---------------------------------------------------------------------------
 
+
 def check_for_update() -> str | None:
     """Manually check for a newer Chromium version. Returns new version or None.
 
@@ -470,9 +496,7 @@ def _get_latest_chromium_version() -> str | None:
     so Linux-only releases won't be offered to macOS users.
     """
     try:
-        resp = httpx.get(
-            GITHUB_API_URL, params={"per_page": 10}, timeout=10.0
-        )
+        resp = httpx.get(GITHUB_API_URL, params={"per_page": 10}, timeout=10.0)
         resp.raise_for_status()
         platform_tarball = get_archive_name()
         for release in resp.json():

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,11 +1,10 @@
 """Unit tests for archive extraction — path traversal protection, flattening, permissions."""
 
 import io
-import os
 import platform
-import stat
 import tarfile
 import zipfile
+from pathlib import Path
 
 import pytest
 
@@ -23,7 +22,7 @@ from cloakbrowser.download import (
 # ---------------------------------------------------------------------------
 
 
-def _create_tar_gz(tmp_path, members: dict[str, bytes]) -> "Path":
+def _create_tar_gz(tmp_path, members: dict[str, bytes]) -> Path:
     """Create a tar.gz with given {name: content} members."""
     archive = tmp_path / "test.tar.gz"
     with tarfile.open(archive, "w:gz") as tar:
@@ -36,7 +35,9 @@ def _create_tar_gz(tmp_path, members: dict[str, bytes]) -> "Path":
 
 class TestExtractTar:
     def test_basic(self, tmp_path):
-        archive = _create_tar_gz(tmp_path, {"chrome": b"binary", "lib/libfoo.so": b"lib"})
+        archive = _create_tar_gz(
+            tmp_path, {"chrome": b"binary", "lib/libfoo.so": b"lib"}
+        )
         dest = tmp_path / "out"
         dest.mkdir()
         _extract_tar(archive, dest)
@@ -54,6 +55,35 @@ class TestExtractTar:
         dest.mkdir()
         with pytest.raises(RuntimeError, match="path traversal"):
             _extract_tar(archive, dest)
+
+    def test_sibling_prefix_traversal_blocked(self, tmp_path):
+        """Containment should use path ancestry, not string prefixes."""
+        archive = tmp_path / "evil.tar.gz"
+        with tarfile.open(archive, "w:gz") as tar:
+            info = tarfile.TarInfo(name="../out_evil/owned.txt")
+            content = b"evil"
+            info.size = len(content)
+            tar.addfile(info, io.BytesIO(content))
+
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with pytest.raises(RuntimeError, match="path traversal"):
+            _extract_tar(archive, dest)
+        assert not (tmp_path / "out_evil" / "owned.txt").exists()
+
+    def test_symlink_entry_path_traversal_blocked(self, tmp_path):
+        archive = tmp_path / "symlink-path.tar.gz"
+        with tarfile.open(archive, "w:gz") as tar:
+            sym = tarfile.TarInfo(name="../out_evil/link")
+            sym.type = tarfile.SYMTYPE
+            sym.linkname = "chrome"
+            tar.addfile(sym)
+
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with pytest.raises(RuntimeError, match="path traversal"):
+            _extract_tar(archive, dest)
+        assert not (tmp_path / "out_evil" / "link").exists()
 
     def test_suspicious_symlink_skipped(self, tmp_path):
         """Symlinks with absolute targets are skipped (logged as warning)."""
@@ -83,7 +113,7 @@ class TestExtractTar:
 # ---------------------------------------------------------------------------
 
 
-def _create_zip(tmp_path, members: dict[str, bytes]) -> "Path":
+def _create_zip(tmp_path, members: dict[str, bytes]) -> Path:
     """Create a zip with given {name: content} members."""
     archive = tmp_path / "test.zip"
     with zipfile.ZipFile(archive, "w") as zf:
@@ -94,7 +124,9 @@ def _create_zip(tmp_path, members: dict[str, bytes]) -> "Path":
 
 class TestExtractZip:
     def test_basic(self, tmp_path):
-        archive = _create_zip(tmp_path, {"chrome.exe": b"binary", "lib/foo.dll": b"lib"})
+        archive = _create_zip(
+            tmp_path, {"chrome.exe": b"binary", "lib/foo.dll": b"lib"}
+        )
         dest = tmp_path / "out"
         dest.mkdir()
         _extract_zip(archive, dest)
@@ -110,6 +142,17 @@ class TestExtractZip:
         dest.mkdir()
         with pytest.raises(RuntimeError, match="path traversal"):
             _extract_zip(archive, dest)
+
+    def test_sibling_prefix_traversal_blocked(self, tmp_path):
+        archive = tmp_path / "evil.zip"
+        with zipfile.ZipFile(archive, "w") as zf:
+            zf.writestr("../out_evil/owned.txt", "evil")
+
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with pytest.raises(RuntimeError, match="path traversal"):
+            _extract_zip(archive, dest)
+        assert not (tmp_path / "out_evil" / "owned.txt").exists()
 
 
 # ---------------------------------------------------------------------------
@@ -169,7 +212,9 @@ class TestFlatten:
 
 
 class TestPermissions:
-    @pytest.mark.skipif(platform.system() == "Windows", reason="chmod not applicable on Windows")
+    @pytest.mark.skipif(
+        platform.system() == "Windows", reason="chmod not applicable on Windows"
+    )
     def test_make_executable(self, tmp_path):
         binary = tmp_path / "chrome"
         binary.write_bytes(b"binary")


### PR DESCRIPTION
## Summary
This PR hardens CloakBrowser's downloaded archive extraction boundary so archive member paths must resolve inside the intended binary cache directory before extraction.

- Replaces string-prefix containment checks with resolved path ancestry checks.
- Applies the same ancestry check to tar member paths, tar link targets, and zip member paths.
- Adds regression tests for sibling-prefix traversal names such as `../out_evil/owned.txt`.
- Keeps the patch focused on archive extraction safety without changing the browser launch API.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Archive member path containment used string-prefix checks | A malicious or compromised downloaded archive could place tar members outside the intended extraction directory when the escaped path shares the destination prefix | High |

## Before this PR
- `_extract_tar()` and `_extract_zip()` compared paths with `str(member_path).startswith(str(dest_dir.resolve()))`.
- That check rejects obvious traversal such as `../../../etc/passwd`, but it does not prove filesystem ancestry.
- A sibling path such as `../out_evil/owned.txt` can resolve to a path whose string still starts with the destination path prefix when the destination is named `out`.
- Tar extraction could then write that member outside the intended cache directory.

## After this PR
- Archive members are accepted only when the resolved destination path is a real descendant of the resolved extraction directory.
- Tar symlink and hardlink targets are checked against the same resolved directory boundary before being included in extraction.
- Regression tests cover direct tar traversal, tar symlink-entry traversal, and zip traversal variants.

## Why this matters
CloakBrowser downloads and extracts Chromium archives into a local cache. That cache boundary should remain intact even if an archive is malformed, malicious, or unexpectedly served from a compromised/misconfigured distribution path.

A string prefix is not a filesystem containment check. Enforcing real path ancestry prevents archive entries from escaping into adjacent paths under the same parent directory.

## How this differs from related issue/PR
This overlaps the archive-hardening portion of #227, but keeps the contribution intentionally narrower:

- #227 bundles archive extraction hardening with Windows test adjustments and a new `cloakbrowser doctor` CLI.
- This PR is a minimal security-only patch for archive path containment in `cloakbrowser/download.py` plus focused regression tests.
- The fix is reviewable independently if maintainers prefer to land the archive containment boundary without the unrelated diagnostics changes.

## Attack flow
```text
attacker influences a downloaded Chromium archive
    -> archive contains a member such as ../out_evil/owned.txt
        -> string-prefix check treats /tmp/.../out_evil as inside /tmp/.../out
            -> tar.extractall writes outside the intended cache directory
                -> local file write outside the extraction root
```

## Affected code

| Issue | Files |
|-------|-------|
| Archive extraction path containment | `cloakbrowser/download.py`, `tests/test_extract.py` |

## Root cause
Issue: archive member path containment used string-prefix comparison.

- `Path.resolve()` was called, but the containment decision was made with string `startswith()`.
- A path can share a textual prefix with the extraction directory without being a child of that directory.
- Symlink and hardlink entries also need their entry path checked before extraction, not only their link target text.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Archive extraction path traversal | 7.5 High | `CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H` |

Rationale:
- The attacker must influence the archive that CloakBrowser downloads or is configured to consume, so attack complexity is high and user interaction is required through install/update/use of the downloader path.
- If reached, the primitive is a local file write outside the intended extraction root, so confidentiality, integrity, and availability impact can be high depending on the escaped path and local permissions.

## Safe reproduction steps
1. Create a temporary extraction destination named `out`.
2. Create a tar archive containing a member named `../out_evil/owned.txt`.
3. Run `_extract_tar(archive, dest)` on the vulnerable code.
4. Observe that extraction returns normally and writes `out_evil/owned.txt` next to the intended destination.

## Expected vulnerable behavior
- The vulnerable code accepts the sibling-prefix path because the resolved escaped path text starts with the extraction directory text.
- The tar member is written outside the extraction root.
- The new regression test asserts that this is rejected and that the outside marker file is not created.

## Changes in this PR
- Adds `_is_relative_to()` to perform resolved path ancestry checks with `Path.relative_to()`.
- Uses the helper for tar member path containment before adding members to `safe_members`.
- Validates tar symlink/hardlink targets against the resolved extraction root before extraction.
- Uses the same ancestry helper for zip member checks.
- Adds regression tests for sibling-prefix traversal and symlink-entry traversal.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Extraction hardening | `cloakbrowser/download.py` | Replaced string-prefix checks with resolved ancestry checks for tar and zip extraction |
| Regression tests | `tests/test_extract.py` | Added traversal tests for sibling-prefix member names and symlink entry paths |

## Maintainer impact
- No browser launch API changes.
- No download URL, checksum, cache naming, or platform selection changes.
- Existing safe archive layouts continue to extract normally.
- Suspicious link targets continue to be skipped, but the path boundary is now based on filesystem ancestry instead of string prefixes.

## Fix rationale
`Path.relative_to()` after resolution expresses the intended boundary directly: the archive member's resolved destination must be inside the resolved extraction directory. This avoids sibling-prefix false positives while keeping the existing extraction flow and macOS bundle symlink support intact.

## Type of change
- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan
- [x] `python -m pytest tests/test_extract.py -q` — 14 passed
- [x] `python -m pytest tests/test_update.py tests/test_proxy.py tests/test_build_args.py tests/test_geoip.py tests/test_config.py -q` — 186 passed
- [x] `python -m ruff check cloakbrowser/download.py tests/test_extract.py`
- [x] `python -m ruff format --check cloakbrowser/download.py tests/test_extract.py`
- [x] `python -m compileall -q cloakbrowser/download.py tests/test_extract.py`
- [x] `git diff --check`
- [ ] `python -m pytest -q` — attempted locally, but this environment does not have `playwright` installed; the run stopped with `ModuleNotFoundError: No module named 'playwright'` in browser/stealth tests after the extraction-focused tests had passed.

## Disclosure notes
- This PR is bounded to local archive extraction path containment in the Python downloader.
- No production services were tested.
- No real secrets, credentials, or production endpoints are included in the reproduction.
- This is intentionally a narrow security-only variant of the archive-hardening work also present in #227.
