### PR TITLE
docs(skills): add CloakBrowser agent skill references

### DIFF
--- a/skills/cloakbrowser/SKILL.md
+++ b/skills/cloakbrowser/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: cloakbrowser
+description: Use this skill for browser automation on websites protected by anti-bot, anti-scraping, or fingerprinting systems. Trigger this skill when the user needs to scrape protected websites, bypass Cloudflare Turnstile, reCAPTCHA, DataDome, Kasada, or Akamai, perform stealth browsing, manage multiple browser identities, solve captchas, spoof browser fingerprints, or automate interactions on sites that block standard playwright or puppeteer automation. Supports Playwright-compatible browser automation in both Python and Node.js (TypeScript/JavaScript).
+allowed-tools: Bash(python:*) Bash(python3:*) Bash(py:*) Bash(npm:*) Bash(npx:*)
+---
+
+# Stealth Browser Automation with CloakBrowser
+
+CloakBrowser is a stealth Chromium browser containing 58 C++ patches that modify fingerprints at the source level, making automated sessions indistinguishable from real human Chrome usage. It is fully API-compatible with Playwright and Puppeteer.
+
+## First Step: Ask the User
+
+Before writing any automation scripts, ask the user whether they want **headed** or **headless** mode:
+- **Headless** (`headless=True`, default): Runs in the background (no visible window). Faster, lower memory usage. Best for headless servers and background tasks.
+- **Headed** (`headless=False`): Opens a real visible browser window. Required for Chrome extensions, debugging, and often recommended to pass the absolute strictest anti-bot systems (e.g. Kasada, DataDome).
+
+Present this as a clear choice, then proceed based on their answer.
+
+## Quick Starts
+
+### Python Quick Start
+
+All Python scripts should be executed with `python` or `python3`.
+
+```python
+from cloakbrowser import launch
+
+# Sync mode
+browser = launch(headless=True)  # or headless=False
+page = browser.new_page()
+page.goto("https://example.com")
+print(page.title())
+page.screenshot(path="screenshot.png")
+browser.close()
+```
+
+### TypeScript / JavaScript Quick Start
+
+Node.js scripts work natively with standard Playwright runner or ts-node.
+
+```typescript
+import { launch } from 'cloakbrowser';
+
+async function main() {
+  const browser = await launch({ headless: true });
+  const page = await browser.newPage();
+  await page.goto('https://example.com');
+  console.log(await page.title());
+  await page.screenshot({ path: 'screenshot.png' });
+  await browser.close();
+}
+main();
+```
+
+## Core Patterns
+
+### Page Interactions (Playwright-compatible API)
+
+Use standard Playwright methods. Ensure you use selector-based page methods for automated humanization:
+
+```python
+page.goto("https://example.com")
+page.click("#submit-button")
+page.fill("#email", "user@example.com")
+page.type("#search", "query")            # types character-by-character
+page.select_option("#dropdown", "value")
+page.hover("#menu-item")
+page.press("Enter")
+
+# Locator API (Recommended)
+page.locator("#my-element").click()
+page.get_by_role("button", name="Submit").click()
+```
+
+### Async Operations (Python)
+
+Use async when concurrency (multiple pages, parallel scraping) is needed:
+
+```python
+import asyncio
+from cloakbrowser import launch_async
+
+async def main():
+    browser = await launch_async(headless=True)
+    page = await browser.new_page()
+    await page.goto("https://example.com")
+    print(await page.title())
+    await browser.close()
+
+asyncio.run(main())
+```
+
+### Wait Strategies
+
+Exposing hard timing signatures can trigger bot detection. Always use native sleep instead of page timeouts:
+
+```python
+import time
+# GOOD: Python time.sleep does not expose automation characteristics to browser scripts
+time.sleep(3) 
+
+# AVOID: page.wait_for_timeout(3000) - can be intercepted by advanced anti-bots
+```
+
+## Core Launch Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `headless` | `bool` | `True` | Run in headless mode. |
+| `backend` | `'playwright' \| 'patchright'` | `'playwright'` | **Critical**: Use `'patchright'` to completely suppress CDP signals (vital for reCAPTCHA v3 Enterprise). Note: Breaks proxy auth and `add_init_script`. |
+| `proxy` | `str \| dict` | `None` | Proxy URL string or dict. Supports native inline credentials for HTTP & SOCKS5, bypassing CDP proxies. |
+| `geoip` | `bool` | `False` | Auto-detect timezone/locale and spoof WebRTC ICE exit IP based on proxy location. |
+| `timezone` | `str` | `None` | Override IANA timezone (e.g. `'America/New_York'`) via binary process flags. |
+| `locale` | `str` | `None` | Override locale (e.g. `'en-US'`) via `--lang` and binary flags. |
+| `humanize` | `bool` | `False` | Enable human-like mouse paths, keyboard typing timing, and scroll patterns. |
+| `human_preset` | `'default' \| 'careful'` | `'default'` | Speed preset for human movements. `'careful'` is slower, with idle pauses. |
+| `extension_paths` | `list[str]` | `None` | List of paths to unpacked Chrome extensions to load (requires `headless=False`). |
+| `viewport` | `dict \| None` | `{"width": 1280, "height": 720}` | Set viewport size. Set to `None` to disable emulation and use native OS window size. |
+| `color_scheme` | `'light' \| 'dark'` | `None` | Force preferred color scheme on the browser context. |
+
+## References & Specialized Guides
+
+* **Anti-Detection Hardening & Patchright** — [references/anti-detection.md](references/anti-detection.md)
+* **Fingerprint Determinism & Seeds** — [references/fingerprint-config.md](references/fingerprint-config.md)
+* **Human Behavior Simulation Tuning** — [references/humanize.md](references/humanize.md)
+* **Persistent Context, Viewports & Extensions** — [references/persistent-context.md](references/persistent-context.md)
+* **SOCKS5, HTTP Preemptive Proxies & WebRTC** — [references/proxy-network.md](references/proxy-network.md)
+* **Migrating seamlessly from stock Playwright** — [references/playwright-migration.md](references/playwright-migration.md)

--- a/skills/cloakbrowser/references/anti-detection.md
+++ b/skills/cloakbrowser/references/anti-detection.md
@@ -1,0 +1,144 @@
+# Anti-Detection Hardening & Patchright Backend
+
+CloakBrowser passes most bot detection systems out of the box. For the toughest targets (DataDome, Kasada, Akamai, reCAPTCHA v3 Enterprise), additional hardening and backend selection are required.
+
+## Backend Selection: Playwright vs. Patchright
+
+CloakBrowser supports a custom `backend` argument that dictates how automation interactions are handled:
+
+| Backend | Suppresses CDP Signals | Handles Proxy Auth | Supports `add_init_script` | Primary Use Case |
+|---|---|---|---|---|
+| `'playwright'` (default) | No | Yes | Yes | Standard sites, basic anti-bots, normal scraping. |
+| `'patchright'` | **Yes** (fully stealth) | No | No | Strictly protected sites, **reCAPTCHA v3 Enterprise**. |
+
+### Why backend="patchright" is critical for reCAPTCHA v3 Enterprise:
+reCAPTCHA v3 Enterprise monitors the Chrome DevTools Protocol (CDP) connection. Stock Playwright communicates over CDP, leaking the `isAutomatedWithCDP` flag. 
+Setting `backend="patchright"` launches a customized Playwright build that actively hides and intercepts CDP traffic, yielding a **0.9 (human)** score on enterprise fingerprinters.
+
+```python
+from cloakbrowser import launch
+
+# Maximum stealth for reCAPTCHA Enterprise
+browser = launch(
+    backend="patchright",
+    humanize=True,
+    human_preset="careful",
+)
+```
+*Note*: When using `'patchright'`, you cannot use standard HTTP proxy authentication popups or Playwright's `page.add_init_script()`.
+
+---
+
+## Recommended Configuration by Difficulty
+
+### Level 1: Basic Web Scraping (no aggressive anti-bots)
+```python
+browser = launch(headless=True)
+```
+
+### Level 2: reCAPTCHA v3 (Target Score: 0.9)
+```python
+browser = launch(
+    backend="patchright",  # Highly recommended for Enterprise
+    humanize=True,
+    human_preset="careful",
+)
+```
+*Follow the behavioral best practices in [humanize.md](humanize.md): use typing delay, sleep, and avoid massive amounts of evaluate calls.*
+
+### Level 3: Cloudflare Turnstile (Headed Mode + Residential IP)
+```python
+browser = launch(
+    headless=False,  # Headed mode recommended to bypass managed Turnstile challenges
+    proxy="socks5://user:pass@residential-proxy:1080",
+    geoip=True,      # Match timezone and locale to proxy IP location
+    humanize=True,
+)
+```
+
+### Level 4: DataDome / Kasada / Akamai (Absolute Maximum Hardening)
+```python
+browser = launch(
+    headless=False,
+    proxy="socks5://user:pass@residential-proxy:1080",
+    geoip=True,
+    humanize=True,
+    human_preset="careful",
+    args=[
+        "--fingerprint-storage-quota=5000",  # Bypasses incognito/private quota detection
+    ]
+)
+```
+*Ensure Windows/macOS fonts are installed if running on headless Linux servers.*
+
+---
+
+## Linux Font Configuration
+
+Kasada and Akamai render hidden canvases to hash emoji and font outputs. Headless Linux servers (e.g. Docker, VPS) have minimal fonts, producing unique hashes that flag the browser as a bot.
+
+1. **Install common font packages**:
+```bash
+sudo apt update
+sudo apt install -y fonts-noto-color-emoji fonts-freefont-ttf fonts-unifont \
+    fonts-ipafont-gothic fonts-wqy-zenhei fonts-tlwg-loma-otf
+```
+
+2. **For CreepJS-level stealth (inject real Windows fonts)**:
+Copy TTF fonts from a Windows machine (`C:\Windows\Fonts`) into your Linux server, then point CloakBrowser to them:
+```bash
+mkdir -p ~/.local/share/fonts/windows
+cp /path/to/windows/fonts/*.ttf ~/.local/share/fonts/windows/
+fc-cache -f  # Mandatory to rebuild font cache
+```
+```python
+browser = launch(
+    args=["--fingerprint-fonts-dir=/home/user/.local/share/fonts/windows"]
+)
+```
+
+---
+
+## Testing Your Hardening Configuration
+
+Use these boilerplate scripts to check your detection status:
+
+### 1. Test Automation Flags (bot.sannysoft.com)
+```python
+from cloakbrowser import launch
+import time
+
+browser = launch(headless=False)
+page = browser.new_page()
+page.goto("https://bot.sannysoft.com")
+time.sleep(5)
+page.screenshot(path="sannysoft-test.png")
+browser.close()
+# Look for solid green "Pass" across all variables.
+```
+
+### 2. Test Incognito Status & Canvas (FingerprintJS)
+```python
+from cloakbrowser import launch
+import time
+
+# Low storage quota will flag as "incognito"
+browser = launch(
+    headless=False,
+    args=["--fingerprint-storage-quota=5000"]
+)
+page = browser.new_page()
+page.goto("https://fingerprintjs.github.io/fingerprintjs/")
+time.sleep(6)
+page.screenshot(path="fingerprintjs-test.png")
+browser.close()
+```
+
+---
+
+## Common Mistakes to Avoid
+
+1. **Calling `page.wait_for_timeout()`**: This is highly detectable because it uses automated timers. Use standard Python `time.sleep()` instead.
+2. **Datacenter Proxies against Akamai/DataDome**: Datacenter IP ranges are blacklisted. High-difficulty targets require premium residential proxies.
+3. **Bypassing Font Setup on Headless Servers**: Bot fingerprinters instantly detect Linux-specific font shortages.
+4. **Too Many `page.evaluate()` Calls**: Frequently invoking JS execution from Playwright generates timing patterns that anti-bots track. Batch your evaluated scripts into single calls.

--- a/skills/cloakbrowser/references/fingerprint-config.md
+++ b/skills/cloakbrowser/references/fingerprint-config.md
@@ -1,0 +1,103 @@
+# Fingerprint & Identity Configuration
+
+CloakBrowser generates a random fingerprint seed on each launch, compiling a fully consistent browser identity from a single integer. All hardware parameters (GPU, screen, CPU, memory, fonts, canvas/WebGL noise) are derived from this seed, making them look coherent and natural without manual tuning.
+
+## How Seeds Work
+
+```
+seed=12345 → GPU=Intel UHD 630,  screen=1920x1080,  CPU=8 cores,  RAM=8GB, WebGL Noise=A
+seed=67890 → GPU=RTX 3070,       screen=2560x1440,  CPU=16 cores, RAM=16GB, WebGL Noise=B
+```
+
+Using the same seed yields the exact same identity across launches. This is invaluable for **multi-account or session persistence** scenarios, as return visits will look like they are coming from the exact same device.
+
+### Usage:
+```python
+from cloakbrowser import launch
+
+# 1. Random seed (Default): Produces a fresh identity every launch.
+browser = launch()
+
+# 2. Fixed seed: Produces the exact same identity every time.
+browser = launch(args=["--fingerprint=42069"])
+```
+
+---
+
+## Platform-Aware Fingerprinting
+
+The wrapper automatically applies platform-aware defaults. If running on Linux, it overrides the OS string to windows for a much more common desktop fingerprint, while macOS naturally runs as native macOS.
+
+To force a specific platform, use the `--fingerprint-platform` flag:
+
+| Flag Value | Reported Platform | GPU Renderer Pool |
+|---|---|---|
+| `--fingerprint-platform=windows` | `Win32` | Windows Intel/NVIDIA/AMD GPUs |
+| `--fingerprint-platform=macos` | `MacIntel` / Apple | macOS Apple Silicon / Intel GPUs |
+| `--fingerprint-platform=linux` | `Linux x86_64` | Linux Mesa/NVIDIA GPUs |
+
+```python
+# Force a Linux script to report as a macOS machine:
+browser = launch(args=["--fingerprint-platform=macos"])
+```
+
+---
+
+## Overriding Individual Fingerprint Attributes
+
+You can pin a seed for general consistency, and override individual hardware metrics manually using process flags:
+
+```python
+browser = launch(
+    args=[
+        "--fingerprint=12345",
+        "--fingerprint-gpu-vendor=NVIDIA Corporation",
+        "--fingerprint-gpu-renderer=NVIDIA GeForce RTX 4070/PCIe/SSE2",
+        "--fingerprint-hardware-concurrency=12",  # Reported CPU cores
+        "--fingerprint-device-memory=16",          # Reported RAM in GB
+        "--fingerprint-screen-width=2560",         # Screen resolution
+        "--fingerprint-screen-height=1440",
+    ]
+)
+```
+
+### Full Fingerprint Flag Reference
+
+| Flag | Controls | Typical Values |
+|---|---|---|
+| `--fingerprint=seed` | Master fingerprint seed | `10000` to `99999` |
+| `--fingerprint-platform` | OS system platform | `windows`, `macos`, `linux` |
+| `--fingerprint-gpu-vendor` | WebGL `UNMASKED_VENDOR_WEBGL` | e.g. `Google Inc. (NVIDIA)` |
+| `--fingerprint-gpu-renderer` | WebGL `UNMASKED_RENDERER_WEBGL` | e.g. `ANGLE (NVIDIA, ...)` |
+| `--fingerprint-hardware-concurrency` | `navigator.hardwareConcurrency` | `4`, `8`, `12`, `16` |
+| `--fingerprint-device-memory` | `navigator.deviceMemory` | `4`, `8` (standard Chromium limits) |
+| `--fingerprint-screen-width` | Resolution width | `1920`, `1440`, `2560` |
+| `--fingerprint-screen-height` | Resolution height | `1080`, `900`, `1440` |
+| `--fingerprint-storage-quota` | Hard storage limit (MB) | `5000` (avoids incognito flags) |
+| `--fingerprint-fonts-dir` | Target directory for fonts | Absolute path to folder |
+| `--fingerprint-noise=false` | Disable canvas/WebGL noise injection | `false` (Not recommended) |
+
+---
+
+## Multi-Account Fingerprint & Profile Pairing
+
+To run multi-account scraping flows, always pair a unique deterministic seed with a unique persistent profile directory. This guarantees that each account is associated with a distinct, stable machine identity that never changes, while keeping account cookies separated:
+
+```python
+accounts = [
+    {"username": "alice", "profile": "./profiles/alice", "seed": "90001"},
+    {"username": "bob",   "profile": "./profiles/bob",   "seed": "90002"},
+]
+
+for acct in accounts:
+    # Launches browser with Alice's specific profile and consistent fingerprint
+    ctx = launch_persistent_context(
+        acct["profile"],
+        headless=True,
+        args=[f"--fingerprint={acct['seed']}"],
+    )
+    page = ctx.new_page()
+    page.goto("https://example.com/dashboard")
+    # ... perform account actions ...
+    ctx.close()
+```

--- a/skills/cloakbrowser/references/humanize.md
+++ b/skills/cloakbrowser/references/humanize.md
@@ -1,0 +1,101 @@
+# Human Behavior Simulation
+
+By passing `humanize=True` to the launcher, CloakBrowser intercepts and replaces standard automation commands (`page.click()`, `page.fill()`, `page.type()`, `page.hover()`, `page.mouse.*`, `page.keyboard.*`) with human-mimicking movements. 
+
+This behavioral masking prevents advanced server-side scorekeepers (like reCAPTCHA v3, Turnstile, and DataDome) from flagging your automation sequence as bot traffic.
+
+## Quick Start
+
+```python
+from cloakbrowser import launch
+
+browser = launch(
+    humanize=True,
+    human_preset="default",  # "default" or "careful"
+)
+page = browser.new_page()
+page.goto("https://protected-site.com")
+
+# The locator API automatically applies Bézier curve aiming and typo simulation!
+page.locator("#username").fill("user@example.com")
+page.locator("button[type=submit]").click()
+```
+
+---
+
+## Humanization Evasion Details
+
+| Action | Standard Playwright | With `humanize=True` |
+|---|---|---|
+| **Mouse Movements** | Instant teleportation (0ms) to target coordinates. | Custom Bézier curve movements with natural easing and overshoot. |
+| **Clicks** | Clicks exact center of element instantly. | Realistic aim point (offset from exact center) + natural press-and-hold duration (50-150ms). |
+| **Keyboard Inputs** | Instantly dumps the entire text string. | Clear field, character-by-character typing with natural delays, thinking pauses, and random typos with self-correction. |
+| **Scrolling** | Jumps instantly to coordinates. | Smooth scroll curve (Accelerate → Cruise → Decelerate) in micro-steps. |
+| **Thinking Pauses** | Actions occur back-to-back at lightspeed. | Injects micro-movements and idle pauses between distinct actions to emulate human reading. |
+
+---
+
+## Configuration Presets & Custom Fine-Tuning
+
+### Presets
+- `"default"`: Fast but highly natural. Good for general anti-bot challenges and normal scrapers.
+- `"careful"`: Slower, adds more deliberate movements, idle micro-movements between operations. Essential for Akamai and Kasada.
+
+### Custom Tuning via `human_config`
+You can fine-tune human behaviors down to individual parameters:
+
+```python
+browser = launch(
+    humanize=True,
+    human_config={
+        "mistype_chance": 0.05,              # 5% chance of making a typo per character
+        "typing_delay": 120,                 # Base delay between keystrokes (ms)
+        "idle_between_actions": True,        # Perform idle mouse drifts between actions
+        "idle_between_duration": [0.4, 0.9], # Duration bounds for idle drifts (seconds)
+    }
+)
+```
+
+---
+
+## Evasion Strategies for reCAPTCHA v3 & Enterprise
+
+reCAPTCHA v3 calculates scores between `0.1` (bot) and `0.9` (human) based on historical page interaction. To guarantee a `0.9` score, enforce the following guidelines in your scripts:
+
+### 1. Let the Page Breathe
+Do not immediately navigate, type, and submit. Real humans take time to read.
+```python
+import time
+
+page.goto("https://recaptcha-demo.com")
+time.sleep(3)  # Emulate user reading above the fold
+```
+
+### 2. Mimic Content Reading (Scroll First)
+Before filling forms, scroll down and back up:
+```python
+# Scroll down slightly to make reading behavior look genuine
+page.evaluate("window.scrollTo(0, document.body.scrollHeight / 3)")
+time.sleep(2)
+page.evaluate("window.scrollTo(0, 0)")
+time.sleep(1)
+```
+
+### 3. Use Locator API over ElementHandles
+Avoid using `page.query_selector()` (ElementHandles) to click elements, as they bypass the humanize wrappers. **Always use Locator API** or selector-based methods:
+```python
+# GOOD (Humanized)
+page.locator("#submit").click()
+page.click("#submit")
+
+# AVOID (CDP direct bypass - teleports mouse)
+el = page.query_selector("#submit")
+el.click()
+```
+
+### 4. Direct Bypass for Speed
+If you need high-speed execution for safe sites or during testing, you can bypass the humanizer for a specific page call by accessing the original page object:
+```python
+# Bypasses humanizer curves, teleports instantly
+page._original.click("#safe-element")
+```

--- a/skills/cloakbrowser/references/persistent-context.md
+++ b/skills/cloakbrowser/references/persistent-context.md
@@ -1,0 +1,104 @@
+# Persistent Context, Extensions & Viewports
+
+CloakBrowser supports persistent contexts (for reusing cookies, localStorage, IndexedDB, and extensions across runs) as well as light-weight ephemeral contexts.
+
+---
+
+## 1. Persistent Context (`launch_persistent_context`)
+
+Persistent profiles save all browser data directly to a local directory on disk. This is highly useful for **staying logged in**, accumulating service worker caches, and **bypassing incognito detection** (which reduces BrowserScan trust scores by 10%).
+
+```python
+from cloakbrowser import launch_persistent_context
+
+# Browser session details will be saved inside the "./my-profile" folder
+ctx = launch_persistent_context(
+    "./my-profile",
+    headless=True,
+    proxy="http://user:pass@proxy:8080"
+)
+
+page = ctx.new_page()
+page.goto("https://example.com/login")
+# ... perform login ...
+ctx.close()  # Cookies, cache, and session variables are saved.
+
+# Next run: Reuses session data seamlessly (no login required)
+ctx = launch_persistent_context("./my-profile", headless=True)
+page = ctx.new_page()
+page.goto("https://example.com/dashboard")  # Already authenticated!
+ctx.close()
+```
+
+---
+
+## 2. Ephemeral Context & Storage State
+
+For lightweight scraping tasks where a full profile directory is not needed, you can use `launch_context()` to spin up an in-memory browser and manually save/restore state files:
+
+```python
+from cloakbrowser import launch_context
+
+# Save cookies + localStorage to JSON
+context = launch_context()
+page = context.new_page()
+page.goto("https://example.com/login")
+# ... log in ...
+context.storage_state(path="session_state.json")
+context.close()
+
+# Restore session in a new instance
+context2 = launch_context(storage_state="session_state.json")
+page2 = context2.new_page()
+page2.goto("https://example.com/dashboard")  # Already logged in
+context2.close()
+```
+
+---
+
+## 3. Chrome Extensions
+
+Loading Chrome extensions requires **headed mode** (`headless=False`) due to a native Chromium design limitation:
+
+```python
+from cloakbrowser import launch_persistent_context
+
+ctx = launch_persistent_context(
+    "./profile-with-extensions",
+    headless=False,  # Extensions must run in headed mode!
+    extension_paths=[
+        "./extensions/my-unpacked-adblocker",  # Path to folder containing manifest.json
+        "./extensions/another-plugin",
+    ]
+)
+page = ctx.new_page()
+page.goto("https://example.com")
+```
+
+---
+
+## 4. Viewport & Color Scheme Stealth
+
+Standard Playwright uses CDP commands to emulate viewport resolutions and color schemes. These emulation commands generate detectable JavaScript quirks that anti-bots track.
+
+CloakBrowser solves this by configuring viewport and color scheme parameters at the native launch level, ensuring zero leaks.
+
+### Bypassing Emulation (Use Native Resolution)
+Real desktop users rarely run emulated viewports. For maximum stealth (especially against Akamai and DataDome), disable viewport emulation. This causes the browser window to match the exact OS size:
+
+```python
+from cloakbrowser import launch_context
+
+context = launch_context(
+    viewport=None,  # Disables emulation entirely, window inherits native OS size
+)
+```
+
+### Color Scheme Control
+Force light or dark color schemes to match your system preferences:
+
+```python
+context = launch_context(
+    color_scheme="dark",  # Forces light/dark modes natively
+)
+```

--- a/skills/cloakbrowser/references/playwright-migration.md
+++ b/skills/cloakbrowser/references/playwright-migration.md
@@ -1,0 +1,98 @@
+# Migrating from Stock Playwright & Puppeteer
+
+CloakBrowser is fully API-compatible with Playwright (Python and JS/TS) and Puppeteer (JS/TS). Migration is a drop-in replacement — you only swap the launch import, leaving all selector-based navigation and page interaction code untouched.
+
+---
+
+## 1. Python Migration
+
+### Synchronous Mode
+
+```python
+# ===== BEFORE: Stock Playwright =====
+from playwright.sync_api import sync_playwright
+pw = sync_playwright().start()
+browser = pw.chromium.launch()
+page = browser.new_page()
+
+# ===== AFTER: CloakBrowser =====
+from cloakbrowser import launch
+browser = launch()  # Done! All stealth and patches active
+page = browser.new_page()
+```
+
+### Asynchronous Mode
+
+```python
+# ===== BEFORE: Stock Playwright Async =====
+from playwright.async_api import async_playwright
+pw = await async_playwright().start()
+browser = await pw.chromium.launch()
+page = await browser.new_page()
+
+# ===== AFTER: CloakBrowser Async =====
+from cloakbrowser import launch_async
+browser = await launch_async()  # Done!
+page = await browser.new_page()
+```
+
+---
+
+## 2. Node.js (JavaScript / TypeScript) Migration
+
+### Playwright Wrapper
+
+```typescript
+// ===== BEFORE: Stock Playwright JS =====
+import { chromium } from 'playwright';
+const browser = await chromium.launch();
+const page = await browser.newPage();
+
+// ===== AFTER: CloakBrowser JS =====
+import { launch } from 'cloakbrowser';
+const browser = await launch();  // Done! Uses the stealth binary
+const page = await browser.newPage();
+```
+
+### Puppeteer Wrapper
+
+```typescript
+// ===== BEFORE: Stock Puppeteer JS =====
+import puppeteer from 'puppeteer';
+const browser = await puppeteer.launch();
+const page = await browser.newPage();
+
+// ===== AFTER: CloakBrowser Puppeteer =====
+import { launch } from 'cloakbrowser/puppeteer';
+const browser = await launch();  // Done!
+const page = await browser.newPage();
+```
+
+---
+
+## 3. What You Gain: Under-the-Hood Stealth Comparison
+
+| Fingerprint Metric | Stock Playwright | CloakBrowser | Evasion Method |
+|---|---|---|---|
+| `navigator.webdriver` | `true` | `false` | C++ binary source patch |
+| `navigator.plugins` | Empty list (`0`) | 5 default plugins | C++ binary source patch |
+| `window.chrome` | `undefined` | Present (standard object) | C++ binary source patch |
+| **User-Agent String** | Leaks `"HeadlessChrome"` | Normal `"Chrome/146..."` | C++ binary source patch |
+| **Canvas & WebGL** | Identical signature (bot flag) | Normal, unique noise | C++ binary source patch |
+| **TLS Signature** | standard Node/python signature | Matches real Chrome (JA3/JA4) | C++ binary source patch |
+| **Mouse / Keyboard** | Teleports instantly (0ms) | Bézier aiming, typo corrections | `humanize=True` wrapper |
+| **Proxy Authentication** | Trigger 407 (CDP Interceptor) | Preemptive inline auth | Custom launcher proxy flags |
+
+---
+
+## 4. API Compatibility Verification
+
+All standard browser context and page interaction hooks operate exactly as expected:
+- `page.goto()`, `page.click()`, `page.fill()`, `page.type()`
+- `page.locator()`, `page.get_by_role()`, `page.get_by_text()`
+- `page.screenshot()`, `page.pdf()`, `page.content()`
+- `page.wait_for_selector()`, `page.wait_for_load_state()`
+- `page.keyboard`, `page.mouse`
+- `BrowserContext`, `context.storage_state()`, `context.cookies()`
+- `page.on("dialog", ...)`, `page.on("download", ...)`
+- `page.expect_download()`, `page.expect_popup()`, `page.expect_navigation()`

--- a/skills/cloakbrowser/references/proxy-network.md
+++ b/skills/cloakbrowser/references/proxy-network.md
@@ -1,0 +1,90 @@
+# Proxy & Network Stealth
+
+CloakBrowser provides robust proxy and network-layer masking: full traffic routing, WebRTC exit IP spoofing, GeoIP location matching, and automated proxy timing/cache header stripping.
+
+---
+
+## 1. Preemptive Proxy Authentication (The Stealth Advantage)
+
+Standard Playwright routes proxies using CDP authentication interceptors. When a page requests a resource, Playwright intercepts it and responds with credentials. Advanced bot-detection systems flag this CDP intercept pattern instantly, and it frequently fails on Google authentication portals.
+
+CloakBrowser bypasses this entirely:
+- **SOCKS5 Proxies**: Routed natively inside Chrome's network engine, with inline credentials.
+- **HTTP/HTTPS Proxies**: Re-routes inline credentials directly into the binary's `--proxy-server` command-line flag on compatible platforms. Chrome sends the `Proxy-Authorization` header preemptively, avoiding the detectable 407 challenge-response loop.
+
+### Supported Formats:
+```python
+from cloakbrowser import launch
+
+# HTTP Proxy with credentials
+browser = launch(proxy="http://user:pass@proxy.example.com:8080")
+
+# SOCKS5 Proxy with credentials (UDP Associate tunnels through native Chrome)
+browser = launch(proxy="socks5://user:pass@socks-proxy.example.com:1080")
+
+# Dict compatibility (Auto-converted internally into stealth inline format)
+browser = launch(proxy={
+    "server": "http://proxy.example.com:8080",
+    "username": "user",
+    "password": "pass",
+})
+```
+
+---
+
+## 2. WebRTC IP Spoofing
+
+WebRTC (Web Real-Time Communication) can leak your real, underlying local or ISP IP address even when all standard traffic is routed through a proxy.
+
+CloakBrowser implements binary WebRTC ICE candidate interceptors. You can configure WebRTC IP spoofing manually or let it resolve automatically:
+
+```python
+# 1. Automatic Resolution: Fetches your proxy exit IP and feeds it to WebRTC.
+# (Performs a single, proxied HTTP check to AWS checkip or ipify)
+browser = launch(
+    proxy="http://user:pass@proxy:8080",
+    args=["--fingerprint-webrtc-ip=auto"]
+)
+
+# 2. Manual Configuration: Explicitly specify the IP to return.
+# (Zero network overhead)
+browser = launch(
+    proxy="http://user:pass@proxy:8080",
+    args=["--fingerprint-webrtc-ip=203.0.113.19"]
+)
+```
+
+---
+
+## 3. GeoIP Auto-Matching (Timezone & Locale)
+
+Residential and rotating proxies constantly change locations. If your proxy IP is in London, but your browser's language is set to `zh-CN` and the timezone is `Asia/Shanghai`, bot fingerprinters (like FingerprintJS and DataDome) will flag the location mismatch.
+
+CloakBrowser solves this with the `geoip` argument:
+
+```python
+# Requires: pip install cloakbrowser[geoip]
+browser = launch(
+    proxy="http://user:pass@my-rotating-proxy:8080",
+    geoip=True,  # Auto-adjusts timezone + locale to match proxy exit IP
+)
+```
+*How it works*: On startup, the launcher contacts the proxy, retrieves the geolocation of the exit IP, maps it to IANA database timezone/locale structures, and configures the Chromium binary's internal clock and localization variables. It also automatically sets the `--fingerprint-webrtc-ip` candidate to the proxy IP at zero extra network cost.
+
+If you don't want the GeoIP network lookup overhead, configure timezone and locale manually:
+```python
+browser = launch(
+    proxy="http://user:pass@proxy:8080",
+    timezone="Europe/London",
+    locale="en-GB",
+)
+```
+
+---
+
+## 4. Proxy Signal Stripping
+
+In addition to routing and IP spoofing, CloakBrowser's custom Chromium binary strips specific network signatures that flag proxy environments:
+- **DNS Lookup Timing**: Standard proxied requests show inconsistent DNS response timing signatures. CloakBrowser normalizes and zeroes out internal DNS resolution latency metrics.
+- **TCP & SSL Handshake Timings**: Timing values are normalized to match standard native Windows/macOS Chrome profiles.
+- **Header Leaks**: Strips `Proxy-Connection` headers and proxy-specific caching protocols.


### PR DESCRIPTION
docs(skills): add CloakBrowser AI agent skill references

Adds a new `skills/cloakbrowser/` directory with structured guidance
for AI-assisted browser automation workflows.

The skill docs focus on CloakBrowser-specific runtime behavior that is
easy for generic Playwright tooling/codegen to misuse or omit, especially
around stealth configuration, fingerprint persistence, humanization, and
proxy handling.

Added:
- `skills/cloakbrowser/SKILL.md`
  - Main entrypoint consumed by coding agents
  - Python + Node.js quickstart snippets
  - Common parameter references + usage conventions

- `skills/cloakbrowser/references/anti-detection.md`
  - Detection surfaces + backend selection notes
  - Documents why `backend="patchright"` should be preferred over
    vanilla `"playwright"` for stealth sessions

- `skills/cloakbrowser/references/fingerprint-config.md`
  - Fingerprint seed behavior
  - Platform / resolution overrides
  - Deterministic profile configuration

- `skills/cloakbrowser/references/humanize.md`
  - Humanization presets
  - Cursor movement + typing delay guidance
  - Notes on avoiding overly deterministic interaction patterns

- `skills/cloakbrowser/references/persistent-context.md`
  - Persistent profile handling
  - Extension loading
  - Viewport emulation behavior

- `skills/cloakbrowser/references/proxy-network.md`
  - SOCKS5 / HTTP proxy configuration
  - Inline credential usage
  - WebRTC exit-IP handling

- `skills/cloakbrowser/references/playwright-migration.md`
  - Migration notes for existing Playwright-based codebases
  - Drop-in compatibility caveats

Rationale:
- Centralizes best practices that were previously scattered across
  examples/issues/docs
- Reduces inconsistent agent-generated automation code
- Keeps topic-specific references isolated to avoid loading unnecessary
  context into coding agents

Verification:
- Verified directory structure + markdown rendering
- Synced documented parameters against current `browser.py`
- Confirmed all internal links + relative reference paths resolve