### PR TITLE
fix: auto-add --disable-extensions-except for --load-extension in args

### DIFF
--- a/cloakbrowser/browser.py
+++ b/cloakbrowser/browser.py
@@ -1022,8 +1022,17 @@ def build_args(
     if extension_paths:
         abs_paths = [os.path.abspath(p) for p in extension_paths]
         ext_val = ",".join(abs_paths)
-    
+
         seen["--load-extension"] = f"--load-extension={ext_val}"
+        seen["--disable-extensions-except"] = (
+            f"--disable-extensions-except={ext_val}"
+        )
+    elif "--load-extension" in seen and "--disable-extensions-except" not in seen:
+        # Auto-add companion flag when --load-extension was provided via
+        # extra_args but the companion --disable-extensions-except was not.
+        # Without this, Playwright's default --disable-extensions blocks all
+        # extensions. See CloakHQ/CloakBrowser-Manager#30 and #37.
+        ext_val = seen["--load-extension"].split("=", 1)[1]
         seen["--disable-extensions-except"] = (
             f"--disable-extensions-except={ext_val}"
         )

--- a/js/src/args.ts
+++ b/js/src/args.ts
@@ -65,6 +65,13 @@ export function buildArgs(options: LaunchOptions): string[] {
       "--disable-extensions-except",
       `--disable-extensions-except=${joined}`
     );
+  } else if (seen.has("--load-extension") && !seen.has("--disable-extensions-except")) {
+    // Auto-add companion flag when --load-extension was provided via
+    // args but the companion --disable-extensions-except was not.
+    // Without this, Playwright's default --disable-extensions blocks all
+    // extensions. See CloakHQ/CloakBrowser-Manager#30 and #37.
+    const extVal = seen.get("--load-extension")!.split("=").slice(1).join("=");
+    seen.set("--disable-extensions-except", `--disable-extensions-except=${extVal}`);
   }
   return [...seen.values()];
 }

--- a/js/tests/extension-loading.test.ts
+++ b/js/tests/extension-loading.test.ts
@@ -15,3 +15,46 @@ test("extension paths inject chrome flags", () => {
     `--disable-extensions-except=${abs}`
   );
 });
+
+test("--load-extension in args auto-adds companion flag", () => {
+  const args = _buildArgsForTest({
+    args: ["--load-extension=/path/to/ext"],
+  });
+
+  expect(args).toContain("--load-extension=/path/to/ext");
+  expect(args).toContain("--disable-extensions-except=/path/to/ext");
+});
+
+test("--load-extension with comma-separated paths auto-adds companion", () => {
+  const args = _buildArgsForTest({
+    args: ["--load-extension=/path/a,/path/b"],
+  });
+
+  expect(args).toContain("--load-extension=/path/a,/path/b");
+  expect(args).toContain("--disable-extensions-except=/path/a,/path/b");
+});
+
+test("no duplicate companion when both flags already present", () => {
+  const args = _buildArgsForTest({
+    args: [
+      "--load-extension=/path/to/ext",
+      "--disable-extensions-except=/path/to/ext",
+    ],
+  });
+
+  const extFlags = args.filter((a) =>
+    a.startsWith("--disable-extensions-except=")
+  );
+  expect(extFlags).toHaveLength(1);
+  expect(extFlags[0]).toBe("--disable-extensions-except=/path/to/ext");
+});
+
+test("no companion flag without --load-extension", () => {
+  const args = _buildArgsForTest({
+    args: ["--disable-gpu"],
+  });
+
+  expect(
+    args.some((a) => a.startsWith("--disable-extensions-except"))
+  ).toBe(false);
+});

--- a/tests/test_build_args.py
+++ b/tests/test_build_args.py
@@ -199,3 +199,57 @@ def test_resolve_webrtc_args_no_flag():
 
     result = _resolve_webrtc_args(["--no-sandbox"], "http://proxy:8080")
     assert result == ["--no-sandbox"]
+
+
+# --- Auto companion flag for --load-extension via extra_args ---
+
+
+def test_load_extension_auto_adds_companion():
+    """--load-extension in extra_args should auto-add --disable-extensions-except."""
+    args = build_args(
+        stealth_args=True,
+        extra_args=["--load-extension=/path/to/ext"],
+    )
+    assert "--load-extension=/path/to/ext" in args
+    assert "--disable-extensions-except=/path/to/ext" in args
+
+
+def test_load_extension_multi_path_auto_adds_companion():
+    """Comma-separated paths in --load-extension should be mirrored exactly."""
+    args = build_args(
+        stealth_args=True,
+        extra_args=["--load-extension=/path/a,/path/b"],
+    )
+    assert "--load-extension=/path/a,/path/b" in args
+    assert "--disable-extensions-except=/path/a,/path/b" in args
+
+
+def test_load_extension_no_duplicate_companion():
+    """If both flags are already in extra_args, no duplicate is added."""
+    args = build_args(
+        stealth_args=True,
+        extra_args=[
+            "--load-extension=/path/to/ext",
+            "--disable-extensions-except=/path/to/ext",
+        ],
+    )
+    ext_flags = [a for a in args if a.startswith("--disable-extensions-except=")]
+    assert len(ext_flags) == 1
+    assert ext_flags[0] == "--disable-extensions-except=/path/to/ext"
+
+
+def test_no_companion_without_load_extension():
+    """No --disable-extensions-except when --load-extension is absent."""
+    args = build_args(stealth_args=True, extra_args=["--disable-gpu"])
+    assert not any(a.startswith("--disable-extensions-except") for a in args)
+
+
+def test_extension_paths_still_works():
+    """extension_paths parameter should still inject both flags as before."""
+    args = build_args(
+        stealth_args=True,
+        extra_args=None,
+        extension_paths=["/path/to/ext"],
+    )
+    assert "--load-extension=/path/to/ext" in args
+    assert "--disable-extensions-except=/path/to/ext" in args


### PR DESCRIPTION
## Problem

When Chrome extensions are loaded via `--load-extension` in `args`/`extra_args` (e.g., through CloakBrowser-Managers `launch_args`), extensions fail to load because Playwrights default `--disable-extensions` flag blocks all extensions.

The `extension_paths` parameter (added in #210) already handles this correctly by injecting both `--load-extension` and `--disable-extensions-except`. However, when `--load-extension` is passed via `args` directly (as CloakBrowser-Manager does), the companion `--disable-extensions-except` flag is **not** automatically injected, leaving extensions broken.

This affects all CloakBrowser-Manager users who try to load extensions via `launch_args`. Related issues:
- CloakHQ/CloakBrowser-Manager#30
- CloakHQ/CloakBrowser-Manager#37

## Fix

In `build_args()`, after processing `extension_paths`, check if `--load-extension` exists in the `seen` dict (from `extra_args`) but `--disable-extensions-except` does not. If so, automatically inject the companion flag with the same paths.

This makes extension loading work seamlessly via either:
1. `extension_paths=["/path/to/ext"]` — existing, unchanged behavior
2. `args=["--load-extension=/path/to/ext"]` — now auto-fixed

**Files changed:**
- `cloakbrowser/browser.py` — Python `build_args()` — auto-inject companion flag
- `js/src/args.ts` — JS `buildArgs()` — same logic
- `tests/test_build_args.py` — 5 new Python tests
- `js/tests/extension-loading.test.ts` — 4 new JS tests

## Testing

All 43 Python tests pass, all 5 JS tests pass:

```
tests/test_build_args.py::test_load_extension_auto_adds_companion PASSED
tests/test_build_args.py::test_load_extension_multi_path_auto_adds_companion PASSED
tests/test_build_args.py::test_load_extension_no_duplicate_companion PASSED
tests/test_build_args.py::test_no_companion_without_load_extension PASSED
tests/test_build_args.py::test_extension_paths_still_works PASSED

js/tests/extension-loading.test.ts (5 tests) PASSED
```

## Backward Compatibility

- Existing `extension_paths` parameter behavior is unchanged (the `elif` only fires when `extension_paths` is falsy)
- If users already manually include `--disable-extensions-except` in their args, no duplication occurs (checked via `seen` dict)
- No API changes, no new parameters