### PR TITLE
fix: humanize=True resolves iframe locators in the owning frame (#428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes are tagged: **[wrapper]** for Python/JS wrapper, **[binary]** for Chromi
 ## [Unreleased]
 
 - **[wrapper]** Fix JS CLI silently exiting with no output when run via `npx`/`node_modules/.bin` (#427). The entry-point guard compared `import.meta.url` to an unresolved `process.argv[1]`; symlinked bin installs (npm/pnpm/npx) never matched, so no subcommand ran. Now realpath-resolves the invoked path before comparing.
+- **[wrapper]** Fix `humanize=True` breaking interactions with elements **inside iframes** (#428). `frame.locator("#btn").click()` / `fill()` / `hover()` / etc. (and the frame-level `frame.click(...)` equivalents) now resolve the selector in the owning sub-frame's own document instead of misrouting to the top page, which previously raised `ElementNotAttachedError`. Humanized mouse motion is preserved inside iframes. Python only (the JS and .NET wrappers were already frame-correct).
 
 ## [0.4.9] — 2026-07-09
 

--- a/cloakbrowser/human/__init__.py
+++ b/cloakbrowser/human/__init__.py
@@ -380,6 +380,30 @@ def _patch_locator_class_sync():
     def _get_cfg(self):
         return getattr(self.page, '_human_cfg', None)
 
+    def _route_target(self):
+        """Resolution target for a humanized locator action (#428).
+
+        Main-frame locators return the Page (unchanged behavior). A locator that
+        belongs to a *sub-frame* returns that frame's humanized wrapper so the
+        selector resolves in the frame's own document. Returns ``None`` when the
+        owning sub-frame is known but not yet humanized, so the caller falls back
+        to the native Playwright locator method (frame-correct, un-humanized).
+        """
+        page = self.page
+        impl_frame = getattr(getattr(self, "_impl_obj", None), "_frame", None)
+        if impl_frame is None:
+            return page
+        try:
+            if impl_frame is page.main_frame._impl_obj:
+                return page
+            for f in page.frames:
+                if getattr(f, "_impl_obj", None) is impl_frame:
+                    return f if getattr(f, "_human_patched", False) else None
+            # Frame not among page.frames (unknown/detached) -> legacy Page path.
+            return page
+        except Exception:
+            return page
+
     def _forward_kwargs(kwargs):
         out = {}
         if "timeout" in kwargs:
@@ -392,31 +416,51 @@ def _patch_locator_class_sync():
 
     def _humanized_fill(self, value, **kwargs):
         if _is_humanized(self):
-            self.page.fill(_get_selector(self), value, **_forward_kwargs(kwargs))
+            tgt = _route_target(self)
+            if tgt is None:
+                _orig_fill(self, value, **kwargs)
+            else:
+                tgt.fill(_get_selector(self), value, **_forward_kwargs(kwargs))
         else:
             _orig_fill(self, value, **kwargs)
 
     def _humanized_click(self, **kwargs):
         if _is_humanized(self):
-            self.page.click(_get_selector(self), **_forward_kwargs(kwargs))
+            tgt = _route_target(self)
+            if tgt is None:
+                _orig_click(self, **kwargs)
+            else:
+                tgt.click(_get_selector(self), **_forward_kwargs(kwargs))
         else:
             _orig_click(self, **kwargs)
 
     def _humanized_type(self, text, **kwargs):
         if _is_humanized(self):
-            self.page.type(_get_selector(self), text, **_forward_kwargs(kwargs))
+            tgt = _route_target(self)
+            if tgt is None:
+                _orig_type(self, text, **kwargs)
+            else:
+                tgt.type(_get_selector(self), text, **_forward_kwargs(kwargs))
         else:
             _orig_type(self, text, **kwargs)
 
     def _humanized_dblclick(self, **kwargs):
         if _is_humanized(self):
-            self.page.dblclick(_get_selector(self), **_forward_kwargs(kwargs))
+            tgt = _route_target(self)
+            if tgt is None:
+                _orig_dblclick(self, **kwargs)
+            else:
+                tgt.dblclick(_get_selector(self), **_forward_kwargs(kwargs))
         else:
             _orig_dblclick(self, **kwargs)
 
     def _humanized_hover(self, **kwargs):
         if _is_humanized(self):
-            self.page.hover(_get_selector(self), **_forward_kwargs(kwargs))
+            tgt = _route_target(self)
+            if tgt is None:
+                _orig_hover(self, **kwargs)
+            else:
+                tgt.hover(_get_selector(self), **_forward_kwargs(kwargs))
         else:
             _orig_hover(self, **kwargs)
 
@@ -450,6 +494,10 @@ def _patch_locator_class_sync():
 
     def _humanized_check(self, **kwargs):
         if _is_humanized(self):
+            tgt = _route_target(self)
+            if tgt is None:
+                _orig_check(self, **kwargs)
+                return
             fwd = _forward_kwargs(kwargs)
             cfg = _get_cfg(self)
             if cfg and cfg.idle_between_actions:
@@ -457,12 +505,16 @@ def _patch_locator_class_sync():
                 human_idle(raw, rand(cfg.idle_between_duration[0], cfg.idle_between_duration[1]), 0, 0, cfg)
             checked = self.is_checked()
             if not checked:
-                self.page.click(_get_selector(self), **fwd)
+                tgt.click(_get_selector(self), **fwd)
         else:
             _orig_check(self, **kwargs)
 
     def _humanized_uncheck(self, **kwargs):
         if _is_humanized(self):
+            tgt = _route_target(self)
+            if tgt is None:
+                _orig_uncheck(self, **kwargs)
+                return
             fwd = _forward_kwargs(kwargs)
             cfg = _get_cfg(self)
             if cfg and cfg.idle_between_actions:
@@ -470,24 +522,32 @@ def _patch_locator_class_sync():
                 human_idle(raw, rand(cfg.idle_between_duration[0], cfg.idle_between_duration[1]), 0, 0, cfg)
             checked = self.is_checked()
             if checked:
-                self.page.click(_get_selector(self), **fwd)
+                tgt.click(_get_selector(self), **fwd)
         else:
             _orig_uncheck(self, **kwargs)
 
     def _humanized_set_checked(self, checked, **kwargs):
         if _is_humanized(self):
+            tgt = _route_target(self)
+            if tgt is None:
+                _orig_set_checked(self, checked, **kwargs)
+                return
             fwd = _forward_kwargs(kwargs)
             current = self.is_checked()
             if current != checked:
-                self.page.click(_get_selector(self), **fwd)
+                tgt.click(_get_selector(self), **fwd)
         else:
             _orig_set_checked(self, checked, **kwargs)
 
     def _humanized_select_option(self, value=None, **kwargs):
         if _is_humanized(self):
+            tgt = _route_target(self)
+            if tgt is None:
+                _orig_select_option(self, value, **kwargs)
+                return
             fwd = _forward_kwargs(kwargs)
             selector = _get_selector(self)
-            self.page.hover(selector, **fwd)
+            tgt.hover(selector, **fwd)
             sleep_ms(rand(100, 300))
             _orig_select_option(self, value, **kwargs)
         else:
@@ -495,10 +555,14 @@ def _patch_locator_class_sync():
 
     def _humanized_press(self, key, **kwargs):
         if _is_humanized(self):
+            tgt = _route_target(self)
+            if tgt is None:
+                _orig_press(self, key, **kwargs)
+                return
             fwd = _forward_kwargs(kwargs)
             selector = _get_selector(self)
-            if not _is_selector_focused(self.page, selector):
-                self.page.click(selector, **fwd)
+            if not _is_selector_focused(tgt, selector):
+                tgt.click(selector, **fwd)
             sleep_ms(rand(50, 150))
             self.page.keyboard.press(key)
         else:
@@ -506,10 +570,14 @@ def _patch_locator_class_sync():
 
     def _humanized_press_sequentially(self, text, **kwargs):
         if _is_humanized(self):
+            tgt = _route_target(self)
+            if tgt is None:
+                _orig_press_sequentially(self, text, **kwargs)
+                return
             fwd = _forward_kwargs(kwargs)
             selector = _get_selector(self)
-            if not _is_selector_focused(self.page, selector):
-                self.page.click(selector, **fwd)
+            if not _is_selector_focused(tgt, selector):
+                tgt.click(selector, **fwd)
             sleep_ms(rand(50, 150))
             self.page.keyboard.type(text)
         else:
@@ -517,7 +585,11 @@ def _patch_locator_class_sync():
 
     def _humanized_tap(self, **kwargs):
         if _is_humanized(self):
-            self.page.click(_get_selector(self), **_forward_kwargs(kwargs))
+            tgt = _route_target(self)
+            if tgt is None:
+                _orig_tap(self, **kwargs)
+            else:
+                tgt.click(_get_selector(self), **_forward_kwargs(kwargs))
         else:
             _orig_tap(self, **kwargs)
 
@@ -546,10 +618,14 @@ def _patch_locator_class_sync():
 
     def _humanized_clear(self, **kwargs):
         if _is_humanized(self):
+            tgt = _route_target(self)
+            if tgt is None:
+                _orig_clear(self, **kwargs)
+                return
             fwd = _forward_kwargs(kwargs)
             selector = _get_selector(self)
-            if not _is_selector_focused(self.page, selector):
-                self.page.click(selector, **fwd)
+            if not _is_selector_focused(tgt, selector):
+                tgt.click(selector, **fwd)
             sleep_ms(rand(50, 100))
             self.page.keyboard.press(_SELECT_ALL)
             sleep_ms(rand(30, 80))
@@ -616,6 +692,30 @@ def _patch_locator_class_async():
     def _get_cfg(self):
         return getattr(self.page, '_human_cfg', None)
 
+    def _route_target(self):
+        """Resolution target for a humanized locator action (#428).
+
+        Main-frame locators return the Page (unchanged behavior). A locator that
+        belongs to a *sub-frame* returns that frame's humanized wrapper so the
+        selector resolves in the frame's own document. Returns ``None`` when the
+        owning sub-frame is known but not yet humanized, so the caller falls back
+        to the native Playwright locator method (frame-correct, un-humanized).
+        """
+        page = self.page
+        impl_frame = getattr(getattr(self, "_impl_obj", None), "_frame", None)
+        if impl_frame is None:
+            return page
+        try:
+            if impl_frame is page.main_frame._impl_obj:
+                return page
+            for f in page.frames:
+                if getattr(f, "_impl_obj", None) is impl_frame:
+                    return f if getattr(f, "_human_patched", False) else None
+            # Frame not among page.frames (unknown/detached) -> legacy Page path.
+            return page
+        except Exception:
+            return page
+
     def _forward_kwargs(kwargs):
         out = {}
         if "timeout" in kwargs:
@@ -628,31 +728,51 @@ def _patch_locator_class_async():
 
     async def _humanized_fill(self, value, **kwargs):
         if _is_humanized(self):
-            await self.page.fill(_get_selector(self), value, **_forward_kwargs(kwargs))
+            tgt = _route_target(self)
+            if tgt is None:
+                await _orig_fill(self, value, **kwargs)
+            else:
+                await tgt.fill(_get_selector(self), value, **_forward_kwargs(kwargs))
         else:
             await _orig_fill(self, value, **kwargs)
 
     async def _humanized_click(self, **kwargs):
         if _is_humanized(self):
-            await self.page.click(_get_selector(self), **_forward_kwargs(kwargs))
+            tgt = _route_target(self)
+            if tgt is None:
+                await _orig_click(self, **kwargs)
+            else:
+                await tgt.click(_get_selector(self), **_forward_kwargs(kwargs))
         else:
             await _orig_click(self, **kwargs)
 
     async def _humanized_type(self, text, **kwargs):
         if _is_humanized(self):
-            await self.page.type(_get_selector(self), text, **_forward_kwargs(kwargs))
+            tgt = _route_target(self)
+            if tgt is None:
+                await _orig_type(self, text, **kwargs)
+            else:
+                await tgt.type(_get_selector(self), text, **_forward_kwargs(kwargs))
         else:
             await _orig_type(self, text, **kwargs)
 
     async def _humanized_dblclick(self, **kwargs):
         if _is_humanized(self):
-            await self.page.dblclick(_get_selector(self), **_forward_kwargs(kwargs))
+            tgt = _route_target(self)
+            if tgt is None:
+                await _orig_dblclick(self, **kwargs)
+            else:
+                await tgt.dblclick(_get_selector(self), **_forward_kwargs(kwargs))
         else:
             await _orig_dblclick(self, **kwargs)
 
     async def _humanized_hover(self, **kwargs):
         if _is_humanized(self):
-            await self.page.hover(_get_selector(self), **_forward_kwargs(kwargs))
+            tgt = _route_target(self)
+            if tgt is None:
+                await _orig_hover(self, **kwargs)
+            else:
+                await tgt.hover(_get_selector(self), **_forward_kwargs(kwargs))
         else:
             await _orig_hover(self, **kwargs)
 
@@ -688,6 +808,10 @@ def _patch_locator_class_async():
 
     async def _humanized_check(self, **kwargs):
         if _is_humanized(self):
+            tgt = _route_target(self)
+            if tgt is None:
+                await _orig_check(self, **kwargs)
+                return
             fwd = _forward_kwargs(kwargs)
             cfg = _get_cfg(self)
             if cfg and cfg.idle_between_actions:
@@ -699,12 +823,16 @@ def _patch_locator_class_async():
                 )
             checked = await self.is_checked()
             if not checked:
-                await self.page.click(_get_selector(self), **fwd)
+                await tgt.click(_get_selector(self), **fwd)
         else:
             await _orig_check(self, **kwargs)
 
     async def _humanized_uncheck(self, **kwargs):
         if _is_humanized(self):
+            tgt = _route_target(self)
+            if tgt is None:
+                await _orig_uncheck(self, **kwargs)
+                return
             fwd = _forward_kwargs(kwargs)
             cfg = _get_cfg(self)
             if cfg and cfg.idle_between_actions:
@@ -716,24 +844,32 @@ def _patch_locator_class_async():
                 )
             checked = await self.is_checked()
             if checked:
-                await self.page.click(_get_selector(self), **fwd)
+                await tgt.click(_get_selector(self), **fwd)
         else:
             await _orig_uncheck(self, **kwargs)
 
     async def _humanized_set_checked(self, checked, **kwargs):
         if _is_humanized(self):
+            tgt = _route_target(self)
+            if tgt is None:
+                await _orig_set_checked(self, checked, **kwargs)
+                return
             fwd = _forward_kwargs(kwargs)
             current = await self.is_checked()
             if current != checked:
-                await self.page.click(_get_selector(self), **fwd)
+                await tgt.click(_get_selector(self), **fwd)
         else:
             await _orig_set_checked(self, checked, **kwargs)
 
     async def _humanized_select_option(self, value=None, **kwargs):
         if _is_humanized(self):
+            tgt = _route_target(self)
+            if tgt is None:
+                await _orig_select_option(self, value, **kwargs)
+                return
             fwd = _forward_kwargs(kwargs)
             selector = _get_selector(self)
-            await self.page.hover(selector, **fwd)
+            await tgt.hover(selector, **fwd)
             await async_sleep_ms(rand(100, 300))
             await _orig_select_option(self, value, **kwargs)
         else:
@@ -741,10 +877,14 @@ def _patch_locator_class_async():
 
     async def _humanized_press(self, key, **kwargs):
         if _is_humanized(self):
+            tgt = _route_target(self)
+            if tgt is None:
+                await _orig_press(self, key, **kwargs)
+                return
             fwd = _forward_kwargs(kwargs)
             selector = _get_selector(self)
-            if not await _async_is_selector_focused(self.page, selector):
-                await self.page.click(selector, **fwd)
+            if not await _async_is_selector_focused(tgt, selector):
+                await tgt.click(selector, **fwd)
             await async_sleep_ms(rand(50, 150))
             await self.page.keyboard.press(key)
         else:
@@ -752,10 +892,14 @@ def _patch_locator_class_async():
 
     async def _humanized_press_sequentially(self, text, **kwargs):
         if _is_humanized(self):
+            tgt = _route_target(self)
+            if tgt is None:
+                await _orig_press_sequentially(self, text, **kwargs)
+                return
             fwd = _forward_kwargs(kwargs)
             selector = _get_selector(self)
-            if not await _async_is_selector_focused(self.page, selector):
-                await self.page.click(selector, **fwd)
+            if not await _async_is_selector_focused(tgt, selector):
+                await tgt.click(selector, **fwd)
             await async_sleep_ms(rand(50, 150))
             await self.page.keyboard.type(text)
         else:
@@ -763,7 +907,11 @@ def _patch_locator_class_async():
 
     async def _humanized_tap(self, **kwargs):
         if _is_humanized(self):
-            await self.page.click(_get_selector(self), **_forward_kwargs(kwargs))
+            tgt = _route_target(self)
+            if tgt is None:
+                await _orig_tap(self, **kwargs)
+            else:
+                await tgt.click(_get_selector(self), **_forward_kwargs(kwargs))
         else:
             await _orig_tap(self, **kwargs)
 
@@ -792,10 +940,14 @@ def _patch_locator_class_async():
 
     async def _humanized_clear(self, **kwargs):
         if _is_humanized(self):
+            tgt = _route_target(self)
+            if tgt is None:
+                await _orig_clear(self, **kwargs)
+                return
             fwd = _forward_kwargs(kwargs)
             selector = _get_selector(self)
-            if not await _async_is_selector_focused(self.page, selector):
-                await self.page.click(selector, **fwd)
+            if not await _async_is_selector_focused(tgt, selector):
+                await tgt.click(selector, **fwd)
             await async_sleep_ms(rand(50, 100))
             await self.page.keyboard.press(_SELECT_ALL)
             await async_sleep_ms(rand(30, 80))
@@ -1567,41 +1719,164 @@ def _patch_single_frame_sync(
         return
     frame._human_patched = True
 
+    # Frame-scoped resolution: humanize via ``frame.locator(selector)`` so the
+    # selector resolves in the sub-frame's own document, while the mouse stays
+    # page-level (bounding_box() is already page/viewport-space). Mirrors the JS
+    # wrapper's patchSingleFrame/moveToFrameSelector. #428.
+    _orig_frame_click = frame.click
+    _orig_frame_dblclick = frame.dblclick
+    _orig_frame_hover = frame.hover
+    _orig_frame_type = frame.type
+    _orig_frame_fill = frame.fill
+    _orig_frame_check = frame.check
+    _orig_frame_uncheck = frame.uncheck
     _orig_frame_select_option = frame.select_option
+    _orig_frame_press = frame.press
     _orig_frame_drag_and_drop = getattr(frame, 'drag_and_drop', None)
 
+    stealth_world = getattr(page, '_stealth_world', None)
+    cdp_session = None
+    if stealth_world is not None:
+        try:
+            cdp_session = stealth_world.get_cdp_session()
+        except Exception:
+            pass
+
+    def _native_kwargs(kwargs: dict) -> dict:
+        # Native Playwright frame methods don't accept our ``human_config`` kwarg.
+        return {k: v for k, v in kwargs.items() if k != "human_config"}
+
+    def _deadline_remaining(kwargs: dict):
+        timeout = kwargs.get("timeout", 30000)
+        deadline = time.monotonic() + timeout / 1000.0
+        return lambda: max(0.0, (deadline - time.monotonic()) * 1000)
+
+    def _frame_is_input(selector: str) -> bool:
+        try:
+            return bool(frame.locator(selector).first.evaluate(
+                "el => { const t = el.tagName.toLowerCase();"
+                " return t === 'input' || t === 'textarea'"
+                " || el.getAttribute('contenteditable') === 'true'; }"
+            ))
+        except Exception:
+            return False
+
+    def _frame_is_focused(selector: str) -> bool:
+        try:
+            return bool(frame.locator(selector).first.evaluate(
+                "el => el === document.activeElement"
+            ))
+        except Exception:
+            return False
+
+    def _move_to_frame_selector(selector: str, kwargs: dict, input_bias: bool, remaining_ms):
+        call_cfg = merge_config(cfg, kwargs.get("human_config"))
+        if call_cfg.idle_between_actions:
+            human_idle(raw_mouse, rand(call_cfg.idle_between_duration[0], call_cfg.idle_between_duration[1]), cursor.x, cursor.y, call_cfg)
+        loc = frame.locator(selector).first
+        try:
+            loc.scroll_into_view_if_needed(timeout=max(1, remaining_ms()))
+        except Exception:
+            pass
+        try:
+            box = loc.bounding_box(timeout=max(1, remaining_ms()))
+        except Exception:
+            box = None
+        if not box:
+            return None
+        is_input = input_bias or _frame_is_input(selector)
+        target = click_target(box, is_input, call_cfg)
+        human_move(raw_mouse, cursor.x, cursor.y, target.x, target.y, call_cfg)
+        cursor.x = target.x
+        cursor.y = target.y
+        return call_cfg, is_input
+
     def _frame_click(selector: str, **kwargs: Any) -> None:
-        page.click(selector, **kwargs)
+        remaining_ms = _deadline_remaining(kwargs)
+        moved = _move_to_frame_selector(selector, kwargs, False, remaining_ms)
+        if moved is None:
+            _orig_frame_click(selector, **_native_kwargs(kwargs))
+            return
+        human_click(raw_mouse, moved[1], moved[0])
 
     def _frame_dblclick(selector: str, **kwargs: Any) -> None:
-        page.dblclick(selector, **kwargs)
+        remaining_ms = _deadline_remaining(kwargs)
+        moved = _move_to_frame_selector(selector, kwargs, False, remaining_ms)
+        if moved is None:
+            _orig_frame_dblclick(selector, **_native_kwargs(kwargs))
+            return
+        raw_mouse.down(click_count=2)
+        sleep_ms(rand(30, 60))
+        raw_mouse.up(click_count=2)
 
     def _frame_hover(selector: str, **kwargs: Any) -> None:
-        page.hover(selector, **kwargs)
+        remaining_ms = _deadline_remaining(kwargs)
+        moved = _move_to_frame_selector(selector, kwargs, False, remaining_ms)
+        if moved is None:
+            _orig_frame_hover(selector, **_native_kwargs(kwargs))
 
     def _frame_type(selector: str, text: str, **kwargs: Any) -> None:
-        page.type(selector, text, **kwargs)
+        call_cfg = merge_config(cfg, kwargs.get("human_config"))
+        sleep_ms(rand_range(call_cfg.field_switch_delay))
+        _frame_click(selector, **kwargs)
+        sleep_ms(rand(100, 250))
+        try:
+            human_type(page, raw_keyboard, text, call_cfg, cdp_session=cdp_session)
+        except Exception:
+            _orig_frame_type(selector, text, **_native_kwargs(kwargs))
 
     def _frame_fill(selector: str, value: str, **kwargs: Any) -> None:
-        page.fill(selector, value, **kwargs)
+        call_cfg = merge_config(cfg, kwargs.get("human_config"))
+        sleep_ms(rand_range(call_cfg.field_switch_delay))
+        _frame_click(selector, **kwargs)
+        sleep_ms(rand(100, 250))
+        originals.keyboard_press(_SELECT_ALL)
+        sleep_ms(rand(30, 80))
+        originals.keyboard_press("Backspace")
+        sleep_ms(rand(50, 150))
+        try:
+            human_type(page, raw_keyboard, value, call_cfg, cdp_session=cdp_session)
+        except Exception:
+            _orig_frame_fill(selector, value, **_native_kwargs(kwargs))
 
     def _frame_check(selector: str, **kwargs: Any) -> None:
-        page.check(selector, **kwargs)
+        try:
+            checked = frame.locator(selector).first.is_checked()
+        except Exception:
+            _orig_frame_check(selector, **_native_kwargs(kwargs))
+            return
+        if not checked:
+            try:
+                _frame_click(selector, **kwargs)
+            except Exception:
+                _orig_frame_check(selector, **_native_kwargs(kwargs))
 
     def _frame_uncheck(selector: str, **kwargs: Any) -> None:
-        page.uncheck(selector, **kwargs)
+        try:
+            checked = frame.locator(selector).first.is_checked()
+        except Exception:
+            _orig_frame_uncheck(selector, **_native_kwargs(kwargs))
+            return
+        if checked:
+            try:
+                _frame_click(selector, **kwargs)
+            except Exception:
+                _orig_frame_uncheck(selector, **_native_kwargs(kwargs))
 
     def _frame_select_option(selector: str, value: Any = None, **kwargs: Any) -> Any:
-        page.hover(selector, **kwargs)
+        _frame_hover(selector, **kwargs)
         sleep_ms(rand(100, 300))
-        return _orig_frame_select_option(selector, value, **kwargs)
+        return _orig_frame_select_option(selector, value, **_native_kwargs(kwargs))
 
     def _frame_press(selector: str, key: str, **kwargs: Any) -> None:
-        page.press(selector, key, **kwargs)
+        if not _frame_is_focused(selector):
+            _frame_click(selector, **kwargs)
+        sleep_ms(rand(50, 150))
+        originals.keyboard_press(key)
 
     def _frame_clear(selector: str, **kwargs: Any) -> None:
-        if not _is_selector_focused(page, selector):
-            page.click(selector, **kwargs)
+        if not _frame_is_focused(selector):
+            _frame_click(selector, **kwargs)
         sleep_ms(rand(50, 100))
         originals.keyboard_press(_SELECT_ALL)
         sleep_ms(rand(30, 80))
@@ -1641,13 +1916,6 @@ def _patch_single_frame_sync(
     frame.drag_and_drop = _frame_drag_and_drop
 
     # --- Patch frame-level ElementHandle selectors ---
-    stealth_world = getattr(page, '_stealth_world', None)
-    cdp_session = None
-    if stealth_world is not None:
-        try:
-            cdp_session = stealth_world.get_cdp_session()
-        except Exception:
-            pass
     _patch_frame_element_handles_sync(
         frame, page, cfg, cursor, raw_mouse, raw_keyboard, originals, stealth_world, cdp_session
     )
@@ -2496,41 +2764,167 @@ def _patch_single_frame_async(
         return
     frame._human_patched = True
 
+    # Frame-scoped resolution (async): humanize via ``frame.locator(selector)`` so
+    # the selector resolves in the sub-frame's own document, while the mouse stays
+    # page-level. Mirrors the sync patcher / JS moveToFrameSelector. #428.
+    _orig_frame_click = frame.click
+    _orig_frame_dblclick = frame.dblclick
+    _orig_frame_hover = frame.hover
+    _orig_frame_type = frame.type
+    _orig_frame_fill = frame.fill
+    _orig_frame_check = frame.check
+    _orig_frame_uncheck = frame.uncheck
     _orig_frame_select_option = frame.select_option
+    _orig_frame_press = frame.press
     _orig_frame_drag_and_drop = getattr(frame, 'drag_and_drop', None)
 
+    stealth_world = getattr(page, '_stealth_world', None)
+    cdp_session_holder = getattr(page, '_cdp_session_holder', [None])
+
+    async def _get_cdp():
+        if cdp_session_holder[0] is None and stealth_world is not None:
+            try:
+                cdp_session_holder[0] = await stealth_world.get_cdp_session()
+            except Exception:
+                cdp_session_holder[0] = None
+        return cdp_session_holder[0]
+
+    def _native_kwargs(kwargs: dict) -> dict:
+        return {k: v for k, v in kwargs.items() if k != "human_config"}
+
+    def _deadline_remaining(kwargs: dict):
+        timeout = kwargs.get("timeout", 30000)
+        deadline = time.monotonic() + timeout / 1000.0
+        return lambda: max(0.0, (deadline - time.monotonic()) * 1000)
+
+    async def _frame_is_input(selector: str) -> bool:
+        try:
+            return bool(await frame.locator(selector).first.evaluate(
+                "el => { const t = el.tagName.toLowerCase();"
+                " return t === 'input' || t === 'textarea'"
+                " || el.getAttribute('contenteditable') === 'true'; }"
+            ))
+        except Exception:
+            return False
+
+    async def _frame_is_focused(selector: str) -> bool:
+        try:
+            return bool(await frame.locator(selector).first.evaluate(
+                "el => el === document.activeElement"
+            ))
+        except Exception:
+            return False
+
+    async def _move_to_frame_selector(selector: str, kwargs: dict, input_bias: bool, remaining_ms):
+        call_cfg = merge_config(cfg, kwargs.get("human_config"))
+        if call_cfg.idle_between_actions:
+            await async_human_idle(raw_mouse, rand(call_cfg.idle_between_duration[0], call_cfg.idle_between_duration[1]), cursor.x, cursor.y, call_cfg)
+        loc = frame.locator(selector).first
+        try:
+            await loc.scroll_into_view_if_needed(timeout=max(1, remaining_ms()))
+        except Exception:
+            pass
+        try:
+            box = await loc.bounding_box(timeout=max(1, remaining_ms()))
+        except Exception:
+            box = None
+        if not box:
+            return None
+        is_input = input_bias or await _frame_is_input(selector)
+        target = click_target(box, is_input, call_cfg)
+        await async_human_move(raw_mouse, cursor.x, cursor.y, target.x, target.y, call_cfg)
+        cursor.x = target.x
+        cursor.y = target.y
+        return call_cfg, is_input
+
     async def _frame_click(selector: str, **kwargs: Any) -> None:
-        await page.click(selector, **kwargs)
+        remaining_ms = _deadline_remaining(kwargs)
+        moved = await _move_to_frame_selector(selector, kwargs, False, remaining_ms)
+        if moved is None:
+            await _orig_frame_click(selector, **_native_kwargs(kwargs))
+            return
+        await async_human_click(raw_mouse, moved[1], moved[0])
 
     async def _frame_dblclick(selector: str, **kwargs: Any) -> None:
-        await page.dblclick(selector, **kwargs)
+        remaining_ms = _deadline_remaining(kwargs)
+        moved = await _move_to_frame_selector(selector, kwargs, False, remaining_ms)
+        if moved is None:
+            await _orig_frame_dblclick(selector, **_native_kwargs(kwargs))
+            return
+        await raw_mouse.down(click_count=2)
+        await async_sleep_ms(rand(30, 60))
+        await raw_mouse.up(click_count=2)
 
     async def _frame_hover(selector: str, **kwargs: Any) -> None:
-        await page.hover(selector, **kwargs)
+        remaining_ms = _deadline_remaining(kwargs)
+        moved = await _move_to_frame_selector(selector, kwargs, False, remaining_ms)
+        if moved is None:
+            await _orig_frame_hover(selector, **_native_kwargs(kwargs))
 
     async def _frame_type(selector: str, text: str, **kwargs: Any) -> None:
-        await page.type(selector, text, **kwargs)
+        call_cfg = merge_config(cfg, kwargs.get("human_config"))
+        await async_sleep_ms(rand_range(call_cfg.field_switch_delay))
+        await _frame_click(selector, **kwargs)
+        await async_sleep_ms(rand(100, 250))
+        try:
+            cdp = await _get_cdp()
+            await async_human_type(page, raw_keyboard, text, call_cfg, cdp_session=cdp)
+        except Exception:
+            await _orig_frame_type(selector, text, **_native_kwargs(kwargs))
 
     async def _frame_fill(selector: str, value: str, **kwargs: Any) -> None:
-        await page.fill(selector, value, **kwargs)
+        call_cfg = merge_config(cfg, kwargs.get("human_config"))
+        await async_sleep_ms(rand_range(call_cfg.field_switch_delay))
+        await _frame_click(selector, **kwargs)
+        await async_sleep_ms(rand(100, 250))
+        await originals.keyboard_press(_SELECT_ALL)
+        await async_sleep_ms(rand(30, 80))
+        await originals.keyboard_press("Backspace")
+        await async_sleep_ms(rand(50, 150))
+        try:
+            cdp = await _get_cdp()
+            await async_human_type(page, raw_keyboard, value, call_cfg, cdp_session=cdp)
+        except Exception:
+            await _orig_frame_fill(selector, value, **_native_kwargs(kwargs))
 
     async def _frame_check(selector: str, **kwargs: Any) -> None:
-        await page.check(selector, **kwargs)
+        try:
+            checked = await frame.locator(selector).first.is_checked()
+        except Exception:
+            await _orig_frame_check(selector, **_native_kwargs(kwargs))
+            return
+        if not checked:
+            try:
+                await _frame_click(selector, **kwargs)
+            except Exception:
+                await _orig_frame_check(selector, **_native_kwargs(kwargs))
 
     async def _frame_uncheck(selector: str, **kwargs: Any) -> None:
-        await page.uncheck(selector, **kwargs)
+        try:
+            checked = await frame.locator(selector).first.is_checked()
+        except Exception:
+            await _orig_frame_uncheck(selector, **_native_kwargs(kwargs))
+            return
+        if checked:
+            try:
+                await _frame_click(selector, **kwargs)
+            except Exception:
+                await _orig_frame_uncheck(selector, **_native_kwargs(kwargs))
 
     async def _frame_select_option(selector: str, value: Any = None, **kwargs: Any) -> Any:
-        await page.hover(selector, **kwargs)
+        await _frame_hover(selector, **kwargs)
         await async_sleep_ms(rand(100, 300))
-        return await _orig_frame_select_option(selector, value, **kwargs)
+        return await _orig_frame_select_option(selector, value, **_native_kwargs(kwargs))
 
     async def _frame_press(selector: str, key: str, **kwargs: Any) -> None:
-        await page.press(selector, key, **kwargs)
+        if not await _frame_is_focused(selector):
+            await _frame_click(selector, **kwargs)
+        await async_sleep_ms(rand(50, 150))
+        await originals.keyboard_press(key)
 
     async def _frame_clear(selector: str, **kwargs: Any) -> None:
-        if not await _async_is_selector_focused(page, selector):
-            await page.click(selector, **kwargs)
+        if not await _frame_is_focused(selector):
+            await _frame_click(selector, **kwargs)
         await async_sleep_ms(rand(50, 100))
         await originals.keyboard_press(_SELECT_ALL)
         await async_sleep_ms(rand(30, 80))
@@ -2570,8 +2964,6 @@ def _patch_single_frame_async(
     frame.drag_and_drop = _frame_drag_and_drop
 
     # --- Patch frame-level ElementHandle selectors (async) ---
-    stealth_world = getattr(page, '_stealth_world', None)
-    cdp_session_holder = getattr(page, '_cdp_session_holder', [None])
     _patch_frame_element_handles_async(
         frame, page, cfg, cursor, raw_mouse, raw_keyboard, originals, stealth_world, cdp_session_holder
     )

--- a/tests/test_humanize_unit.py
+++ b/tests/test_humanize_unit.py
@@ -396,6 +396,175 @@ class TestFramePatching:
 
 
 # =========================================================================
+# 6b. iframe humanize routing (#428)
+# =========================================================================
+
+def _make_frame_for_routing(is_input=False, box=None):
+    """A MagicMock frame whose locator resolves to a real bounding box."""
+    from cloakbrowser.human import _patch_single_frame_sync, _CursorState
+    from cloakbrowser.human.config import resolve_config
+    cfg = resolve_config("default", None)
+    cursor = _CursorState()
+    page = MagicMock()
+    page._original = MagicMock()
+    page._stealth_world = None          # skip CDP path
+    frame = MagicMock()
+    frame._human_patched = False
+    loc_first = frame.locator.return_value.first
+    loc_first.bounding_box.return_value = box if box is not None else {
+        "x": 10.0, "y": 10.0, "width": 40.0, "height": 20.0}
+    loc_first.evaluate.return_value = is_input
+    loc_first.is_checked.return_value = False
+    orig_click = frame.click                                   # capture pre-patch
+    _patch_single_frame_sync(frame, page, cfg, cursor, MagicMock(), MagicMock(), MagicMock())
+    return frame, page, orig_click
+
+
+class TestFrameHumanizedRouting:
+    def test_frame_click_resolves_in_frame_not_page(self):
+        from unittest.mock import patch as mock_patch
+        frame, page, _ = _make_frame_for_routing()
+        with mock_patch("cloakbrowser.human.human_move") as mv, \
+             mock_patch("cloakbrowser.human.human_click") as clk:
+            frame.click("#btn")
+        # resolved through the frame's own locator, moved + clicked the real mouse,
+        # and NEVER re-dispatched to page.click (the #428 bug)
+        frame.locator.assert_any_call("#btn")
+        assert mv.called and clk.called
+        page.click.assert_not_called()
+
+    def test_frame_click_falls_back_to_native_when_no_box(self):
+        from unittest.mock import patch as mock_patch
+        frame, page, orig_click = _make_frame_for_routing(box=False)  # bounding_box -> falsy
+        with mock_patch("cloakbrowser.human.human_move") as mv, \
+             mock_patch("cloakbrowser.human.human_click") as clk:
+            frame.click("#btn")
+        assert not mv.called and not clk.called
+        orig_click.assert_called_once()          # native frame.click used
+        page.click.assert_not_called()
+
+
+def _make_locator_for_routing(frame_kind):
+    """Build a MagicMock locator + page.frames for _route_target testing.
+
+    frame_kind: 'main' | 'patched_sub' | 'unpatched_sub'
+    Returns (loc, page, child_frame).
+    """
+    _ensure_locator_patched()
+    page = MagicMock()
+    page._original = MagicMock()
+    main = MagicMock()
+    child = MagicMock()
+    child._human_patched = (frame_kind == "patched_sub")
+    page.main_frame = main
+    page.frames = [main, child]
+    loc = MagicMock()
+    loc.page = page
+    loc._impl_obj._selector = "#btn"
+    if frame_kind == "main":
+        loc._impl_obj._frame = main._impl_obj
+    else:
+        loc._impl_obj._frame = child._impl_obj
+    return loc, page, child
+
+
+class TestLocatorSubframeRouting:
+    def test_subframe_locator_routes_to_owning_frame(self):
+        from playwright.sync_api._generated import Locator
+        loc, page, child = _make_locator_for_routing("patched_sub")
+        Locator.click(loc)
+        child.click.assert_called_once()
+        assert child.click.call_args[0][0] == "#btn"
+        page.click.assert_not_called()
+
+    def test_mainframe_locator_routes_to_page(self):
+        from playwright.sync_api._generated import Locator
+        loc, page, child = _make_locator_for_routing("main")
+        Locator.click(loc)
+        page.click.assert_called_once()
+        assert page.click.call_args[0][0] == "#btn"
+        child.click.assert_not_called()
+
+    def test_unpatched_subframe_falls_back_to_native(self):
+        from playwright.sync_api._generated import Locator
+        loc, page, child = _make_locator_for_routing("unpatched_sub")
+        # native Locator.click is invoked on the mock; neither humanized path runs
+        Locator.click(loc)
+        child.click.assert_not_called()
+        page.click.assert_not_called()
+
+
+class TestLocatorSubframeRoutingAsync:
+    @pytest.mark.asyncio
+    async def test_async_subframe_locator_routes_to_owning_frame(self):
+        import cloakbrowser.human as h
+        from unittest.mock import AsyncMock
+        h._locator_async_patched = False
+        h._patch_locator_class_async()
+        from playwright.async_api._generated import Locator as AsyncLocator
+
+        page = MagicMock()
+        page._original = MagicMock()
+        main = MagicMock()
+        child = MagicMock()
+        child._human_patched = True
+        child.click = AsyncMock()
+        page.main_frame = main
+        page.frames = [main, child]
+        loc = MagicMock()
+        loc.page = page
+        loc._impl_obj._selector = "#btn"
+        loc._impl_obj._frame = child._impl_obj
+
+        await AsyncLocator.click(loc)
+        child.click.assert_awaited_once()
+        assert child.click.call_args[0][0] == "#btn"
+
+
+class TestFrameClickArgContract:
+    """#428 guard: _frame_click must call human_click(raw, is_input, cfg) in order.
+    The routing tests mock human_click, so a swap would slip through."""
+
+    def test_frame_click_passes_is_input_bool_and_cfg(self):
+        from unittest.mock import patch as mock_patch
+        from cloakbrowser.human.config import HumanConfig
+        frame, page, _ = _make_frame_for_routing(is_input=False)  # button
+        with mock_patch("cloakbrowser.human.human_move"), \
+             mock_patch("cloakbrowser.human.human_click") as clk:
+            frame.click("#btn")
+        args = clk.call_args[0]
+        assert isinstance(args[1], bool) and args[1] is False   # is_input
+        assert isinstance(args[2], HumanConfig)                 # cfg
+
+    def test_frame_click_marks_is_input_true_for_input(self):
+        from unittest.mock import patch as mock_patch
+        frame, page, _ = _make_frame_for_routing(is_input=True)
+        with mock_patch("cloakbrowser.human.human_move"), \
+             mock_patch("cloakbrowser.human.human_click") as clk:
+            frame.click("#inp")
+        assert clk.call_args[0][1] is True
+
+
+class TestFrameFillFocus:
+    def test_frame_fill_clicks_before_typing(self):
+        from unittest.mock import patch as mock_patch
+        frame, page, _ = _make_frame_for_routing(is_input=True)
+        with mock_patch("cloakbrowser.human.human_move"), \
+             mock_patch("cloakbrowser.human.human_click"), \
+             mock_patch("cloakbrowser.human.human_type") as htype:
+            frame.fill("#inp", "hello")
+        assert htype.called and htype.call_args[0][2] == "hello"
+
+    def test_frame_fill_falls_back_when_type_raises(self):
+        from unittest.mock import patch as mock_patch
+        frame, page, _ = _make_frame_for_routing(is_input=True)
+        with mock_patch("cloakbrowser.human.human_move"), \
+             mock_patch("cloakbrowser.human.human_click"), \
+             mock_patch("cloakbrowser.human.human_type", side_effect=RuntimeError("boom")):
+            frame.fill("#inp", "hello")  # must not raise — native fallback
+
+
+# =========================================================================
 # 7. drag_to safety
 # =========================================================================
 
@@ -646,6 +815,118 @@ class TestBrowserFill:
         val = page.locator('#searchInput').input_value()
         assert val == ''
         browser.close()
+
+
+# =========================================================================
+# 6c. iframe humanize end-to-end (#428) — real same-origin iframe over HTTP
+# =========================================================================
+
+import threading
+import http.server
+import socketserver
+import contextlib
+
+_IFRAME_PARENT = (
+    b"<html><body><h1>parent</h1>"
+    b"<iframe name='myframe' src='/child.html' width=400 height=250></iframe>"
+    b"</body></html>"
+)
+_IFRAME_CHILD = (
+    b"<html><body>"
+    b"<button id='btn' onclick=\"this.textContent='CLICKED'\">Click Me</button>"
+    b"<input id='inp'>"
+    b"</body></html>"
+)
+
+
+@contextlib.contextmanager
+def _iframe_server():
+    """Serve a parent page + same-origin child page with a button/input."""
+    class _H(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            body = _IFRAME_CHILD if self.path.startswith("/child") else _IFRAME_PARENT
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *a):
+            pass
+
+    srv = socketserver.TCPServer(("127.0.0.1", 0), _H)
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{port}/"
+    finally:
+        srv.shutdown()
+
+
+@pytest.mark.slow
+class TestBrowserIframeHumanize:
+    """Regression for #428: humanize=True must interact with elements inside
+    sub-frames instead of misrouting to the top document."""
+
+    def test_humanized_click_inside_iframe(self):
+        from cloakbrowser import launch
+        with _iframe_server() as url:
+            browser = launch(headless=True, humanize=True)
+            try:
+                page = browser.new_page()
+                page.goto(url, wait_until="networkidle")
+                frame = page.frame(name="myframe")
+                assert frame is not None
+                # the #428 case: a Locator obtained from a sub-frame
+                frame.locator("#btn").click(timeout=5000)
+                assert frame.locator("#btn").text_content() == "CLICKED"
+            finally:
+                browser.close()
+
+    def test_humanized_fill_inside_iframe(self):
+        from cloakbrowser import launch
+        with _iframe_server() as url:
+            browser = launch(headless=True, humanize=True)
+            try:
+                page = browser.new_page()
+                page.goto(url, wait_until="networkidle")
+                frame = page.frame(name="myframe")
+                frame.locator("#inp").fill("hello", timeout=5000)
+                assert frame.locator("#inp").input_value() == "hello"
+            finally:
+                browser.close()
+
+    def test_native_control_click_inside_iframe(self):
+        """Control: humanize=False must also work (parity)."""
+        from cloakbrowser import launch
+        with _iframe_server() as url:
+            browser = launch(headless=True, humanize=False)
+            try:
+                page = browser.new_page()
+                page.goto(url, wait_until="networkidle")
+                frame = page.frame(name="myframe")
+                frame.locator("#btn").click(timeout=5000)
+                assert frame.locator("#btn").text_content() == "CLICKED"
+            finally:
+                browser.close()
+
+
+@pytest.mark.slow
+class TestBrowserIframeHumanizeAsync:
+    @pytest.mark.asyncio
+    async def test_async_humanized_click_inside_iframe(self):
+        from cloakbrowser import launch_async
+        with _iframe_server() as url:
+            browser = await launch_async(headless=True, humanize=True)
+            try:
+                page = await browser.new_page()
+                await page.goto(url, wait_until="networkidle")
+                frame = page.frame(name="myframe")
+                assert frame is not None
+                await frame.locator("#btn").click(timeout=5000)
+                assert await frame.locator("#btn").text_content() == "CLICKED"
+            finally:
+                await browser.close()
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Fixes #428.

## Problem

With `humanize=True`, any `Locator` action on an element **inside an iframe** (`frame.locator("#btn").click()`, `fill()`, `hover()`, …) failed with `cloakbrowser.human.actionability.ElementNotAttachedError: element not found in DOM`. Native Playwright (`humanize=False`) clicked the same element fine.

## Root cause

The humanize layer resolved every selector against the **main frame**, never the owning sub-frame. Two independent misroutes in `cloakbrowser/human/__init__.py`:

1. **Locator wrapper** — `_humanized_click` etc. called `self.page.click(self._impl_obj._selector, …)`. A frame locator's `.page` is the *main* Page, so `#btn` was searched on the top document.
2. **Frame wrapper** — `_frame_click(sel)` → `page.click(sel)`, discarding the frame identity.

The mouse half was already cross-frame-correct (`bounding_box()` on a frame locator returns page/viewport-space coords), so only *element resolution* was wrong.

## Fix (keeps humanization inside iframes)

Mirrors the design already shipping in the JS wrapper:

- **Frame wrapper** now resolves through `frame.locator(selector)`, does a native `scroll_into_view_if_needed`, reads the page-space `bounding_box`, detects input type in the frame's own context, then runs the **humanized** Bézier mouse-move + human click on the page-level mouse (native-frame fallback if the box can't be read).
- **Locator wrapper** routes a sub-frame locator to its owning frame's now-humanized method; main-frame locators are unchanged (still go through the Page — byte-for-byte the same path). Unknown/detached frames fall back to native Playwright (frame-correct).

Sync **and** async. No changes to the page-level primitives, so the main-frame path carries zero regression risk.

The JS and .NET wrappers were already frame-correct — this is a **Python-only** change (verified by running a real same-origin iframe through all three wrappers).

## Testing

- **New unit tests** (mocked, no binary): sub-frame Locator routing (sub-frame → owning frame, main-frame → page, unpatched → native), frame-humanized resolution + native fallback, sync + async.
- **New integration tests** (`@pytest.mark.slow`, real binary, local same-origin iframe over HTTP): humanized click + fill inside an iframe, async click, and a `humanize=False` parity control.
- Existing humanize unit suite: **71 passed** (no main-frame regression).
- On the v148 Pro binary in Docker: the 4 new iframe integration tests pass; pre-existing humanize browser tests pass; matrix **group 9 (Humanize)** and groups **1/2/3/5** = **57/57 passed, 0 failed**.

## Ask

@evelaa123 — as the humanize layer's main author, could you review this and re-run the humanize tests on your side (especially the new iframe integration tests, and any humanize flows you rely on)? Would like a second pair of eyes on the frame-routing before it merges.
