### PR TITLE
feat(pxbypass): automatic PerimeterX challenge handling

### DIFF
--- a/cloakbrowser/__init__.py
+++ b/cloakbrowser/__init__.py
@@ -17,7 +17,7 @@ from .download import binary_info, check_for_update, clear_cache, ensure_binary
 from .license import CloakBrowserLicenseError, LicenseInfo, validate_license
 from ._version import __version__
 
-# Human-like behavioral layer (optional)
+# Lazy-loaded optional modules (human + pxbypass)
 def __getattr__(name):
     if name == "HumanConfig":
         from .human.config import HumanConfig
@@ -27,6 +27,18 @@ def __getattr__(name):
         from .human.config import resolve_config
         globals()["resolve_human_config"] = resolve_config
         return resolve_config
+    if name == "PxConfig":
+        from .pxbypass.config import PxConfig
+        globals()["PxConfig"] = PxConfig
+        return PxConfig
+    if name == "detect_px":
+        from .pxbypass import detect_px
+        globals()["detect_px"] = detect_px
+        return detect_px
+    if name == "solve_px":
+        from .pxbypass import solve_px
+        globals()["solve_px"] = solve_px
+        return solve_px
     raise AttributeError(f"module 'cloakbrowser' has no attribute {name}")
 
 __all__ = [
@@ -50,6 +62,8 @@ __all__ = [
     "CloakBrowserLicenseError",
     "HumanConfig",
     "resolve_human_config",
+    "PxConfig",
+    "detect_px",
+    "solve_px",
     "__version__",
 ]
-

--- a/cloakbrowser/browser.py
+++ b/cloakbrowser/browser.py
@@ -179,6 +179,8 @@ def launch(
     license_key: str | None = None,
     browser_version: str | None = None,
     _suppress_maximize: bool = False,
+    bypass_px: bool = False,
+    px_config: Any = None,
     **kwargs: Any,
 ) -> Any:
     """Launch stealth Chromium browser. Returns a Playwright Browser object.
@@ -279,6 +281,14 @@ def launch(
         cfg = resolve_config(human_preset, human_config)
         patch_browser(browser, cfg)
 
+    # PX captcha auto-solving
+    if bypass_px:
+        from .pxbypass import patch_browser as patch_browser_px
+        from .pxbypass.config import PxConfig
+        px_cfg = px_config if isinstance(px_config, PxConfig) else PxConfig(**(px_config or {}))
+        patch_browser_px(browser, px_cfg)
+        logger.info("PerimeterX bypass enabled")
+
     return browser
 
 
@@ -297,6 +307,8 @@ async def launch_async(  # noqa: C901
     license_key: str | None = None,
     browser_version: str | None = None,
     _suppress_maximize: bool = False,
+    bypass_px: bool = False,
+    px_config: Any = None,
     **kwargs: Any,
 ) -> Any:
     """Async version of launch(). Returns a Playwright Browser object.
@@ -391,6 +403,14 @@ async def launch_async(  # noqa: C901
         from .human.config import resolve_config
         cfg = resolve_config(human_preset, human_config)
         patch_browser_async(browser, cfg)
+
+    # PX captcha auto-solving (async)
+    if bypass_px:
+        from .pxbypass import patch_browser_async as patch_browser_px_async
+        from .pxbypass.config import PxConfig
+        px_cfg = px_config if isinstance(px_config, PxConfig) else PxConfig(**(px_config or {}))
+        patch_browser_px_async(browser, px_cfg)
+        logger.info("PerimeterX bypass enabled (async)")
 
     return browser
 

--- a/cloakbrowser/browser.py
+++ b/cloakbrowser/browser.py
@@ -143,6 +143,15 @@ def _resolve_timezone(timezone: str | None, kwargs: dict[str, Any]) -> str | Non
     return timezone
 
 
+def _resolve_px_bypass(bypass_px: bool, kwargs: dict[str, Any]) -> bool:
+    """Accept the issue's ``pxBypass`` spelling without leaking it to Playwright."""
+    if "pxBypass" in kwargs:
+        alias = bool(kwargs.pop("pxBypass"))
+        if not bypass_px:
+            bypass_px = alias
+    return bypass_px
+
+
 def _check_removed_kwargs(kwargs: dict[str, Any]) -> None:
     """Raise a clear error for removed parameters that now fall into **kwargs."""
     if "backend" in kwargs:
@@ -217,6 +226,7 @@ def launch(
         >>> print(page.title())
         >>> browser.close()
     """
+    bypass_px = _resolve_px_bypass(bypass_px, kwargs)
     _check_removed_kwargs(kwargs)
 
     from playwright.sync_api import sync_playwright
@@ -288,6 +298,7 @@ def launch(
         px_cfg = px_config if isinstance(px_config, PxConfig) else PxConfig(**(px_config or {}))
         patch_browser_px(browser, px_cfg)
         logger.info("PerimeterX bypass enabled")
+        browser._px_bypass_active = True
 
     return browser
 
@@ -343,6 +354,7 @@ async def launch_async(  # noqa: C901
         >>>
         >>> asyncio.run(main())
     """
+    bypass_px = _resolve_px_bypass(bypass_px, kwargs)
     _check_removed_kwargs(kwargs)
 
     from playwright.async_api import async_playwright
@@ -411,6 +423,7 @@ async def launch_async(  # noqa: C901
         px_cfg = px_config if isinstance(px_config, PxConfig) else PxConfig(**(px_config or {}))
         patch_browser_px_async(browser, px_cfg)
         logger.info("PerimeterX bypass enabled (async)")
+        browser._px_bypass_active = True
 
     return browser
 
@@ -433,6 +446,8 @@ def launch_persistent_context(
     extension_paths: list[str] | None = None,
     license_key: str | None = None,
     browser_version: str | None = None,
+    bypass_px: bool = False,
+    px_config: Any = None,
     **kwargs: Any,
 ) -> Any:
     """Launch stealth browser with a persistent profile and return a BrowserContext.
@@ -475,6 +490,7 @@ def launch_persistent_context(
         >>> page.goto("https://protected-site.com")
         >>> ctx.close()  # Profile is saved; re-use path next run to restore state.
     """
+    bypass_px = _resolve_px_bypass(bypass_px, kwargs)
     _check_removed_kwargs(kwargs)
 
     from playwright.sync_api import sync_playwright
@@ -557,6 +573,17 @@ def launch_persistent_context(
         cfg = resolve_config(human_preset, human_config)
         patch_context(context, cfg)
 
+    # PX captcha auto-solving
+    if bypass_px:
+        from .pxbypass import patch_page as patch_page_px
+        from .pxbypass.config import PxConfig
+        px_cfg = px_config if isinstance(px_config, PxConfig) else PxConfig(**(px_config or {}))
+        for page in context.pages:
+            patch_page_px(page, px_cfg)
+        context.on("page", lambda p: patch_page_px(p, px_cfg))
+        logger.info("PerimeterX bypass enabled (persistent context)")
+        setattr(context, "_px_bypass_active", True)
+
     return context
 
 
@@ -578,6 +605,8 @@ async def launch_persistent_context_async(
     extension_paths: list[str] | None = None,
     license_key: str | None = None,
     browser_version: str | None = None,
+    bypass_px: bool = False,
+    px_config: Any = None,
     **kwargs: Any,
 ) -> Any:
     """Async version of launch_persistent_context().
@@ -622,6 +651,7 @@ async def launch_persistent_context_async(
         >>>
         >>> asyncio.run(main())
     """
+    bypass_px = _resolve_px_bypass(bypass_px, kwargs)
     _check_removed_kwargs(kwargs)
 
     from playwright.async_api import async_playwright
@@ -704,6 +734,18 @@ async def launch_persistent_context_async(
         cfg = resolve_config(human_preset, human_config)
         patch_context_async(context, cfg)
 
+    # PX captcha auto-solving (async)
+    if bypass_px:
+        import asyncio
+        from .pxbypass import patch_page_async as patch_page_px_async
+        from .pxbypass.config import PxConfig
+        px_cfg = px_config if isinstance(px_config, PxConfig) else PxConfig(**(px_config or {}))
+        for page in context.pages:
+            await patch_page_px_async(page, px_cfg)
+        context.on("page", lambda p: asyncio.ensure_future(patch_page_px_async(p, px_cfg)))
+        logger.info("PerimeterX bypass enabled (persistent context async)")
+        setattr(context, "_px_bypass_active", True)
+
     return context
 
 
@@ -724,6 +766,8 @@ def launch_context(
     extension_paths: list[str] | None = None,
     license_key: str | None = None,
     browser_version: str | None = None,
+    bypass_px: bool = False,
+    px_config: Any = None,
     **kwargs: Any,
 ) -> Any:
     """Launch stealth browser and return a BrowserContext with common options pre-set.
@@ -753,6 +797,7 @@ def launch_context(
     Returns:
         Playwright BrowserContext object.
     """
+    bypass_px = _resolve_px_bypass(bypass_px, kwargs)
     _check_removed_kwargs(kwargs)
 
     timezone = _resolve_timezone(timezone, kwargs)
@@ -768,6 +813,7 @@ def launch_context(
     browser = launch(headless=headless, proxy=proxy, args=args, stealth_args=stealth_args,
                      timezone=timezone, locale=locale, extension_paths=extension_paths,
                      license_key=license_key, browser_version=browser_version,
+                     bypass_px=bypass_px, px_config=px_config,
                      # Caller chose a viewport geometry → don't also auto-maximize
                      # the window (mirrors the persistent-context path + JS).
                      _suppress_maximize=(viewport is not _VIEWPORT_UNSET or "no_viewport" in kwargs))
@@ -829,6 +875,8 @@ async def launch_context_async(
     extension_paths: list[str] | None = None,
     license_key: str | None = None,
     browser_version: str | None = None,
+    bypass_px: bool = False,
+    px_config: Any = None,
     **kwargs: Any,
 ) -> Any:
     """Async version of launch_context().
@@ -878,6 +926,7 @@ async def launch_context_async(
         >>>
         >>> asyncio.run(main())
     """
+    bypass_px = _resolve_px_bypass(bypass_px, kwargs)
     _check_removed_kwargs(kwargs)
 
     timezone = _resolve_timezone(timezone, kwargs)
@@ -892,6 +941,7 @@ async def launch_context_async(
     browser = await launch_async(headless=headless, proxy=proxy, args=args, stealth_args=stealth_args,
                                  timezone=timezone, locale=locale, extension_paths=extension_paths,
                                  license_key=license_key, browser_version=browser_version,
+                                 bypass_px=bypass_px, px_config=px_config,
                                  # Caller chose a viewport geometry → don't also auto-maximize
                                  # the window (mirrors the persistent-context path + JS).
                                  _suppress_maximize=(viewport is not _VIEWPORT_UNSET or "no_viewport" in kwargs))
@@ -949,6 +999,7 @@ async def launch_context_async(
 
 def _ensure_proxy_scheme(proxy_url: str) -> str:
     """Prepend http:// to schemeless proxy URLs so parsers can extract hostname."""
+    proxy_url = proxy_url.strip()
     return proxy_url if "://" in proxy_url else f"http://{proxy_url}"
 
 
@@ -1424,6 +1475,7 @@ def _normalize_http_string_url(url: str) -> str:
     Same pattern as ``_normalize_socks_string_url`` — decode then re-encode to
     ensure Chromium's proxy URL parser handles special chars correctly.
     """
+    url = url.strip()
     normalized = url if "://" in url else f"http://{url}"
     try:
         parsed = urlparse(normalized)

--- a/cloakbrowser/pxbypass/README.md
+++ b/cloakbrowser/pxbypass/README.md
@@ -49,7 +49,19 @@ browser = launch(bypass_px=True)
 page = browser.new_page()
 page.goto("https://target-with-px.com")
 # 遇到 PX 挑战会自动检测并求解
+# 后台持续监控，不管 PX 在 1 分钟后还是 10 分钟后触发，都能自动过掉
 ```
+
+## 工作原理
+
+`bypass_px=True` 会在浏览器层面打补丁，拦截所有新页面的创建。每个页面创建时：
+
+1. **立即启动后台监控** — daemon 线程（sync API）或 asyncio task（async API）
+2. 每 `monitor_interval` 秒（默认 1.5s）用 JS 快速探测页面 DOM
+3. 一旦发现 PX 挑战 UI，立即自动检测挑战类型并执行按住求解
+4. 页面关闭后监控自动停止
+
+监控覆盖所有页面，无论导航方式：`goto()`、点击链接、SPA 路由跳转、`window.location` 等均不受影响。
 
 ## PxEngine 高级用法
 
@@ -78,8 +90,8 @@ if detect_result.detected:
 else:
     print("No PX detected")
 
-# 或者一步到位
-if engine.detect_and_solve(page):
+# 手动检查并求解（不等待）
+if engine.check_and_solve(page):
     print("PX solved!")
 ```
 
@@ -198,6 +210,8 @@ engine.register_handler(MySiteHandler())
 | `hold_min` | `3.8` | 最短按住时间(秒) |
 | `hold_max` | `6.5` | 最长按住时间(秒) |
 | `post_wait` | `30.0` | 松开后等待 UI 消失(秒) |
+| `ui_wait_timeout` | `45.0` | 首次检测时等待 PX UI 出现的超时(秒) |
 | `button_wait_timeout` | `20.0` | 等待按钮出现超时(秒) |
+| `monitor_interval` | `1.5` | 后台监控轮询间隔(秒)，越小检测越快但 CPU 略高 |
 | `reload_if_hidden` | `True` | PX 未显示时是否刷新页面 |
 | `checker` | `None` | 可选验证回调 `(page) → bool` |

--- a/cloakbrowser/pxbypass/README.md
+++ b/cloakbrowser/pxbypass/README.md
@@ -1,0 +1,203 @@
+# PxEngine: PerimeterX 验证码自动求解引擎
+
+`pxbypass` 是 CloakBrowser 的 PerimeterX (PX) 验证码自动求解模块。采用类层次架构，支持多种检测策略和求解策略的灵活组合。
+
+## 目录结构
+
+```
+pxbypass/
+├── README.md              ← 本文档
+├── __init__.py            ← 对外 API（patch_browser, detect_px, solve_px, PxEngine）
+├── config.py              ← PxConfig 配置类
+│
+├── engine.py              ← PxEngine: 自动识别PX类型 → 调度求解流程
+│
+├── detector.py            ← （旧版）向后兼容的单文件 detector
+├── solver.py              ← （旧版）向后兼容的单文件 solver
+│
+├── detect/                ← 检测策略（每个策略一个类）
+│   ├── __init__.py
+│   ├── base.py            ← BaseDetector (ABC) + DetectResult
+│   ├── keyword.py         ← DetectPxByKeyword: 页面文本关键词扫描
+│   ├── dom_element.py     ← DetectPxByDomElement: DOM 元素检查
+│   ├── script_src.py      ← DetectPxByScriptSrc: 脚本 URL 检查
+│   ├── url_pattern.py     ← DetectPxByUrlPattern: URL 模式匹配
+│   ├── globals.py         ← DetectPxByGlobals: JS 全局变量检查
+│   └── composite.py       ← CompositeDetector + DetectMode
+│
+├── solve/                 ← 求解策略（每个策略一个类）
+│   ├── __init__.py
+│   ├── base.py            ← BaseSolver (ABC) + SolveResult + HoldTarget
+│   ├── press_hold_button.py   ← SolveByHoldButton: 文本定位 → 按住
+│   ├── press_hold_container.py ← SolveByHoldContainer: 容器定位 → 按住
+│   └── composite.py       ← CompositeSolver: 按优先级尝试多个求解器
+│
+└── site/                  ← 网站专属配置（组合检测器+求解器）
+    ├── __init__.py
+    ├── base.py            ← SiteHandler (ABC)
+    ├── walmart.py         ← WalmartHandler: 3种检测 + 2种求解
+    └── ifood.py           ← IfoodHandler: 2种检测 + 1种求解
+```
+
+## 快速使用
+
+```python
+from cloakbrowser import launch
+
+# 加一个参数即可
+browser = launch(bypass_px=True)
+page = browser.new_page()
+page.goto("https://target-with-px.com")
+# 遇到 PX 挑战会自动检测并求解
+```
+
+## PxEngine 高级用法
+
+```python
+from cloakbrowser.pxbypass import PxEngine, PxConfig
+from cloakbrowser.pxbypass.site import WalmartHandler, IfoodHandler
+
+# 创建引擎
+engine = PxEngine(PxConfig(
+    max_attempts=5,
+    hold_min=3.5,
+    hold_max=6.0,
+    post_wait=30.0,
+))
+
+# 注册网站处理器（优先级高的先匹配）
+engine.register_handler(WalmartHandler())  # priority=10
+engine.register_handler(IfoodHandler())    # priority=10
+
+# detect → solve 两步
+handler, detect_result = engine.detect(page)
+if detect_result.detected:
+    solve_result = engine.solve(page, handler, detect_result)
+    print(f"{'Solved' if solve_result.solved else 'Failed'} via {solve_result.method}"
+          f" ({solve_result.attempts} attempts, {solve_result.duration:.1f}s)")
+else:
+    print("No PX detected")
+
+# 或者一步到位
+if engine.detect_and_solve(page):
+    print("PX solved!")
+```
+
+## 扩展指南
+
+### 添加新的检测方式
+
+新建一个类，继承 `BaseDetector`，实现 `detect(page) → DetectResult`：
+
+```python
+# pxbypass/detect/shadow_dom.py
+from .base import BaseDetector, DetectResult
+
+class DetectPxByShadowDom(BaseDetector):
+    """检测 PX 是否藏在 shadow DOM 中."""
+
+    def detect(self, page) -> DetectResult:
+        found = page.evaluate("""() => {
+            const hosts = [];
+            document.querySelectorAll('*').forEach(el => {
+                if (el.shadowRoot && el.shadowRoot.querySelector('#px-captcha'))
+                    hosts.push(el.tagName);
+            });
+            return hosts;
+        }""")
+        if found:
+            return DetectResult(
+                detected=True,
+                confidence=0.8,
+                evidence={"shadow_hosts": found},
+            )
+        return DetectResult()
+```
+
+然后在 site handler 中组合使用：
+
+```python
+from ..detect.shadow_dom import DetectPxByShadowDom
+
+class MySiteHandler(SiteHandler):
+    def build_detector(self):
+        return CompositeDetector([
+            DetectPxByKeyword(["key phrase"]),
+            DetectPxByShadowDom(),  # ← 新增
+        ])
+```
+
+### 添加新的求解方式
+
+```python
+# pxbypass/solve/custom_solver.py
+from .base import BaseSolver, SolveResult, HoldTarget
+
+class SolveByCustom(BaseSolver):
+    def solve(self, page, cfg, detect_result=None) -> SolveResult:
+        # 自定义求解逻辑
+        return SolveResult(solved=True, method="SolveByCustom")
+```
+
+### 添加新的网站
+
+```python
+# pxbypass/site/mysite.py
+from ..detect.composite import CompositeDetector
+from ..detect.keyword import DetectPxByKeyword
+from ..solve.composite import CompositeSolver
+from ..solve.press_hold_button import SolveByHoldButton
+from .base import SiteHandler
+
+class MySiteHandler(SiteHandler):
+    name = "mysite"
+    priority = 10  # 数值越大越优先
+
+    def build_detector(self):
+        return CompositeDetector([
+            DetectPxByKeyword(["press and hold", "verify you're human"]),
+        ])
+
+    def build_solver(self):
+        return CompositeSolver([
+            SolveByHoldButton(["Press and hold"]),
+            SolveByHoldContainer("#px-captcha"),
+        ])
+```
+
+注册即可使用：
+
+```python
+from cloakbrowser.pxbypass.site.mysite import MySiteHandler
+engine.register_handler(MySiteHandler())
+```
+
+## 检测策略参考
+
+| 策略类 | 检测方式 | 适用场景 | 典型置信度 |
+|--------|----------|----------|:---:|
+| `DetectPxByKeyword` | 页面文本关键词 | 所有 PX 变体 | 0.5~0.9 |
+| `DetectPxByDomElement` | DOM 元素选择器 | 有 #px-captcha 等元素 | 0.85 |
+| `DetectPxByScriptSrc` | 页面脚本 URL | Cloud 版本 PX | 0.75~0.9 |
+| `DetectPxByUrlPattern` | 当前页面 URL | 路径含 /blocked 等 | 0.7 |
+| `DetectPxByGlobals` | JS 全局变量 | PX SDK 已加载 | 0.6 |
+
+## 求解策略参考
+
+| 策略类 | 求解方式 | 适用场景 |
+|--------|----------|----------|
+| `SolveByHoldButton` | 文本定位按钮 → 贝塞尔曲线移动 → 按住 3~6秒 | iframe modal 变体 (iFood) |
+| `SolveByHoldContainer` | 容器位置定位 → 模拟按住 | 跨域 cloud 变体 (Walmart) |
+
+## PxConfig 参数
+
+| 参数 | 默认值 | 说明 |
+|------|:---:|------|
+| `enabled` | `True` | 是否启用自动求解 |
+| `max_attempts` | `3` | 最大尝试次数 |
+| `hold_min` | `3.8` | 最短按住时间(秒) |
+| `hold_max` | `6.5` | 最长按住时间(秒) |
+| `post_wait` | `30.0` | 松开后等待 UI 消失(秒) |
+| `button_wait_timeout` | `20.0` | 等待按钮出现超时(秒) |
+| `reload_if_hidden` | `True` | PX 未显示时是否刷新页面 |
+| `checker` | `None` | 可选验证回调 `(page) → bool` |

--- a/cloakbrowser/pxbypass/__init__.py
+++ b/cloakbrowser/pxbypass/__init__.py
@@ -2,7 +2,10 @@
 
 Activated via bypass_px=True in launch() / launch_async().
 Automatically detects and solves PerimeterX "Press & Hold" challenges
-during page navigation, similar to how humanize patches browser interactions.
+on ALL pages in the browser, regardless of how navigation happens.
+
+Background monitoring starts as soon as a page is created and continuously
+polls the page for PX UI. When detected, it solves automatically.
 
 Architecture:
     - detect/     : Individual detection strategies (keyword, DOM, script, URL, globals)
@@ -15,6 +18,7 @@ Usage:
     browser = launch(bypass_px=True)
     page = browser.new_page()
     page.goto("https://target-site.com")  # PX solved automatically if encountered
+    # Background monitor keeps watching — any PX that appears later is also solved.
 
 Advanced:
     from cloakbrowser.pxbypass import PxEngine
@@ -111,6 +115,9 @@ def solve_px(page: Any, cfg: PxConfig | None = None) -> bool:
 def patch_browser(browser: Any, cfg: PxConfig | None = None) -> None:
     """Patch browser to auto-solve PX on new pages (sync).
 
+    Every page created from this browser (via new_page() or
+    context.new_page()) will have background PX monitoring enabled.
+
     Args:
         browser: Playwright Browser object.
         cfg: Optional PxConfig override.
@@ -146,6 +153,9 @@ def patch_browser(browser: Any, cfg: PxConfig | None = None) -> None:
 def patch_browser_async(browser: Any, cfg: PxConfig | None = None) -> None:
     """Patch browser to auto-solve PX on new pages (async).
 
+    Every page created from this browser (via new_page() or
+    context.new_page()) will have background PX monitoring enabled.
+
     Args:
         browser: Playwright Browser object (async API).
         cfg: Optional PxConfig override.
@@ -158,7 +168,7 @@ def patch_browser_async(browser: Any, cfg: PxConfig | None = None) -> None:
 
     async def _patched_new_page(**kwargs: Any) -> Any:
         page = await _original_new_page(**kwargs)
-        _patch_page_async(page, cfg)
+        await _patch_page_async(page, cfg)
         return page
 
     async def _patched_new_context(**kwargs: Any) -> Any:
@@ -167,7 +177,7 @@ def patch_browser_async(browser: Any, cfg: PxConfig | None = None) -> None:
 
         async def _patched_cx_new_page(**pk: Any) -> Any:
             page = await _original_cx_page(**pk)
-            _patch_page_async(page, cfg)
+            await _patch_page_async(page, cfg)
             return page
 
         context.new_page = _patched_cx_new_page
@@ -179,7 +189,7 @@ def patch_browser_async(browser: Any, cfg: PxConfig | None = None) -> None:
 
 
 def patch_page(page: Any, cfg: PxConfig) -> None:
-    """Patch page.goto() to auto-solve PX on navigation (sync).
+    """Patch a single page to auto-solve PX (sync).
 
     Args:
         page: Playwright Page object.
@@ -189,7 +199,7 @@ def patch_page(page: Any, cfg: PxConfig) -> None:
 
 
 def patch_page_async(page: Any, cfg: PxConfig) -> None:
-    """Patch page.goto() to auto-solve PX on navigation (async).
+    """Patch a single page to auto-solve PX (async).
 
     Args:
         page: Playwright Page object (async API).
@@ -204,40 +214,60 @@ def patch_page_async(page: Any, cfg: PxConfig) -> None:
 
 
 def _patch_page(page: Any, cfg: PxConfig) -> None:
-    """Internal: patch page for sync API."""
+    """Internal: patch page for sync API.
+
+    Starts background PX monitoring immediately and patches goto()
+    for an early detection attempt after navigation.
+    """
     engine = _get_engine(cfg)
+    page._px_cfg = cfg
+
+    # Start background monitoring thread — polls for PX continuously
+    engine.start_monitoring(page)
+
+    # Also patch goto() for a quick initial detection after navigation
     _original_goto = page.goto
 
     def _patched_goto(url: str, **kwargs: Any) -> Any:
         response = _original_goto(url, **kwargs)
         if cfg.enabled:
+            # Quick check right after navigation
             try:
-                engine.detect_and_solve(page)
+                engine.check_and_solve(page)
             except Exception as exc:
                 logger.debug("PX solve failed (non-fatal): %s", exc)
         return response
 
     page.goto = _patched_goto
-    page._px_cfg = cfg
     logger.debug("PX bypass patched on page (sync)")
 
 
-def _patch_page_async(page: Any, cfg: PxConfig) -> None:
-    """Internal: patch page for async API."""
+async def _patch_page_async(page: Any, cfg: PxConfig) -> None:
+    """Internal: patch page for async API.
+
+    Starts background PX monitoring immediately and patches goto()
+    for an early detection attempt after navigation.
+    """
     engine = _get_engine(cfg)
+    page._px_cfg = cfg
+
+    # Start background monitoring asyncio task — polls for PX continuously
+    await engine.start_monitoring_async(page)
+
+    # Also patch goto() for a quick initial detection after navigation
     _original_goto = page.goto
 
     async def _patched_goto(url: str, **kwargs: Any) -> Any:
         response = await _original_goto(url, **kwargs)
         if cfg.enabled:
+            # Quick check right after navigation
             try:
-                engine.detect_and_solve(page)
+                await engine.check_and_solve_async(page)
             except Exception as exc:
                 logger.debug("PX solve failed (non-fatal): %s", exc)
         return response
 
     page.goto = _patched_goto
-    page._px_cfg = cfg
     logger.debug("PX bypass patched on page (async)")
 
 

--- a/cloakbrowser/pxbypass/__init__.py
+++ b/cloakbrowser/pxbypass/__init__.py
@@ -216,14 +216,18 @@ def patch_page_async(page: Any, cfg: PxConfig) -> None:
 def _patch_page(page: Any, cfg: PxConfig) -> None:
     """Internal: patch page for sync API.
 
-    Starts background PX monitoring immediately and patches goto()
-    for an early detection attempt after navigation.
+    Injects a MutationObserver into the page that watches for
+    PX challenge elements. When detected, fires a Python callback
+    that runs detection and solving — all on the main thread.
+
+    Also patches goto() for a quick initial detection after navigation.
     """
     engine = _get_engine(cfg)
     page._px_cfg = cfg
 
-    # Start background monitoring thread — polls for PX continuously
-    engine.start_monitoring(page)
+    # Inject JS MutationObserver — watches DOM for PX elements,
+    # calls back to Python via page.expose_binding
+    engine.install_observer(page)
 
     # Also patch goto() for a quick initial detection after navigation
     _original_goto = page.goto
@@ -245,14 +249,17 @@ def _patch_page(page: Any, cfg: PxConfig) -> None:
 async def _patch_page_async(page: Any, cfg: PxConfig) -> None:
     """Internal: patch page for async API.
 
-    Starts background PX monitoring immediately and patches goto()
-    for an early detection attempt after navigation.
+    Injects MutationObserver + patches goto().
+
+    Args:
+        page: Playwright Page object (async API).
+        cfg: PxConfig instance.
     """
     engine = _get_engine(cfg)
     page._px_cfg = cfg
 
-    # Start background monitoring asyncio task — polls for PX continuously
-    await engine.start_monitoring_async(page)
+    # Inject JS MutationObserver — async variant
+    await engine.install_observer_async(page)
 
     # Also patch goto() for a quick initial detection after navigation
     _original_goto = page.goto
@@ -260,7 +267,6 @@ async def _patch_page_async(page: Any, cfg: PxConfig) -> None:
     async def _patched_goto(url: str, **kwargs: Any) -> Any:
         response = await _original_goto(url, **kwargs)
         if cfg.enabled:
-            # Quick check right after navigation
             try:
                 await engine.check_and_solve_async(page)
             except Exception as exc:

--- a/cloakbrowser/pxbypass/__init__.py
+++ b/cloakbrowser/pxbypass/__init__.py
@@ -1,0 +1,259 @@
+"""PerimeterX (PX) Captcha auto-solver for cloakbrowser.
+
+Activated via bypass_px=True in launch() / launch_async().
+Automatically detects and solves PerimeterX "Press & Hold" challenges
+during page navigation, similar to how humanize patches browser interactions.
+
+Architecture:
+    - detect/     : Individual detection strategies (keyword, DOM, script, URL, globals)
+    - solve/      : Individual solving strategies (hold button, hold container)
+    - site/       : Site-specific handler configurations (Walmart, iFood)
+    - engine.py   : PxEngine orchestrates detect → solve pipeline
+
+Usage:
+    from cloakbrowser import launch
+    browser = launch(bypass_px=True)
+    page = browser.new_page()
+    page.goto("https://target-site.com")  # PX solved automatically if encountered
+
+Advanced:
+    from cloakbrowser.pxbypass import PxEngine
+    from cloakbrowser.pxbypass.config import PxConfig
+    from cloakbrowser.pxbypass.site import WalmartHandler
+
+    engine = PxEngine(PxConfig(max_attempts=5))
+    engine.register_handler(WalmartHandler())
+
+    handler, result = engine.detect(page)
+    if result.detected:
+        engine.solve(page, handler, result)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .engine import PxEngine
+from .config import PxConfig
+from .detect.base import DetectResult
+from .solve.base import SolveResult
+from .detect import (
+    BaseDetector, DetectPxByKeyword, DetectPxByDomElement,
+    DetectPxByScriptSrc, DetectPxByUrlPattern, DetectPxByGlobals,
+    CompositeDetector, DetectMode,
+)
+from .solve import (
+    BaseSolver, SolveByHoldButton, SolveByHoldContainer, CompositeSolver,
+)
+from .site import SiteHandler, WalmartHandler, IfoodHandler
+
+logger = logging.getLogger("cloakbrowser.pxbypass")
+
+# Default engine instance for quick use
+_default_engine: PxEngine | None = None
+
+
+def _get_engine(cfg: PxConfig | None = None) -> PxEngine:
+    """Get or create the default PxEngine singleton."""
+    global _default_engine
+    if _default_engine is None or cfg is not None:
+        engine = PxEngine(cfg or PxConfig())
+        if not engine._site_handlers:  # Only register if empty
+            engine.register_handler(WalmartHandler())
+            engine.register_handler(IfoodHandler())
+        if cfg is None:
+            _default_engine = engine
+        return engine
+    return _default_engine
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatible public API (same signatures as original detector.py)
+# ---------------------------------------------------------------------------
+
+
+def detect_px(page: Any) -> str | None:
+    """Detect if the current page has a PerimeterX challenge.
+
+    Args:
+        page: Playwright Page object.
+
+    Returns:
+        'perimeterx' if PX challenge is detected, None otherwise.
+    """
+    engine = _get_engine()
+    handler, result = engine.detect(page)
+    if result.detected:
+        logger.debug("PX detected via %s (confidence=%.2f)",
+                     handler.name if handler else "generic", result.confidence)
+        return "perimeterx"
+    return None
+
+
+def solve_px(page: Any, cfg: PxConfig | None = None) -> bool:
+    """Try to solve a PX challenge on the current page.
+
+    Args:
+        page: Playwright Page object.
+        cfg: Optional PxConfig override.
+
+    Returns:
+        True if solved, False if failed.
+    """
+    engine = _get_engine(cfg)
+    handler, result = engine.detect(page)
+    if not result.detected:
+        return True  # No PX to solve
+    return engine.solve(page, handler, result).solved
+
+
+def patch_browser(browser: Any, cfg: PxConfig | None = None) -> None:
+    """Patch browser to auto-solve PX on new pages (sync).
+
+    Args:
+        browser: Playwright Browser object.
+        cfg: Optional PxConfig override.
+    """
+    if cfg is None:
+        cfg = PxConfig()
+
+    _original_new_page = browser.new_page
+    _original_new_context = browser.new_context
+
+    def _patched_new_page(**kwargs: Any) -> Any:
+        page = _original_new_page(**kwargs)
+        _patch_page(page, cfg)
+        return page
+
+    def _patched_new_context(**kwargs: Any) -> Any:
+        context = _original_new_context(**kwargs)
+        _original_cx_page = context.new_page
+
+        def _patched_cx_new_page(**pk: Any) -> Any:
+            page = _original_cx_page(**pk)
+            _patch_page(page, cfg)
+            return page
+
+        context.new_page = _patched_cx_new_page
+        return context
+
+    browser.new_page = _patched_new_page
+    browser.new_context = _patched_new_context
+    logger.debug("PX bypass patched on browser (sync)")
+
+
+def patch_browser_async(browser: Any, cfg: PxConfig | None = None) -> None:
+    """Patch browser to auto-solve PX on new pages (async).
+
+    Args:
+        browser: Playwright Browser object (async API).
+        cfg: Optional PxConfig override.
+    """
+    if cfg is None:
+        cfg = PxConfig()
+
+    _original_new_page = browser.new_page
+    _original_new_context = browser.new_context
+
+    async def _patched_new_page(**kwargs: Any) -> Any:
+        page = await _original_new_page(**kwargs)
+        _patch_page_async(page, cfg)
+        return page
+
+    async def _patched_new_context(**kwargs: Any) -> Any:
+        context = await _original_new_context(**kwargs)
+        _original_cx_page = context.new_page
+
+        async def _patched_cx_new_page(**pk: Any) -> Any:
+            page = await _original_cx_page(**pk)
+            _patch_page_async(page, cfg)
+            return page
+
+        context.new_page = _patched_cx_new_page
+        return context
+
+    browser.new_page = _patched_new_page
+    browser.new_context = _patched_new_context
+    logger.debug("PX bypass patched on browser (async)")
+
+
+def patch_page(page: Any, cfg: PxConfig) -> None:
+    """Patch page.goto() to auto-solve PX on navigation (sync).
+
+    Args:
+        page: Playwright Page object.
+        cfg: PxConfig instance.
+    """
+    _patch_page(page, cfg)
+
+
+def patch_page_async(page: Any, cfg: PxConfig) -> None:
+    """Patch page.goto() to auto-solve PX on navigation (async).
+
+    Args:
+        page: Playwright Page object (async API).
+        cfg: PxConfig instance.
+    """
+    _patch_page_async(page, cfg)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _patch_page(page: Any, cfg: PxConfig) -> None:
+    """Internal: patch page for sync API."""
+    engine = _get_engine(cfg)
+    _original_goto = page.goto
+
+    def _patched_goto(url: str, **kwargs: Any) -> Any:
+        response = _original_goto(url, **kwargs)
+        if cfg.enabled:
+            try:
+                engine.detect_and_solve(page)
+            except Exception as exc:
+                logger.debug("PX solve failed (non-fatal): %s", exc)
+        return response
+
+    page.goto = _patched_goto
+    page._px_cfg = cfg
+    logger.debug("PX bypass patched on page (sync)")
+
+
+def _patch_page_async(page: Any, cfg: PxConfig) -> None:
+    """Internal: patch page for async API."""
+    engine = _get_engine(cfg)
+    _original_goto = page.goto
+
+    async def _patched_goto(url: str, **kwargs: Any) -> Any:
+        response = await _original_goto(url, **kwargs)
+        if cfg.enabled:
+            try:
+                engine.detect_and_solve(page)
+            except Exception as exc:
+                logger.debug("PX solve failed (non-fatal): %s", exc)
+        return response
+
+    page.goto = _patched_goto
+    page._px_cfg = cfg
+    logger.debug("PX bypass patched on page (async)")
+
+
+__all__ = [
+    # Core
+    "PxEngine", "PxConfig", "DetectResult", "SolveResult",
+    # Detection
+    "BaseDetector", "DetectPxByKeyword", "DetectPxByDomElement",
+    "DetectPxByScriptSrc", "DetectPxByUrlPattern", "DetectPxByGlobals",
+    "CompositeDetector", "DetectMode",
+    # Solving
+    "BaseSolver", "SolveByHoldButton", "SolveByHoldContainer", "CompositeSolver",
+    # Sites
+    "SiteHandler", "WalmartHandler", "IfoodHandler",
+    # Backward compat
+    "detect_px", "solve_px",
+    "patch_browser", "patch_browser_async",
+    "patch_page", "patch_page_async",
+]

--- a/cloakbrowser/pxbypass/__init__.py
+++ b/cloakbrowser/pxbypass/__init__.py
@@ -35,10 +35,12 @@ Advanced:
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 from typing import Any
 
-from .engine import PxEngine
+from .engine import PxEngine, _patch_methods_for_px_polling
 from .config import PxConfig
 from .detect.base import DetectResult
 from .solve.base import SolveResult
@@ -198,14 +200,14 @@ def patch_page(page: Any, cfg: PxConfig) -> None:
     _patch_page(page, cfg)
 
 
-def patch_page_async(page: Any, cfg: PxConfig) -> None:
+async def patch_page_async(page: Any, cfg: PxConfig) -> None:
     """Patch a single page to auto-solve PX (async).
 
     Args:
         page: Playwright Page object (async API).
         cfg: PxConfig instance.
     """
-    _patch_page_async(page, cfg)
+    await _patch_page_async(page, cfg)
 
 
 # ---------------------------------------------------------------------------
@@ -221,13 +223,27 @@ def _patch_page(page: Any, cfg: PxConfig) -> None:
     that runs detection and solving — all on the main thread.
 
     Also patches goto() for a quick initial detection after navigation.
+
+    NOTE: Playwright's sync API uses greenlets and is NOT thread-safe.
+    We do NOT start a background thread for polling. Instead we rely on:
+    - MutationObserver JS (with JS-side setInterval polling every 1.5s)
+    - goto() patch for immediate post-navigation check
+    - load event handler with delayed checks (3s, 10s)
+    - frameattached handler for dynamically injected iframes
     """
+    if getattr(page, '_px_patched', False):
+        return
+    page._px_patched = True
+
     engine = _get_engine(cfg)
     page._px_cfg = cfg
 
-    # Inject JS MutationObserver — watches DOM for PX elements,
-    # calls back to Python via page.expose_binding
+    # Inject JS MutationObserver — watches DOM for PX elements
     engine.install_observer(page)
+    # Make the sync API poll on ordinary Playwright calls immediately. Waiting
+    # for a later load callback can miss challenges already present when goto()
+    # returns (and leaves wait_for_px_solved unavailable to the caller).
+    _patch_methods_for_px_polling(page, engine)
 
     # Also patch goto() for a quick initial detection after navigation
     _original_goto = page.goto
@@ -235,26 +251,30 @@ def _patch_page(page: Any, cfg: PxConfig) -> None:
     def _patched_goto(url: str, **kwargs: Any) -> Any:
         response = _original_goto(url, **kwargs)
         if cfg.enabled:
-            # Quick check right after navigation
             try:
-                engine.check_and_solve(page)
+                engine._on_page_load(page)
             except Exception as exc:
-                logger.debug("PX solve failed (non-fatal): %s", exc)
+                logger.debug("PX navigate check failed (non-fatal): %s", exc)
         return response
 
     page.goto = _patched_goto
+
     logger.debug("PX bypass patched on page (sync)")
 
 
 async def _patch_page_async(page: Any, cfg: PxConfig) -> None:
     """Internal: patch page for async API.
 
-    Injects MutationObserver + patches goto().
+    Injects MutationObserver + patches goto() + starts background monitor.
 
     Args:
         page: Playwright Page object (async API).
         cfg: PxConfig instance.
     """
+    if getattr(page, '_px_patched', False):
+        return
+    page._px_patched = True
+
     engine = _get_engine(cfg)
     page._px_cfg = cfg
 
@@ -268,13 +288,61 @@ async def _patch_page_async(page: Any, cfg: PxConfig) -> None:
         response = await _original_goto(url, **kwargs)
         if cfg.enabled:
             try:
-                await engine.check_and_solve_async(page)
+                await engine._on_page_load_async(page)
             except Exception as exc:
-                logger.debug("PX solve failed (non-fatal): %s", exc)
+                logger.debug("PX navigate check failed (non-fatal): %s", exc)
         return response
 
     page.goto = _patched_goto
-    logger.debug("PX bypass patched on page (async)")
+
+    # Start background monitoring asyncio task (same event loop — thread-safe)
+    _start_bg_monitor_async(page, engine, cfg)
+
+    logger.debug("PX bypass patched on page (async) with background monitor")
+
+
+# ---------------------------------------------------------------------------
+# Background monitoring (async only — sync API relies on JS-side setInterval)
+# ---------------------------------------------------------------------------
+
+
+def _start_bg_monitor_async(page: Any, engine: PxEngine, cfg: PxConfig) -> None:
+    """Start an asyncio background task that periodically polls for PX.
+
+    Only call this from async API — runs in the same event loop as Playwright,
+    so it is thread-safe.
+    """
+    if getattr(page, '_px_bg_monitor_started', False):
+        return
+    page._px_bg_monitor_started = True
+    page._px_bg_closed = False
+
+    async def _monitor_loop() -> None:
+        while not getattr(page, '_px_bg_closed', False):
+            try:
+                # Check if page is still alive
+                try:
+                    await page.evaluate("1+1")
+                except Exception:
+                    page._px_bg_closed = True
+                    break
+
+                if cfg.enabled:
+                    await engine.check_and_solve_async(page)
+            except Exception:
+                pass
+            await asyncio.sleep(cfg.monitor_interval)
+
+    asyncio.ensure_future(_monitor_loop())
+
+    # Patch page.close to stop the monitor
+    _orig_close = page.close
+
+    async def _patched_close(*args: Any, **kwargs: Any) -> Any:
+        page._px_bg_closed = True
+        return await _orig_close(*args, **kwargs)
+
+    page.close = _patched_close
 
 
 __all__ = [

--- a/cloakbrowser/pxbypass/config.py
+++ b/cloakbrowser/pxbypass/config.py
@@ -11,6 +11,7 @@ DEFAULT_MAX_ATTEMPTS = 3
 DEFAULT_HOLD_MIN = 3.8
 DEFAULT_HOLD_MAX = 6.5
 DEFAULT_POST_WAIT = 30.0
+DEFAULT_MONITOR_INTERVAL = 1.5
 PX_UI_WAIT_TIMEOUT = 45.0
 PX_BUTTON_WAIT_TIMEOUT = 20.0
 PX_POST_INJECT_WAIT = 25.0
@@ -29,6 +30,9 @@ class PxConfig:
         post_wait: Seconds to wait after mouse up for PX to clear.
         ui_wait_timeout: Max seconds to wait for PX UI to appear.
         button_wait_timeout: Max seconds to wait for hold button to render.
+        monitor_interval: Seconds between background PX checks (default 1.5).
+            The background monitor runs in a daemon thread and polls the page
+            at this interval. Lower = faster detection, higher = less CPU.
         reload_if_hidden: Whether to reload page if PX UI doesn't appear.
         debug_capture: Save DOM probe snapshots for debugging.
         checker: Optional callable to verify the page is usable after PX solve.
@@ -43,6 +47,7 @@ class PxConfig:
     post_wait: float = DEFAULT_POST_WAIT
     ui_wait_timeout: float = PX_UI_WAIT_TIMEOUT
     button_wait_timeout: float = PX_BUTTON_WAIT_TIMEOUT
+    monitor_interval: float = DEFAULT_MONITOR_INTERVAL
     post_inject_wait: float = PX_POST_INJECT_WAIT
     app_ready_timeout: float = PX_APP_READY_TIMEOUT
     reload_if_hidden: bool = True
@@ -56,6 +61,7 @@ class PXConfigDefaults:
     HOLD_MIN = DEFAULT_HOLD_MIN
     HOLD_MAX = DEFAULT_HOLD_MAX
     POST_WAIT = DEFAULT_POST_WAIT
+    MONITOR_INTERVAL = DEFAULT_MONITOR_INTERVAL
     UI_WAIT_TIMEOUT = PX_UI_WAIT_TIMEOUT
     BUTTON_WAIT_TIMEOUT = PX_BUTTON_WAIT_TIMEOUT
     POST_INJECT_WAIT = PX_POST_INJECT_WAIT

--- a/cloakbrowser/pxbypass/config.py
+++ b/cloakbrowser/pxbypass/config.py
@@ -1,0 +1,87 @@
+"""Configuration for PerimeterX challenge auto-solving."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+# Default parameters for PerimeterX "Press & Hold" solving
+DEFAULT_MAX_ATTEMPTS = 3
+DEFAULT_HOLD_MIN = 3.8
+DEFAULT_HOLD_MAX = 6.5
+DEFAULT_POST_WAIT = 30.0
+PX_UI_WAIT_TIMEOUT = 45.0
+PX_BUTTON_WAIT_TIMEOUT = 20.0
+PX_POST_INJECT_WAIT = 25.0
+PX_APP_READY_TIMEOUT = 60.0
+
+
+@dataclass
+class PxConfig:
+    """Configuration for PerimeterX challenge auto-solving.
+
+    Attributes:
+        enabled: Set to False to disable auto-solving (useful toggling).
+        max_attempts: Maximum number of press-and-hold attempts before giving up.
+        hold_min: Minimum hold duration in seconds.
+        hold_max: Maximum hold duration in seconds.
+        post_wait: Seconds to wait after mouse up for PX to clear.
+        ui_wait_timeout: Max seconds to wait for PX UI to appear.
+        button_wait_timeout: Max seconds to wait for hold button to render.
+        reload_if_hidden: Whether to reload page if PX UI doesn't appear.
+        debug_capture: Save DOM probe snapshots for debugging.
+        checker: Optional callable to verify the page is usable after PX solve.
+            Called as checker(page) -> bool. If provided, the solver will
+            wait until this returns True (with a timeout).
+        webrtc_ip: Optional WebRTC IP to spoof during the solve process.
+    """
+    enabled: bool = True
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS
+    hold_min: float = DEFAULT_HOLD_MIN
+    hold_max: float = DEFAULT_HOLD_MAX
+    post_wait: float = DEFAULT_POST_WAIT
+    ui_wait_timeout: float = PX_UI_WAIT_TIMEOUT
+    button_wait_timeout: float = PX_BUTTON_WAIT_TIMEOUT
+    post_inject_wait: float = PX_POST_INJECT_WAIT
+    app_ready_timeout: float = PX_APP_READY_TIMEOUT
+    reload_if_hidden: bool = True
+    debug_capture: bool = False
+    checker: Any = None  # Optional callable(page) -> bool
+
+
+class PXConfigDefaults:
+    """Read-only namespace of default PX config values for reference."""
+    MAX_ATTEMPTS = DEFAULT_MAX_ATTEMPTS
+    HOLD_MIN = DEFAULT_HOLD_MIN
+    HOLD_MAX = DEFAULT_HOLD_MAX
+    POST_WAIT = DEFAULT_POST_WAIT
+    UI_WAIT_TIMEOUT = PX_UI_WAIT_TIMEOUT
+    BUTTON_WAIT_TIMEOUT = PX_BUTTON_WAIT_TIMEOUT
+    POST_INJECT_WAIT = PX_POST_INJECT_WAIT
+    APP_READY_TIMEOUT = PX_APP_READY_TIMEOUT
+
+
+# Text markers used to identify PerimeterX challenge pages
+PX_TEXT_MARKERS = (
+    "pressione e segure",
+    "press and hold",
+    "press & hold",
+    "activate and hold",
+    "antes de continuarmos",
+    "confirmar que você é um humano",
+    "px-captcha",
+    "robot or human",
+)
+
+# Short button labels (not instruction paragraphs)
+PX_HOLD_BUTTON_LABELS = (
+    "Pressione e segure",
+    "Press and hold",
+    "Press & hold",
+    "Activate and hold",
+)
+
+# Walmart-specific PX iframe selector
+PX_IFRAME_SELECTOR = "#px-captcha iframe"
+PX_CAPTCHA_CONTAINER = "#px-captcha"

--- a/cloakbrowser/pxbypass/detect/__init__.py
+++ b/cloakbrowser/pxbypass/detect/__init__.py
@@ -1,0 +1,15 @@
+"""Detection strategies for PerimeterX challenges."""
+from .base import BaseDetector, DetectResult
+from .keyword import DetectPxByKeyword
+from .dom_element import DetectPxByDomElement
+from .script_src import DetectPxByScriptSrc
+from .url_pattern import DetectPxByUrlPattern
+from .globals import DetectPxByGlobals
+from .composite import CompositeDetector, DetectMode
+
+__all__ = [
+    "BaseDetector", "DetectResult",
+    "DetectPxByKeyword", "DetectPxByDomElement", "DetectPxByScriptSrc",
+    "DetectPxByUrlPattern", "DetectPxByGlobals",
+    "CompositeDetector", "DetectMode",
+]

--- a/cloakbrowser/pxbypass/detect/base.py
+++ b/cloakbrowser/pxbypass/detect/base.py
@@ -37,3 +37,7 @@ class BaseDetector:
             DetectResult with detection status and evidence.
         """
         raise NotImplementedError
+
+    async def detect_async(self, page: Any) -> DetectResult:
+        """Async Playwright variant of :meth:`detect`."""
+        raise NotImplementedError

--- a/cloakbrowser/pxbypass/detect/base.py
+++ b/cloakbrowser/pxbypass/detect/base.py
@@ -1,0 +1,39 @@
+"""Base detector class and detection result."""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class DetectResult:
+    """Result from a detection strategy.
+
+    Attributes:
+        detected: Whether the PX challenge was detected.
+        confidence: Detection confidence score (0.0 - 1.0).
+        px_type: Type of PX detected ('perimeterx' or site-specific).
+        evidence: Optional data supporting the detection (e.g. matched text).
+    """
+    detected: bool = False
+    confidence: float = 0.0
+    px_type: str = "perimeterx"
+    evidence: dict | None = None
+
+
+class BaseDetector:
+    """Abstract base class for PX detection strategies.
+
+    Each subclass implements a single detection method (keyword scan,
+    DOM element check, script URL check, etc.).
+    """
+
+    def detect(self, page: Any) -> DetectResult:
+        """Run this detection strategy on the page.
+
+        Args:
+            page: Playwright Page object (sync or async compatible).
+
+        Returns:
+            DetectResult with detection status and evidence.
+        """
+        raise NotImplementedError

--- a/cloakbrowser/pxbypass/detect/composite.py
+++ b/cloakbrowser/pxbypass/detect/composite.py
@@ -1,0 +1,78 @@
+"""Composite detector that runs multiple sub-detectors."""
+from __future__ import annotations
+from enum import Enum
+from typing import Any
+from .base import BaseDetector, DetectResult
+
+class DetectMode(Enum):
+    """How sub-detector results are combined."""
+    ANY = "any"       # At least one detector hits
+    ALL = "all"       # All detectors must hit
+    WEIGHTED = "weighted"  # Weighted confidence average
+
+
+class CompositeDetector(BaseDetector):
+    """Run multiple detection strategies and combine results.
+
+    Usage:
+        detector = CompositeDetector([
+            DetectPxByKeyword(["robot or human"]),
+            DetectPxByDomElement(["#px-captcha"]),
+            DetectPxByScriptSrc(["px-cloud.net"]),
+        ], mode=DetectMode.ANY)
+    """
+
+    def __init__(
+        self,
+        detectors: list[BaseDetector],
+        mode: DetectMode = DetectMode.ANY,
+        min_confidence: float = 0.3,
+    ):
+        """
+        Args:
+            detectors: List of detector instances.
+            mode: How to combine results.
+            min_confidence: Minimum confidence to consider a positive detection.
+        """
+        self.detectors = detectors
+        self.mode = mode
+        self.min_confidence = min_confidence
+
+    def detect(self, page: Any) -> DetectResult:
+        results = [d.detect(page) for d in self.detectors]
+        hits = [r for r in results if r.detected and r.confidence >= self.min_confidence]
+
+        if self.mode == DetectMode.ALL:
+            if len(hits) < len(self.detectors):
+                return DetectResult(
+                    confidence=max((r.confidence for r in hits), default=0.0),
+                    evidence={"partial_hits": [r.evidence for r in hits]},
+                )
+        elif self.mode == DetectMode.ANY:
+            if not hits:
+                return DetectResult()
+
+        # Weighted confidence: higher from more detectors
+        avg_conf = sum(r.confidence for r in hits) / len(hits) if hits else 0.0
+        count_bonus = min(len(hits) * 0.1, 0.2)
+        final_conf = min(avg_conf + count_bonus, 1.0)
+
+        # Collect evidence
+        evidence = {
+            "detectors": [
+                {
+                    "type": d.__class__.__name__,
+                    "result": r.detected,
+                    "confidence": r.confidence,
+                    "evidence": r.evidence,
+                }
+                for d, r in zip(self.detectors, results)
+            ]
+        }
+
+        return DetectResult(
+            detected=True,
+            confidence=final_conf,
+            px_type="perimeterx",
+            evidence=evidence,
+        )

--- a/cloakbrowser/pxbypass/detect/composite.py
+++ b/cloakbrowser/pxbypass/detect/composite.py
@@ -40,6 +40,13 @@ class CompositeDetector(BaseDetector):
 
     def detect(self, page: Any) -> DetectResult:
         results = [d.detect(page) for d in self.detectors]
+        return self._combine(results)
+
+    async def detect_async(self, page: Any) -> DetectResult:
+        results = [await detector.detect_async(page) for detector in self.detectors]
+        return self._combine(results)
+
+    def _combine(self, results: list[DetectResult]) -> DetectResult:
         hits = [r for r in results if r.detected and r.confidence >= self.min_confidence]
 
         if self.mode == DetectMode.ALL:

--- a/cloakbrowser/pxbypass/detect/dom_element.py
+++ b/cloakbrowser/pxbypass/detect/dom_element.py
@@ -1,0 +1,37 @@
+"""Detect PX by checking for specific DOM elements."""
+from __future__ import annotations
+from typing import Any
+from .base import BaseDetector, DetectResult
+
+# Common PX-related DOM elements
+PX_ELEMENT_SELECTORS = [
+    "#px-captcha",
+    "#px-captcha-modal",
+    ".re-captcha",
+    "[data-px-captcha]",
+    ".px-challenge",
+]
+
+class DetectPxByDomElement(BaseDetector):
+    """Detect PerimeterX by checking for known DOM element patterns."""
+    def __init__(self, selectors: list[str] | None = None):
+        self.selectors = selectors or PX_ELEMENT_SELECTORS
+
+    def detect(self, page: Any) -> DetectResult:
+        try:
+            found = []
+            for sel in self.selectors:
+                count = page.evaluate(
+                    "(sel) => document.querySelectorAll(sel).length", sel
+                )
+                if count and count > 0:
+                    found.append({"selector": sel, "count": count})
+            if not found:
+                return DetectResult()
+            return DetectResult(
+                detected=True,
+                confidence=0.85,
+                evidence={"elements_found": found},
+            )
+        except Exception as exc:
+            return DetectResult(evidence={"error": str(exc)})

--- a/cloakbrowser/pxbypass/detect/dom_element.py
+++ b/cloakbrowser/pxbypass/detect/dom_element.py
@@ -35,3 +35,22 @@ class DetectPxByDomElement(BaseDetector):
             )
         except Exception as exc:
             return DetectResult(evidence={"error": str(exc)})
+
+    async def detect_async(self, page: Any) -> DetectResult:
+        try:
+            found = []
+            for sel in self.selectors:
+                count = await page.evaluate(
+                    "(sel) => document.querySelectorAll(sel).length", sel
+                )
+                if count and count > 0:
+                    found.append({"selector": sel, "count": count})
+            if not found:
+                return DetectResult()
+            return DetectResult(
+                detected=True,
+                confidence=0.85,
+                evidence={"elements_found": found},
+            )
+        except Exception as exc:
+            return DetectResult(evidence={"error": str(exc)})

--- a/cloakbrowser/pxbypass/detect/globals.py
+++ b/cloakbrowser/pxbypass/detect/globals.py
@@ -1,0 +1,28 @@
+"""Detect PX by checking for JS global objects."""
+from __future__ import annotations
+from typing import Any
+from .base import BaseDetector, DetectResult
+
+PX_GLOBAL_KEYS = ["_px", "px_captcha", "PX", "PERIMETERX"]
+
+class DetectPxByGlobals(BaseDetector):
+    """Detect PerimeterX by checking for known global JS variables."""
+    def __init__(self, keys: list[str] | None = None):
+        self.keys = keys or PX_GLOBAL_KEYS
+
+    def detect(self, page: Any) -> DetectResult:
+        try:
+            found = []
+            for key in self.keys:
+                exists = page.evaluate("(k) => k in window", key)
+                if exists:
+                    found.append(key)
+            if not found:
+                return DetectResult()
+            return DetectResult(
+                detected=True,
+                confidence=0.6,
+                evidence={"globals_found": found},
+            )
+        except Exception as exc:
+            return DetectResult(evidence={"error": str(exc)})

--- a/cloakbrowser/pxbypass/detect/keyword.py
+++ b/cloakbrowser/pxbypass/detect/keyword.py
@@ -1,0 +1,69 @@
+"""Detect PX by scanning page body text for known keywords."""
+from __future__ import annotations
+from typing import Any
+from .base import BaseDetector, DetectResult
+
+# Default keyword sets for different PX variants
+PERIMETERX_KEYWORDS = [
+    "pressione e segure",
+    "press and hold",
+    "press & hold",
+    "activate and hold",
+    "antes de continuarmos",
+    "confirmar que você é um humano",
+    "robot or human",
+]
+
+# Keywords that strongly indicate an active PX challenge
+HIGH_CONFIDENCE_KEYWORDS = [
+    "activate and hold the button",
+    "pressione e segure o botão",
+    "press and hold the button",
+    "confirm that you're human",
+    "confirmar que você é um humano",
+]
+
+
+class DetectPxByKeyword(BaseDetector):
+    """Detect PerimeterX challenge by scanning page body text.
+
+    The body text often contains phrases like:
+    - "Activate and hold the button to confirm that you're human."
+    - "Robot or human?"
+    - "Pressione e segure o botão"
+    """
+
+    def __init__(self, keywords: list[str] | None = None):
+        """
+        Args:
+            keywords: Custom keyword list. Uses defaults if None.
+        """
+        self.keywords = keywords or PERIMETERX_KEYWORDS
+
+    def detect(self, page: Any) -> DetectResult:
+        """Scan page body text for PX-related keywords."""
+        try:
+            body = page.evaluate(
+                "() => (document.body ? document.body.innerText : '') || ''"
+            )
+            if not body:
+                return DetectResult()
+
+            body_lower = body.lower()
+            matches = [kw for kw in self.keywords if kw.lower() in body_lower]
+
+            if not matches:
+                return DetectResult()
+
+            # Check high-confidence matches
+            hc_matches = [kw for kw in HIGH_CONFIDENCE_KEYWORDS if kw.lower() in body_lower]
+            confidence = 0.9 if hc_matches else min(0.5 + len(matches) * 0.15, 0.85)
+
+            return DetectResult(
+                detected=True,
+                confidence=confidence,
+                px_type="perimeterx",
+                evidence={"keywords_matched": matches, "high_confidence": hc_matches or None},
+            )
+        except Exception as exc:
+            return DetectResult(evidence={"error": str(exc)})

--- a/cloakbrowser/pxbypass/detect/keyword.py
+++ b/cloakbrowser/pxbypass/detect/keyword.py
@@ -67,3 +67,26 @@ class DetectPxByKeyword(BaseDetector):
             )
         except Exception as exc:
             return DetectResult(evidence={"error": str(exc)})
+
+    async def detect_async(self, page: Any) -> DetectResult:
+        """Scan an async Playwright page for PX-related keywords."""
+        try:
+            body = await page.evaluate(
+                "() => (document.body ? document.body.innerText : '') || ''"
+            )
+            if not body:
+                return DetectResult()
+            body_lower = body.lower()
+            matches = [kw for kw in self.keywords if kw.lower() in body_lower]
+            if not matches:
+                return DetectResult()
+            hc_matches = [kw for kw in HIGH_CONFIDENCE_KEYWORDS if kw.lower() in body_lower]
+            confidence = 0.9 if hc_matches else min(0.5 + len(matches) * 0.15, 0.85)
+            return DetectResult(
+                detected=True,
+                confidence=confidence,
+                px_type="perimeterx",
+                evidence={"keywords_matched": matches, "high_confidence": hc_matches or None},
+            )
+        except Exception as exc:
+            return DetectResult(evidence={"error": str(exc)})

--- a/cloakbrowser/pxbypass/detect/script_src.py
+++ b/cloakbrowser/pxbypass/detect/script_src.py
@@ -42,3 +42,30 @@ class DetectPxByScriptSrc(BaseDetector):
             )
         except Exception as exc:
             return DetectResult(evidence={"error": str(exc)})
+
+    async def detect_async(self, page: Any) -> DetectResult:
+        try:
+            scripts = await page.evaluate("""() => {
+                const urls = [];
+                document.querySelectorAll('script').forEach(s => {
+                    if (s.src) urls.push(s.src);
+                });
+                return urls;
+            }""")
+            if not scripts:
+                return DetectResult()
+            found = []
+            for script in scripts:
+                for pattern in self.patterns:
+                    if pattern in script:
+                        found.append({"script": script[:120], "pattern": pattern})
+                        break
+            if not found:
+                return DetectResult()
+            return DetectResult(
+                detected=True,
+                confidence=0.9 if any("main.min.js" in item["script"] for item in found) else 0.75,
+                evidence={"scripts_matched": found},
+            )
+        except Exception as exc:
+            return DetectResult(evidence={"error": str(exc)})

--- a/cloakbrowser/pxbypass/detect/script_src.py
+++ b/cloakbrowser/pxbypass/detect/script_src.py
@@ -1,0 +1,44 @@
+"""Detect PX by checking page script sources for PX CDN URLs."""
+from __future__ import annotations
+from typing import Any
+from .base import BaseDetector, DetectResult
+
+PX_SCRIPT_PATTERNS = [
+    "px-cloud.net",
+    "client.px-cloud.net",
+    "collector-px",
+    "/px/",
+    "perimeterx",
+]
+
+class DetectPxByScriptSrc(BaseDetector):
+    """Detect PerimeterX by scanning script src URLs."""
+    def __init__(self, patterns: list[str] | None = None):
+        self.patterns = patterns or PX_SCRIPT_PATTERNS
+
+    def detect(self, page: Any) -> DetectResult:
+        try:
+            scripts = page.evaluate("""() => {
+                const urls = [];
+                document.querySelectorAll('script').forEach(s => {
+                    if (s.src) urls.push(s.src);
+                });
+                return urls;
+            }""")
+            if not scripts:
+                return DetectResult()
+            found = []
+            for s in scripts:
+                for p in self.patterns:
+                    if p in s:
+                        found.append({"script": s[:120], "pattern": p})
+                        break
+            if not found:
+                return DetectResult()
+            return DetectResult(
+                detected=True,
+                confidence=0.9 if any("main.min.js" in f["script"] for f in found) else 0.75,
+                evidence={"scripts_matched": found},
+            )
+        except Exception as exc:
+            return DetectResult(evidence={"error": str(exc)})

--- a/cloakbrowser/pxbypass/detect/url_pattern.py
+++ b/cloakbrowser/pxbypass/detect/url_pattern.py
@@ -1,0 +1,33 @@
+"""Detect PX by checking page URL patterns."""
+from __future__ import annotations
+from typing import Any
+from .base import BaseDetector, DetectResult
+
+PX_URL_PATTERNS = [
+    "/blocked",
+    "px-captcha",
+    "captcha",
+]
+
+class DetectPxByUrlPattern(BaseDetector):
+    """Detect PerimeterX by analyzing the page URL."""
+    def __init__(self, patterns: list[str] | None = None):
+        self.patterns = patterns or PX_URL_PATTERNS
+
+    def detect(self, page: Any) -> DetectResult:
+        try:
+            url = page.evaluate("() => window.location.href")
+            if not url:
+                return DetectResult()
+            url_lower = url.lower()
+            found = [p for p in self.patterns if p.lower() in url_lower]
+            if not found:
+                return DetectResult()
+            return DetectResult(
+                detected=True,
+                confidence=0.7,
+                px_type="perimeterx",
+                evidence={"url_patterns": found, "url": url[:200]},
+            )
+        except Exception as exc:
+            return DetectResult(evidence={"error": str(exc)})

--- a/cloakbrowser/pxbypass/detector.py
+++ b/cloakbrowser/pxbypass/detector.py
@@ -1,0 +1,237 @@
+"""PerimeterX challenge detection logic.
+
+Detects PerimeterX "Press & Hold" / "Pressione e segure" / "Activate and hold"
+challenge UI in the current page, including iframe, shadow DOM, and modal variants.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from .config import PX_TEXT_MARKERS
+
+logger = logging.getLogger("cloakbrowser.pxbypass.detector")
+
+# Regex for the hold button short text - supports multiple languages/wordings
+_HOLD_BTN_RE = re.compile(
+    r"^\s*(pressione e segure|press and hold|press & hold|activate and hold)\s*$",
+    re.IGNORECASE,
+)
+
+# Probe JS that checks for PX challenge presence
+_PROBE_PX_JS = """
+() => {
+  const results = {
+    modalVisible: false,
+    onIfoodApp: false,
+    isCf: false,
+    isBlockPage: false,
+    url: window.location.href,
+    title: document.title,
+    main: { title: document.title, markersFound: [], bodyPreview: '' },
+    pxGlobals: [],
+    shadowHosts: [],
+    pxIframes: [],
+    diagnosis: 'unknown',
+  };
+
+  // Check URL for PX/CF patterns
+  const host = window.location.hostname;
+  const path = window.location.pathname;
+  if (host.includes('px') || path.includes('px-captcha')) {
+    results.isBlockPage = true;
+  }
+
+  // Check for common PX-related global objects
+  const pxCandidates = ['_px', 'px_captcha', 'PX', 'PERIMETERX'];
+  for (const key of pxCandidates) {
+    if (key in window) results.pxGlobals.push(key);
+  }
+
+  // Check iframe-based PX modal in #px-captcha
+  const pxCaptcha = document.getElementById('px-captcha');
+  if (pxCaptcha) {
+    results.modalVisible = true;
+    const iframe = pxCaptcha.querySelector('iframe');
+    if (iframe) {
+      // Use getComputedStyle for cross-origin safety
+      var style = window.getComputedStyle(iframe);
+      results.pxIframes.push({
+        display: style.display,
+        width: iframe.offsetWidth,
+        height: iframe.offsetHeight,
+        token: iframe.getAttribute('token') ? 'present' : 'absent',
+        visible: iframe.offsetWidth > 0 && iframe.offsetHeight > 0,
+      });
+    }
+  }
+
+  // Check #px-captcha-modal (iFood variant)
+  const modal = document.getElementById('px-captcha-modal');
+  if (modal && modal.contentDocument) {
+    results.modalVisible = true;
+  }
+
+  // Check shadow DOM hosts that might contain PX
+  const allElements = document.querySelectorAll('*');
+  for (const el of allElements) {
+    if (el.shadowRoot && el.shadowRoot.querySelector('#px-captcha')) {
+      results.shadowHosts.push(el.tagName);
+      results.modalVisible = true;
+    }
+  }
+
+  // Check for px-cloud.net scripts (Walmart/cloud variant)
+  const pxScripts = [];
+  document.querySelectorAll('script').forEach(s => {
+    if (s.src && s.src.includes('px-cloud.net')) {
+      pxScripts.push(s.src.substring(0, 100));
+    }
+  });
+  if (pxScripts.length > 0) {
+    results.pxScripts = pxScripts;
+    results.modalVisible = true;
+  }
+
+  // Body text markers
+  const body = document.body ? (document.body.innerText || '') : '';
+  results.main.bodyPreview = body.slice(0, 200);
+  const markers = """ + str(list(PX_TEXT_MARKERS)) + """;
+  for (const marker of markers) {
+    if (body.toLowerCase().includes(marker)) {
+      results.main.markersFound.push(marker);
+      results.modalVisible = true;
+    }
+  }
+
+  // Check for "Activate and hold" (Walmart variant)
+  if (body.toLowerCase().includes('activate and hold')) {
+    if (!results.main.markersFound.includes('activate and hold')) {
+      results.main.markersFound.push('activate and hold');
+      results.modalVisible = true;
+    }
+  }
+  // Check for "Robot or human" (common PX block page title)
+  if (body.toLowerCase().includes('robot or human')) {
+    if (!results.main.markersFound.includes('robot or human')) {
+      results.main.markersFound.push('robot or human');
+      results.modalVisible = true;
+    }
+  }
+
+  // Diagnosis
+  if (results.modalVisible) {
+    results.diagnosis = 'px_visible';
+  } else if (results.pxGlobals.length > 0) {
+    results.diagnosis = 'px_globals_found';
+  } else {
+    results.diagnosis = 'clean';
+  }
+
+  return results;
+}
+"""
+
+
+def detect_px(page: Any) -> str | None:
+    """Detect if the current page has a PerimeterX challenge.
+
+    Args:
+        page: Playwright Page object (sync or async).
+
+    Returns:
+        'perimeterx' if PX challenge is detected,
+        None if no challenge is visible.
+    """
+    try:
+        result = page.evaluate(_PROBE_PX_JS)
+        if isinstance(result, dict):
+            if result.get("modalVisible") or result.get("diagnosis") in (
+                "px_visible", "px_globals_found",
+            ):
+                logger.debug(
+                    "PX detected: diagnosis=%s, globals=%s, markers=%s, pxScripts=%s",
+                    result.get("diagnosis"),
+                    result.get("pxGlobals"),
+                    result.get("main", {}).get("markersFound"),
+                    result.get("pxScripts"),
+                )
+                return "perimeterx"
+    except Exception as exc:
+        logger.debug("PX detection failed: %s", exc)
+
+    return None
+
+
+def is_px_visible(page: Any) -> bool:
+    """Quick check if PX challenge UI is currently visible on the page.
+
+    This is a lighter check than detect_px(), suitable for polling loops.
+
+    Args:
+        page: Playwright Page object.
+
+    Returns:
+        True if PX challenge UI appears to be visible.
+    """
+    try:
+        result = page.evaluate(
+            """() => {
+                // iframe modal (iFood variant)
+                if (document.getElementById('px-captcha-modal')) return true;
+                // direct px-captcha element (Walmart variant)
+                const pxDiv = document.getElementById('px-captcha');
+                if (pxDiv) return true;
+                // shadow DOM px-captcha
+                for (const el of document.querySelectorAll('*')) {
+                    if (el.shadowRoot && el.shadowRoot.querySelector('#px-captcha')) return true;
+                }
+                // Check for PX script presence in page
+                const scripts = document.querySelectorAll('script');
+                for (const s of scripts) {
+                    if (s.src && s.src.includes('px-cloud.net')) return true;
+                }
+                // Check body text for PX markers
+                const body = (document.body ? document.body.innerText : '') || '';
+                if (body.toLowerCase().includes('robot or human')) return true;
+                if (body.toLowerCase().includes('activate and hold')) return true;
+                const markers = """ + str(list(PX_TEXT_MARKERS)) + """;
+                for (const m of markers) {
+                    if (body.toLowerCase().includes(m)) return true;
+                }
+                return false;
+            }"""
+        )
+        return bool(result)
+    except Exception:
+        return False
+
+
+def is_px_block_page(page: Any) -> bool:
+    """Check if the current page is a full PX block page (not a modal overlay).
+
+    Args:
+        page: Playwright Page object.
+
+    Returns:
+        True if the page itself is a PX challenge page (not the target content).
+    """
+    try:
+        result = page.evaluate(
+            """() => {
+                const body = (document.body ? document.body.innerText : '') || '';
+                const allMarkers = """ + str(list(PX_TEXT_MARKERS) + ["activate and hold", "robot or human"]) + """;
+                const hasMarkers = allMarkers.some(
+                    m => body.toLowerCase().includes(m)
+                );
+                const pxEl = document.querySelector(
+                    '#px-captcha, #px-captcha-modal, .re-captcha'
+                );
+                return hasMarkers && (pxEl !== null || document.title.toLowerCase().includes('captcha'));
+            }"""
+        )
+        return bool(result)
+    except Exception:
+        return False

--- a/cloakbrowser/pxbypass/engine.py
+++ b/cloakbrowser/pxbypass/engine.py
@@ -2,11 +2,21 @@
 
 Auto-detects the PX variant using site-specific handlers and generic
 detectors, then selects the best solving strategy.
+
+Key improvements over v1:
+- Cross-origin iframe PX detection via Playwright frame traversal
+- Delayed detection window after goto (3s + 10s retries)
+- Frame-attached listener for dynamically injected PX iframes
+- CDP-level frame scanning when main-world JS can't cross origins
+- Three-layer detection: JS observer → frame poll → Python fallback
+- Async-compatible solving with proper await support
+- Unified visibility checking across engine and solvers
 """
 from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import Any
 
 from .config import PxConfig
@@ -14,7 +24,6 @@ from .detect.base import BaseDetector, DetectResult
 from .detect.composite import CompositeDetector
 from .detect.keyword import DetectPxByKeyword
 from .detect.dom_element import DetectPxByDomElement
-from .detect.script_src import DetectPxByScriptSrc
 from .solve.base import BaseSolver, SolveResult
 from .solve.composite import CompositeSolver
 from .solve.press_hold_button import SolveByHoldButton
@@ -23,56 +32,78 @@ from .site.base import SiteHandler
 
 logger = logging.getLogger("cloakbrowser.pxbypass.engine")
 
-# JS expression that checks whether PX challenge UI is visible on the page.
+# ---------------------------------------------------------------------------
+# JS helpers — injected into the main page
+# ---------------------------------------------------------------------------
+
+# Checks main-page DOM for PX elements AND tries to probe child iframes.
+# This JS runs in the main page context, so same-origin iframes are accessible.
+# Cross-origin iframes are handled by Python-level frame traversal below.
 _PX_UI_WATCHER_JS = """() => {
-  // Check known container/overlay elements
-  var px = document.getElementById('px-captcha');
-  if (px) { var r = px.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return true; }
-  px = document.getElementById('px-captcha-modal');
-  if (px) { var r = px.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return true; }
-  var el = document.querySelector('[data-px-captcha]');
-  if (el) { var r = el.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return true; }
-  el = document.querySelector('.px-challenge');
-  if (el) { var r = el.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return true; }
+  function checkDoc(doc) {
+    var px = doc.getElementById('px-captcha');
+    if (px) { var r = px.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return true; }
+    px = doc.getElementById('px-captcha-modal');
+    if (px) { var r = px.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return true; }
+    var el = doc.querySelector('[data-px-captcha]');
+    if (el) { var r = el.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return true; }
+    el = doc.querySelector('.px-challenge');
+    if (el) { var r = el.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return true; }
+    // Same-origin iframes
+    try {
+      for (var i = 0; i < doc.querySelectorAll('iframe').length; i++) {
+        var ifr = doc.querySelectorAll('iframe')[i];
+        try {
+          var iDoc = ifr.contentDocument || ifr.contentWindow.document;
+          if (iDoc) {
+            var r2 = iDoc.getElementById('px-captcha');
+            if (r2) { var rb = r2.getBoundingClientRect(); if (rb.width > 10 && rb.height > 10) return true; }
+            var r3 = iDoc.getElementById('px-captcha-modal');
+            if (r3) { var rb = r3.getBoundingClientRect(); if (rb.width > 10 && rb.height > 10) return true; }
+          }
+        } catch(e) {}
+      }
+    } catch(e) {}
+    return false;
+  }
+
+  if (checkDoc(document)) return true;
   // Check body text for challenge markers
   var body = (document.body ? document.body.innerText : '') || '';
-  if (!body) return false;
-  var t = body.toLowerCase();
-  return t.includes('activate and hold') || t.includes('press and hold')
-      || t.includes('pressione e segure') || t.includes('robot or human')
-      || t.includes('verifica') || t.includes('px-captcha')
-      || t.includes('perimeterx') || t.includes('antes de continuarmos');
+  if (body) {
+    var t = body.toLowerCase();
+    if (t.includes('activate and hold') || t.includes('press and hold')
+        || t.includes('pressione e segure') || t.includes('robot or human')
+        || t.includes('verifica') || t.includes('px-captcha')
+        || t.includes('perimeterx') || t.includes('antes de continuarmos'))
+      return true;
+  }
+  return false;
 }"""
 
-# MutationObserver script injected into the page.
+# MutationObserver that also watches for <iframe> insertion.
+# This JS has a TWO-LEVEL detection approach:
+#   1. MutationObserver fires on DOM changes
+#   2. setInterval(1500) polls regardless (catches cross-origin, visibility changes)
+# When PX is found, call __pxNotify() which is the Python exposed binding.
+# NOTE: __pxNotify() returns a promise (from Playwright binding). We do NOT
+# await it — it's fire-and-forget from JS perspective. The Python callback
+# will run when the Playwright event loop processes it.
 _PX_MUTATION_OBSERVER_JS = """() => {
   if (window.__pxObserverInstalled) return;
   window.__pxObserverInstalled = true;
 
   function pxCheckAndNotify() {
     if (window.__pxSolving) return;
-    var found = false;
-    // Check DOM elements
-    var px = document.getElementById('px-captcha');
-    if (px) { var r = px.getBoundingClientRect(); if (r.width > 10 && r.height > 10) found = true; }
-    if (!found) {
-      px = document.getElementById('px-captcha-modal');
-      if (px) { var r = px.getBoundingClientRect(); if (r.width > 10 && r.height > 10) found = true; }
-    }
-    if (!found) {
-      var el = document.querySelector('[data-px-captcha], .px-challenge');
-      if (el) { var r = el.getBoundingClientRect(); if (r.width > 10 && r.height > 10) found = true; }
-    }
+    var found = !!(document.getElementById('px-captcha'));
+    if (!found) found = !!(document.getElementById('px-captcha-modal'));
+    if (!found) found = !!(document.querySelector('[data-px-captcha], .px-challenge'));
     // Check body text
     if (!found && document.body) {
-      var body = (document.body ? document.body.innerText : '') || '';
-      if (body) {
-        var t = body.toLowerCase();
-        found = t.includes('activate and hold') || t.includes('press and hold')
-             || t.includes('pressione e segure') || t.includes('robot or human')
-             || t.includes('verifica') || t.includes('px-captcha')
-             || t.includes('antes de continuarmos');
-      }
+      var t = (document.body.innerText || '').toLowerCase();
+      found = t.includes('activate and hold') || t.includes('press and hold')
+           || t.includes('pressione e segure') || t.includes('robot or human')
+           || t.includes('px-captcha') || t.includes('antes de continuarmos');
     }
     if (found && window.__pxNotify) {
       window.__pxSolving = true;
@@ -80,7 +111,6 @@ _PX_MUTATION_OBSERVER_JS = """() => {
     }
   }
 
-  // Observe DOM AND text changes
   var observer = new MutationObserver(function(mutations) {
     pxCheckAndNotify();
   });
@@ -92,16 +122,125 @@ _PX_MUTATION_OBSERVER_JS = """() => {
       pxCheckAndNotify();
     });
   }
-  // Also poll every 2 seconds as fallback
-  setInterval(pxCheckAndNotify, 2000);
+  // Poll every 1.5 seconds as fallback (catches cross-origin iframe injection,
+  // visibility-only changes that MutationObserver misses)
+  setInterval(pxCheckAndNotify, 1500);
 }"""
+
+
+# ---------------------------------------------------------------------------
+# Python helpers — Playwright-level frame traversal
+# ---------------------------------------------------------------------------
+
+def _check_px_on_all_frames(page: Any) -> bool:
+    """Walk ALL frames (including cross-origin) and check for PX elements.
+
+    Playwright's page.frames includes child frames regardless of origin.
+    This catches PX challenges rendered in cross-origin iframes (Walmart, etc.)
+    that the JS MutationObserver running in the main page cannot see.
+
+    Returns True if PX challenge UI is detected.
+    """
+    for frame in page.frames:
+        if frame == page.main_frame:
+            continue  # already checked via _PX_UI_WATCHER_JS
+        try:
+            found = frame.evaluate("""() => {
+                var px = document.getElementById('px-captcha');
+                if (px) { var r = px.getBoundingClientRect(); return r.width > 10 && r.height > 10; }
+                px = document.getElementById('px-captcha-modal');
+                if (px) { var r = px.getBoundingClientRect(); return r.width > 10 && r.height > 10; }
+                var el = document.querySelector('[data-px-captcha], .px-challenge');
+                if (el) { var r = el.getBoundingClientRect(); return r.width > 10 && r.height > 10; }
+                // keyword check
+                var body = (document.body ? document.body.innerText : '') || '';
+                if (body) {
+                  var t = body.toLowerCase();
+                  return t.includes('activate and hold') || t.includes('press and hold')
+                      || t.includes('pressione e segure') || t.includes('robot or human')
+                      || t.includes('px-captcha') || t.includes('antes de continuarmos');
+                }
+                return false;
+            }""")
+            if found:
+                logger.debug("PX detected in child frame: %s", frame.url[:120])
+                return True
+        except Exception:
+            pass  # cross-origin frame without access — skip
+    return False
+
+
+def _detect_px_on_all_frames(page: Any) -> DetectResult:
+    """Return evidence when PX is rendered only inside a child frame."""
+    for frame in page.frames:
+        if frame == page.main_frame:
+            continue
+        try:
+            if frame.evaluate(_PX_UI_WATCHER_JS):
+                return DetectResult(
+                    detected=True,
+                    confidence=0.9,
+                    evidence={"frame_url": frame.url[:200]},
+                )
+        except Exception:
+            pass
+    return DetectResult()
+
+
+async def _check_px_on_all_frames_async(page: Any) -> bool:
+    """Async version of _check_px_on_all_frames."""
+    for frame in page.frames:
+        if frame == page.main_frame:
+            continue
+        try:
+            found = await frame.evaluate("""() => {
+                var px = document.getElementById('px-captcha');
+                if (px) { var r = px.getBoundingClientRect(); return r.width > 10 && r.height > 10; }
+                px = document.getElementById('px-captcha-modal');
+                if (px) { var r = px.getBoundingClientRect(); return r.width > 10 && r.height > 10; }
+                var el = document.querySelector('[data-px-captcha], .px-challenge');
+                if (el) { var r = el.getBoundingClientRect(); return r.width > 10 && r.height > 10; }
+                var body = (document.body ? document.body.innerText : '') || '';
+                if (body) {
+                  var t = body.toLowerCase();
+                  return t.includes('activate and hold') || t.includes('press and hold')
+                      || t.includes('pressione e segure') || t.includes('robot or human')
+                      || t.includes('px-captcha') || t.includes('antes de continuarmos');
+                }
+                return false;
+            }""")
+            if found:
+                logger.debug("PX detected in child frame (async): %s", frame.url[:120])
+                return True
+        except Exception:
+            pass
+    return False
+
+
+async def _detect_px_on_all_frames_async(page: Any) -> DetectResult:
+    """Async variant of :func:`_detect_px_on_all_frames`."""
+    for frame in page.frames:
+        if frame == page.main_frame:
+            continue
+        try:
+            if await frame.evaluate(_PX_UI_WATCHER_JS):
+                return DetectResult(
+                    detected=True,
+                    confidence=0.9,
+                    evidence={"frame_url": frame.url[:200]},
+                )
+        except Exception:
+            pass
+    return DetectResult()
 
 
 class PxEngine:
     """Orchestrates detection and solving of PerimeterX challenges.
 
-    Detection uses MutationObserver injected into the page's JS context,
-    so it works across all navigations without cross-thread issues.
+    Detection uses three layers:
+    1. MutationObserver injected into main page (catches same-origin PX)
+    2. Python-level Playwright frame traversal (catches cross-origin iframe PX)
+    3. Method-patching on page objects (catches PX appearing during idle loops)
     """
 
     def __init__(self, cfg: PxConfig | None = None):
@@ -117,10 +256,13 @@ class PxEngine:
     @property
     def generic_detector(self) -> BaseDetector:
         """Fallback detector used when no site handler matches."""
+        # Script/global presence only proves the PX SDK is installed.  Most
+        # protected applications load it on every normal page, so treating the
+        # SDK itself as an active captcha causes permanent false positives.
+        # Active challenge detection must come from visible text/DOM or frame UI.
         return CompositeDetector([
             DetectPxByKeyword(),
             DetectPxByDomElement(),
-            DetectPxByScriptSrc(),
         ])
 
     @property
@@ -160,6 +302,34 @@ class PxEngine:
                          generic_result.confidence)
             return None, generic_result
 
+        frame_result = _detect_px_on_all_frames(page)
+        if frame_result.detected:
+            logger.debug("PX detected from child-frame evidence")
+            return None, frame_result
+
+        return None, DetectResult()
+
+    async def detect_async(self, page: Any) -> tuple[SiteHandler | None, DetectResult]:
+        """Async Playwright variant of :meth:`detect`."""
+        for handler in self._site_handlers:
+            if not handler.match_url(page):
+                continue
+            result = await handler.detect_async(page)
+            if result.detected and result.confidence >= 0.3:
+                logger.debug(
+                    "Site handler '%s' matched async (confidence=%.2f)",
+                    handler.name,
+                    result.confidence,
+                )
+                return handler, result
+
+        generic_result = await self.generic_detector.detect_async(page)
+        if generic_result.detected:
+            return None, generic_result
+
+        frame_result = await _detect_px_on_all_frames_async(page)
+        if frame_result.detected:
+            return None, frame_result
         return None, DetectResult()
 
     def solve(self, page: Any, handler: SiteHandler | None,
@@ -175,14 +345,157 @@ class PxEngine:
         logger.info("Using generic solver")
         return self.generic_solver.solve(page, self.cfg, detect_result)
 
+    async def solve_async(self, page: Any, handler: SiteHandler | None,
+                          detect_result: DetectResult) -> SolveResult:
+        """Solve the detected PX challenge (async).
+
+        Uses solver's async solve method if available. Falls back to sync solve.
+        """
+        if not self.cfg.enabled:
+            return SolveResult(method="PxEngine", error="disabled")
+
+        solver: BaseSolver
+        if handler is not None:
+            logger.info("Using site handler '%s' for solving (async)", handler.name)
+            solver = handler.build_solver()
+        else:
+            logger.info("Using generic solver (async)")
+            solver = self.generic_solver
+
+        return await solver.async_solve(page, self.cfg, detect_result)
+
+    # -----------------------------------------------------------------------
+    # Core detection with three-layer fallback
+    # -----------------------------------------------------------------------
+
+    def _is_px_visible(self, page: Any) -> bool:
+        """Check if PX UI is visible — three-layer approach.
+
+        1. JS main-page check (fast, works for same-origin + text)
+        2. Python frame traversal (catches cross-origin iframe PX)
+        """
+        try:
+            if page.evaluate(_PX_UI_WATCHER_JS):
+                return True
+        except Exception:
+            pass
+
+        # Layer 2: walk all child frames via Playwright
+        try:
+            if _check_px_on_all_frames(page):
+                return True
+        except Exception:
+            pass
+
+        return False
+
+    async def _is_px_visible_async(self, page: Any) -> bool:
+        """Async version of _is_px_visible."""
+        try:
+            if await page.evaluate(_PX_UI_WATCHER_JS):
+                return True
+        except Exception:
+            pass
+
+        try:
+            if await _check_px_on_all_frames_async(page):
+                return True
+        except Exception:
+            pass
+
+        return False
+
+    def check_and_solve(self, page: Any) -> bool:
+        """Check if PX is present and solve it (one-shot).
+
+        Uses a page-level `_px_is_solving` flag to prevent concurrent solve
+        attempts — multiple background polls or callbacks stacking up would
+        otherwise simulate overlapping press-and-hold, wasting time and
+        potentially interfering with each other.
+
+        Returns True if no PX found or PX solved successfully.
+        Returns False if PX present but solving failed.
+        """
+        if not self.cfg.enabled:
+            return True
+
+        if not self._is_px_visible(page):
+            return True
+
+        # Guard: skip if already solving (concurrent press-and-hold would
+        # interfere — multiple threads/tasks all holding at the same time
+        # never let the browser process a clean mouse-up)
+        if getattr(page, '_px_is_solving', False):
+            logger.debug("PX solve already in progress, skipping")
+            return False
+
+        page._px_is_solving = True
+        try:
+            handler, result = self.detect(page)
+            if not result.detected:
+                return True
+
+            logger.info("PX detected (confidence=%.2f), solving...", result.confidence)
+            solve_result = self.solve(page, handler, result)
+
+            if solve_result.solved:
+                logger.info("PX solved via %s in %.1fs",
+                            solve_result.method, solve_result.duration)
+            else:
+                logger.warning("PX solve failed via %s: %s",
+                               solve_result.method, solve_result.error)
+            return solve_result.solved
+        finally:
+            page._px_is_solving = False
+
+    async def check_and_solve_async(self, page: Any) -> bool:
+        """Async version of check_and_solve with concurrency guard."""
+        if not self.cfg.enabled:
+            return True
+
+        if not await self._is_px_visible_async(page):
+            return True
+
+        if getattr(page, '_px_is_solving', False):
+            logger.debug("PX solve already in progress (async), skipping")
+            return False
+
+        page._px_is_solving = True
+        try:
+            handler, result = await self.detect_async(page)
+            if not result.detected:
+                return True
+
+            logger.info("PX detected (async, confidence=%.2f), solving...", result.confidence)
+            solve_result = await self.solve_async(page, handler, result)
+
+            if solve_result.solved:
+                logger.info("PX solved via %s (async) in %.1fs",
+                            solve_result.method, solve_result.duration)
+            else:
+                logger.warning("PX solve failed via %s (async): %s",
+                               solve_result.method, solve_result.error)
+            return solve_result.solved
+        finally:
+            page._px_is_solving = False
+
+    # -----------------------------------------------------------------------
+    # Observer installation (sync)
+    # -----------------------------------------------------------------------
+
     def install_observer(self, page: Any) -> None:
         """Inject MutationObserver into the page and expose Python callback."""
         if getattr(page, '_px_observer_installed', False):
             return
         page._px_observer_installed = True
 
-        page.expose_binding("__pxNotify", lambda: self._on_px_detected(page))
-        page.on("load", lambda: self._reinject_observer(page))
+        page.expose_binding(
+            "__pxNotify",
+            lambda _source, *args: self._on_px_detected(page),
+        )
+        page.on("load", lambda *args: self._on_page_load(page))
+        # Listen for new iframes being attached
+        page.on("frameattached", lambda f: self._on_frame_attached(page, f))
         self._reinject_observer(page)
 
     def _reinject_observer(self, page: Any) -> None:
@@ -191,7 +504,31 @@ class PxEngine:
         except Exception:
             pass
 
+    def _on_page_load(self, page: Any) -> None:
+        """Called when page fires 'load' event."""
+        self._reinject_observer(page)
+        # Quick check right after load
+        try:
+            self.check_and_solve(page)
+        except Exception as exc:
+            logger.debug("PX check after load failed (non-fatal): %s", exc)
+
+        # Patch commonly-used page properties/methods to trigger PX checks.
+        # This is needed because Playwright's sync API uses greenlets and
+        # pending callbacks (from expose_binding via __pxNotify) are only
+        # processed when a Playwright API call is actively made. During
+        # user code like "while True: time.sleep(1)", callbacks pile up.
+        _patch_methods_for_px_polling(page, self)
+
+    def _on_frame_attached(self, page: Any, frame: Any) -> None:
+        """Called when a new frame is attached — could be a PX iframe."""
+        try:
+            self.check_and_solve(page)
+        except Exception:
+            pass
+
     def _on_px_detected(self, page: Any) -> None:
+        """Called from JS __pxNotify binding — PX detected on browser side."""
         try:
             self.check_and_solve(page)
         except Exception as exc:
@@ -202,32 +539,9 @@ class PxEngine:
             except Exception:
                 pass
 
-    def check_and_solve(self, page: Any) -> bool:
-        """Check if PX is present and solve it (one-shot)."""
-        if not self.cfg.enabled:
-            return True
-
-        try:
-            px_visible = bool(page.evaluate(_PX_UI_WATCHER_JS))
-        except Exception:
-            return True
-        if not px_visible:
-            return True
-
-        handler, result = self.detect(page)
-        if not result.detected:
-            return True
-
-        logger.info("PX detected (confidence=%.2f), solving...", result.confidence)
-        solve_result = self.solve(page, handler, result)
-
-        if solve_result.solved:
-            logger.info("PX solved via %s in %.1fs",
-                        solve_result.method, solve_result.duration)
-        else:
-            logger.warning("PX solve failed via %s: %s",
-                           solve_result.method, solve_result.error)
-        return solve_result.solved
+    # -----------------------------------------------------------------------
+    # Observer installation (async)
+    # -----------------------------------------------------------------------
 
     async def install_observer_async(self, page: Any) -> None:
         """Async version of install_observer."""
@@ -235,13 +549,39 @@ class PxEngine:
             return
         page._px_observer_installed = True
 
-        await page.expose_binding("__pxNotify", lambda: self._on_px_detected_async(page))
-        page.on("load", lambda: asyncio.create_task(self._reinject_observer_async(page)))
+        await page.expose_binding(
+            "__pxNotify",
+            lambda _source, *args: self._on_px_detected_async(page),
+        )
+        page.on("load", lambda *args: asyncio.create_task(self._on_page_load_async(page)))
+        page.on("frameattached", lambda f: asyncio.create_task(self._on_frame_attached_async(page, f)))
         await self._reinject_observer_async(page)
 
     async def _reinject_observer_async(self, page: Any) -> None:
         try:
             await page.evaluate(_PX_MUTATION_OBSERVER_JS)
+        except Exception:
+            pass
+
+    async def _on_page_load_async(self, page: Any) -> None:
+        await self._reinject_observer_async(page)
+        try:
+            await self.check_and_solve_async(page)
+        except Exception as exc:
+            logger.debug("PX check after load (async) failed: %s", exc)
+        # Delayed checks via asyncio (event-loop-safe)
+        async def _delayed(delay: float):
+            await asyncio.sleep(delay)
+            try:
+                await self.check_and_solve_async(page)
+            except Exception:
+                pass
+        asyncio.create_task(_delayed(3.0))
+        asyncio.create_task(_delayed(10.0))
+
+    async def _on_frame_attached_async(self, page: Any, frame: Any) -> None:
+        try:
+            await self.check_and_solve_async(page)
         except Exception:
             pass
 
@@ -258,29 +598,121 @@ class PxEngine:
         except Exception:
             pass
 
-    async def check_and_solve_async(self, page: Any) -> bool:
-        """Async version of check_and_solve."""
-        if not self.cfg.enabled:
-            return True
 
-        try:
-            px_visible = bool(await page.evaluate(_PX_UI_WATCHER_JS))
-        except Exception:
-            return True
-        if not px_visible:
-            return True
+# ---------------------------------------------------------------------------
+# Sync API polling — patch page methods to trigger PX checks
+# ---------------------------------------------------------------------------
+# CRITICAL: Playwright's sync API uses greenlets and pending callbacks from
+# expose_binding are ONLY processed when a Playwright API call is made. This
+# means that during user code like:
+#
+#   while True:
+#       time.sleep(1)  # ← no Playwright calls → __pxNotify callback stuck!
+#
+# the PX callback never fires in Python. The JS-side setInterval fires __pxNotify()
+# correctly, but the Python callback sits in a greenlet buffer undelivered.
+#
+# Our solution: Patch the most commonly-used page methods to do a lightweight
+# PX detection pass. This "flushes" the callback buffer whenever the user
+# interacts with the page.
 
-        handler, result = self.detect(page)
-        if not result.detected:
-            return True
+_PATCHED_CALLABLE_METHODS = [
+    "title", "content", "evaluate", "query_selector",
+    "query_selector_all", "wait_for_selector", "screenshot",
+    "click", "fill",
+]
+# NOTE: "url" is a read-only property, not a method — skip it.
+# "keyboard" and "mouse" return objects, not functions — skip them too.
+# Only patch actual callables that won't raise AttributeError on setattr.
 
-        logger.info("PX detected (async, confidence=%.2f), solving...", result.confidence)
-        solve_result = self.solve(page, handler, result)
 
-        if solve_result.solved:
-            logger.info("PX solved via %s (async) in %.1fs",
-                        solve_result.method, solve_result.duration)
-        else:
-            logger.warning("PX solve failed via %s (async): %s",
-                           solve_result.method, solve_result.error)
-        return solve_result.solved
+def _patch_methods_for_px_polling(page: Any, engine: PxEngine) -> None:
+    """Patch common page METHODS to trigger periodic PX checks.
+
+    Only patches callable methods — NOT read-only properties like `page.url`.
+    Every call to a patched method does: original() + periodic PX check (~3s).
+
+    Also adds a `wait_for_px_solved()` convenience method.
+    """
+    if getattr(page, '_px_methods_patched', False):
+        return
+    page._px_methods_patched = True
+    page._px_last_poll_time = 0.0
+    page._px_poll_interval = 3.0  # seconds between PX checks
+    page._px_engine = engine
+
+    # Patch only callable methods
+    for method_name in _PATCHED_CALLABLE_METHODS:
+        _patch_single_method(page, method_name)
+
+    # Add a convenience method for the user to call manually
+    def _px_wait_for_solved(timeout: float = 120.0) -> bool:
+        """Wait until the current PX challenge clears after an actual solve."""
+        import time as _time
+        deadline = _time.monotonic() + timeout
+        saw_px = False
+        while _time.monotonic() < deadline:
+            visible = engine._is_px_visible(page)
+            if not visible:
+                # If we previously saw a challenge, confirm with the full
+                # detector before claiming success.  This avoids transient DOM
+                # gaps while PX replaces/reloads its iframe.
+                if not saw_px:
+                    return True
+                _time.sleep(0.2)
+                _handler, result = engine.detect(page)
+                if not result.detected:
+                    return True
+                visible = True
+            saw_px = True
+            try:
+                if not engine.check_and_solve(page):
+                    _time.sleep(0.5)
+                    continue
+            except Exception:
+                pass
+            _time.sleep(0.5)
+        return not engine.detect(page)[1].detected
+
+    page.wait_for_px_solved = _px_wait_for_solved
+
+
+def _patch_single_method(page: Any, method_name: str) -> None:
+    """Patch a single page METHOD to trigger PX checks periodically.
+
+    Only patches callables — skips read-only properties.
+    """
+    original = getattr(page, method_name, None)
+    if original is None:
+        return
+    # Skip if it's a property (not callable)
+    if not callable(original):
+        return
+    # Attempt setattr — if it fails (read-only property), skip silently
+    try:
+        def _make_patched(orig):
+            def _patched(*args: Any, **kwargs: Any) -> Any:
+                result = orig(*args, **kwargs)
+                _try_px_poll(page)
+                return result
+            return _patched
+        setattr(page, method_name, _make_patched(original))
+    except (AttributeError, TypeError):
+        pass
+
+
+def _try_px_poll(page: Any) -> None:
+    """Try to check-and-solve PX if enough time has passed."""
+    now = time.monotonic()
+    last = getattr(page, '_px_last_poll_time', 0.0)
+    interval = getattr(page, '_px_poll_interval', 3.0)
+    if now - last < interval:
+        return
+    page._px_last_poll_time = now
+    engine = getattr(page, '_px_engine', None)
+    if engine is None:
+        return
+    try:
+        engine.check_and_solve(page)
+    except Exception:
+        pass

--- a/cloakbrowser/pxbypass/engine.py
+++ b/cloakbrowser/pxbypass/engine.py
@@ -23,41 +23,49 @@ from .site.base import SiteHandler
 
 logger = logging.getLogger("cloakbrowser.pxbypass.engine")
 
-# JS expression that checks whether PX UI is present on the page.
+# JS expression that checks whether PX challenge UI is actually visible on the page.
+# This checks for REAL DOM elements, not just script preloading.
 _PX_UI_WATCHER_JS = """() => {
-  if (document.getElementById('px-captcha')) return true;
-  if (document.getElementById('px-captcha-modal')) return true;
+  // Check known container/overlay elements that appear only when challenge is active
+  var px = document.getElementById('px-captcha');
+  if (px) { var r = px.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return true; }
+  px = document.getElementById('px-captcha-modal');
+  if (px) { var r = px.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return true; }
   var el = document.querySelector('[data-px-captcha]');
-  if (el) { var r = el.getBoundingClientRect(); if (r.width > 10) return true; }
+  if (el) { var r = el.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return true; }
   el = document.querySelector('.px-challenge');
-  if (el) { var r = el.getBoundingClientRect(); if (r.width > 10) return true; }
+  if (el) { var r = el.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return true; }
+  // Check body text for active challenge markers (must be long enough to be real page)
   var body = (document.body ? document.body.innerText : '') || '';
+  if (body.length < 20) return false;  // empty/loading page
   var t = body.toLowerCase();
-  return t.includes('activate and hold') || t.includes('press and hold')
-      || t.includes('pressione e segure') || t.includes('robot or human');
+  return t.includes('activate and hold')
+      || t.includes('press and hold')
+      || t.includes('pressione e segure')
+      || t.includes('robot or human');
 }"""
 
 # MutationObserver script injected into the page.
-# Watches for PX challenge elements to appear in the DOM.
-# When detected, calls window.__pxNotify() which triggers Python solver.
 _PX_MUTATION_OBSERVER_JS = """() => {
   if (window.__pxObserverInstalled) return;
   window.__pxObserverInstalled = true;
 
   function pxCheckAndNotify() {
-    if (window.__pxSolving) return;  // solver is already running
+    if (window.__pxSolving) return;
     var found = false;
-    if (document.getElementById('px-captcha')) found = true;
-    else if (document.getElementById('px-captcha-modal')) found = true;
-    else {
-      var el = document.querySelector('[data-px-captcha]');
-      if (el) { var r = el.getBoundingClientRect(); if (r.width > 10) found = true; }
-      if (!found) {
-        el = document.querySelector('.px-challenge');
-        if (el) { var r = el.getBoundingClientRect(); if (r.width > 10) found = true; }
-      }
-      if (!found) {
-        var body = (document.body ? document.body.innerText : '') || '';
+    var px = document.getElementById('px-captcha');
+    if (px) { var r = px.getBoundingClientRect(); if (r.width > 10 && r.height > 10) found = true; }
+    if (!found) {
+      px = document.getElementById('px-captcha-modal');
+      if (px) { var r = px.getBoundingClientRect(); if (r.width > 10 && r.height > 10) found = true; }
+    }
+    if (!found) {
+      var el = document.querySelector('[data-px-captcha], .px-challenge');
+      if (el) { var r = el.getBoundingClientRect(); if (r.width > 10 && r.height > 10) found = true; }
+    }
+    if (!found) {
+      var body = (document.body ? document.body.innerText : '') || '';
+      if (body.length >= 20) {
         var t = body.toLowerCase();
         found = t.includes('activate and hold') || t.includes('press and hold')
              || t.includes('pressione e segure') || t.includes('robot or human');
@@ -69,7 +77,6 @@ _PX_MUTATION_OBSERVER_JS = """() => {
     }
   }
 
-  // Observe DOM changes
   var observer = new MutationObserver(function(mutations) {
     for (var i = 0; i < mutations.length; i++) {
       for (var j = 0; j < (mutations[i].addedNodes || []).length; j++) {
@@ -90,19 +97,12 @@ _PX_MUTATION_OBSERVER_JS = """() => {
       pxCheckAndNotify();
     });
   }
-
-  // Also check periodically as a fallback (every 3 seconds)
   setInterval(pxCheckAndNotify, 3000);
 }"""
 
 
 class PxEngine:
     """Orchestrates detection and solving of PerimeterX challenges.
-
-    Flow:
-        1. Try site-specific handlers (Walmart, iFood, etc.) in priority order
-        2. If no site matches, fall back to generic CompositeDetector/Solver
-        3. detect() returns handler + result → solve() uses handler's solver
 
     Detection uses MutationObserver injected into the page's JS context,
     so it works across all navigations without cross-thread issues.
@@ -135,8 +135,39 @@ class PxEngine:
             SolveByHoldContainer(),
         ])
 
+    def _px_ui_visible(self, page: Any) -> bool:
+        """Check if PX challenge UI is actually visible on the page.
+        
+        Returns False if page is empty, loading, or has no PX challenge.
+        This is the gating check to prevent false positives from script detection.
+        """
+        try:
+            body = page.evaluate("""() => {
+                var body = (document.body ? document.body.innerText : '') || '';
+                if (body.length < 20) return 'empty';
+                // Check for real PX elements
+                var px = document.getElementById('px-captcha');
+                if (px) { var r = px.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return 'element'; }
+                px = document.getElementById('px-captcha-modal');
+                if (px) { var r = px.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return 'element'; }
+                var el = document.querySelector('[data-px-captcha], .px-challenge');
+                if (el) { var r = el.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return 'element'; }
+                var t = body.toLowerCase();
+                if (t.includes('activate and hold') || t.includes('press and hold')
+                    || t.includes('pressione e segure') || t.includes('robot or human')) {
+                    return 'text';
+                }
+                return 'none';
+            }""")
+            return body in ('element', 'text')
+        except Exception:
+            return False
+
     def detect(self, page: Any) -> tuple[SiteHandler | None, DetectResult]:
         """Detect PX challenge and identify the best handler.
+
+        First verifies that PX UI is actually visible (not just scripts loaded),
+        then tries site-specific handlers, then falls back to generic detection.
 
         Args:
             page: Playwright Page object.
@@ -144,6 +175,10 @@ class PxEngine:
         Returns:
             (handler, result) — handler may be None if no specific site matches.
         """
+        # Gating: must have visible PX UI or meaningful page content
+        if not self._px_ui_visible(page):
+            return None, DetectResult()
+
         # Try site-specific handlers first
         for handler in self._site_handlers:
             result = handler.detect(page)
@@ -163,16 +198,7 @@ class PxEngine:
 
     def solve(self, page: Any, handler: SiteHandler | None,
               detect_result: DetectResult) -> SolveResult:
-        """Solve the detected PX challenge.
-
-        Args:
-            page: Playwright Page object.
-            handler: SiteHandler from detect(), or None for generic.
-            detect_result: DetectResult from detect().
-
-        Returns:
-            SolveResult indicating success/failure.
-        """
+        """Solve the detected PX challenge."""
         if not self.cfg.enabled:
             return SolveResult(method="PxEngine", error="disabled")
 
@@ -184,59 +210,34 @@ class PxEngine:
         return self.generic_solver.solve(page, self.cfg, detect_result)
 
     def install_observer(self, page: Any) -> None:
-        """Inject MutationObserver into the page and expose Python callback.
-
-        Safe to call multiple times — only installs once per page.
-
-        Args:
-            page: Playwright Page object.
-        """
+        """Inject MutationObserver into the page and expose Python callback."""
         if getattr(page, '_px_observer_installed', False):
             return
         page._px_observer_installed = True
 
-        # Expose a Python callback that JS can call via window.__pxNotify()
         page.expose_binding("__pxNotify", lambda: self._on_px_detected(page))
-
-        # When navigation happens, the observer may need to be re-injected
-        # because the execution context is destroyed.
         page.on("load", lambda: self._reinject_observer(page))
-
-        # Inject the observer JS
         self._reinject_observer(page)
 
     def _reinject_observer(self, page: Any) -> None:
-        """Re-inject the MutationObserver after navigation."""
         try:
             page.evaluate(_PX_MUTATION_OBSERVER_JS)
         except Exception:
             pass
 
     def _on_px_detected(self, page: Any) -> None:
-        """Called from JS when PX is detected via MutationObserver."""
         try:
             self.check_and_solve(page)
         except Exception as exc:
             logger.debug("PX solve failed (non-fatal): %s", exc)
         finally:
-            # Reset the solving flag so observer can fire again next time
             try:
                 page.evaluate("window.__pxSolving = false")
             except Exception:
                 pass
 
     def check_and_solve(self, page: Any) -> bool:
-        """Check if PX is present and solve it.
-
-        One-shot: checks the current page state and solves if PX is there.
-        Does NOT wait.
-
-        Args:
-            page: Playwright Page object.
-
-        Returns:
-            True if PX was not present or was solved.
-        """
+        """Check if PX is present and solve it (one-shot)."""
         if not self.cfg.enabled:
             return True
 
@@ -269,9 +270,7 @@ class PxEngine:
         page._px_observer_installed = True
 
         await page.expose_binding("__pxNotify", lambda: self._on_px_detected_async(page))
-
         page.on("load", lambda: asyncio.create_task(self._reinject_observer_async(page)))
-
         await self._reinject_observer_async(page)
 
     async def _reinject_observer_async(self, page: Any) -> None:
@@ -281,7 +280,6 @@ class PxEngine:
             pass
 
     def _on_px_detected_async(self, page: Any) -> None:
-        """Called from JS when PX is detected (async variant)."""
         try:
             asyncio.create_task(self._solve_async(page))
         except Exception as exc:

--- a/cloakbrowser/pxbypass/engine.py
+++ b/cloakbrowser/pxbypass/engine.py
@@ -6,7 +6,7 @@ detectors, then selects the best solving strategy.
 from __future__ import annotations
 
 import logging
-import time
+import threading
 from typing import Any
 
 from .config import PxConfig
@@ -22,6 +22,20 @@ from .solve.press_hold_container import SolveByHoldContainer
 from .site.base import SiteHandler
 
 logger = logging.getLogger("cloakbrowser.pxbypass.engine")
+
+# JS expression that checks whether PX UI is present on the page.
+_PX_UI_WATCHER_JS = """() => {
+  if (document.getElementById('px-captcha')) return true;
+  if (document.getElementById('px-captcha-modal')) return true;
+  var el = document.querySelector('[data-px-captcha]');
+  if (el) { var r = el.getBoundingClientRect(); if (r.width > 10) return true; }
+  el = document.querySelector('.px-challenge');
+  if (el) { var r = el.getBoundingClientRect(); if (r.width > 10) return true; }
+  var body = (document.body ? document.body.innerText : '') || '';
+  var t = body.toLowerCase();
+  return t.includes('activate and hold') || t.includes('press and hold')
+      || t.includes('pressione e segure') || t.includes('robot or human');
+}"""
 
 
 class PxEngine:
@@ -108,21 +122,32 @@ class PxEngine:
         logger.info("Using generic solver")
         return self.generic_solver.solve(page, self.cfg, detect_result)
 
-    def detect_and_solve(self, page: Any) -> bool:
-        """Convenience: detect and solve in one call.
+    def check_and_solve(self, page: Any) -> bool:
+        """Check if PX is present and solve it.
+
+        One-shot: checks the current page state and solves if PX is there.
+        Does NOT wait. Used by the background monitor.
 
         Args:
             page: Playwright Page object.
 
         Returns:
-            True if PX was solved or not present.
+            True if PX was not present or was solved.
         """
         if not self.cfg.enabled:
             return True
 
+        # Quick check: is PX UI visible right now?
+        try:
+            px_visible = bool(page.evaluate(_PX_UI_WATCHER_JS))
+        except Exception:
+            # Page might be closed or navigating
+            return True
+        if not px_visible:
+            return True
+
         handler, result = self.detect(page)
         if not result.detected:
-            logger.debug("No PX detected, skipping solve")
             return True
 
         logger.info("PX detected (confidence=%.2f), solving...", result.confidence)
@@ -134,5 +159,104 @@ class PxEngine:
         else:
             logger.warning("PX solve failed via %s: %s",
                            solve_result.method, solve_result.error)
-
         return solve_result.solved
+
+    def start_monitoring(self, page: Any) -> None:
+        """Start background monitoring for PX on this page (sync API).
+
+        The monitor runs in a daemon thread, polling the page every
+        ``monitor_interval`` seconds. It auto-stops when the page is closed.
+
+        Safe to call multiple times — only starts once per page.
+        """
+        if getattr(page, '_px_monitor_active', False):
+            return
+        page._px_monitor_active = True
+
+        interval = self.cfg.monitor_interval
+
+        def _loop() -> None:
+            logger.debug("PX monitor started for page (sync)")
+            try:
+                while getattr(page, '_px_monitor_active', False):
+                    # Check if page is still alive
+                    try:
+                        _ = page.url
+                    except Exception:
+                        break
+
+                    self.check_and_solve(page)
+
+                    import time as _time
+                    _time.sleep(interval)
+            except Exception:
+                pass
+            finally:
+                logger.debug("PX monitor stopped for page (sync)")
+
+        t = threading.Thread(target=_loop, daemon=True)
+        t.start()
+
+    async def check_and_solve_async(self, page: Any) -> bool:
+        """Async version of check_and_solve. Used by async monitor."""
+        if not self.cfg.enabled:
+            return True
+
+        try:
+            px_visible = bool(await page.evaluate(_PX_UI_WATCHER_JS))
+        except Exception:
+            return True
+        if not px_visible:
+            return True
+
+        handler, result = self.detect(page)
+        if not result.detected:
+            return True
+
+        logger.info("PX detected (async, confidence=%.2f), solving...", result.confidence)
+        solve_result = self.solve(page, handler, result)
+
+        if solve_result.solved:
+            logger.info("PX solved via %s (async) in %.1fs",
+                        solve_result.method, solve_result.duration)
+        else:
+            logger.warning("PX solve failed via %s (async): %s",
+                           solve_result.method, solve_result.error)
+        return solve_result.solved
+
+    async def start_monitoring_async(self, page: Any) -> None:
+        """Start background monitoring for PX on this page (async API).
+
+        Spawns an asyncio task that polls the page every ``monitor_interval``
+        seconds. The task auto-cancels when the page is closed.
+
+        Safe to call multiple times — only starts once per page.
+        """
+        if getattr(page, '_px_monitor_task', None) is not None:
+            return
+
+        interval = self.cfg.monitor_interval
+
+        async def _monitor_loop() -> None:
+            import asyncio
+            logger.debug("PX monitor started for page (async)")
+            try:
+                while True:
+                    # Check if page is still alive
+                    try:
+                        _ = page.url
+                    except Exception:
+                        break
+
+                    await self.check_and_solve_async(page)
+                    await asyncio.sleep(interval)
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                pass
+            finally:
+                page._px_monitor_task = None
+                logger.debug("PX monitor stopped for page (async)")
+
+        import asyncio
+        page._px_monitor_task = asyncio.create_task(_monitor_loop())

--- a/cloakbrowser/pxbypass/engine.py
+++ b/cloakbrowser/pxbypass/engine.py
@@ -5,8 +5,8 @@ detectors, then selects the best solving strategy.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
-import threading
 from typing import Any
 
 from .config import PxConfig
@@ -37,6 +37,64 @@ _PX_UI_WATCHER_JS = """() => {
       || t.includes('pressione e segure') || t.includes('robot or human');
 }"""
 
+# MutationObserver script injected into the page.
+# Watches for PX challenge elements to appear in the DOM.
+# When detected, calls window.__pxNotify() which triggers Python solver.
+_PX_MUTATION_OBSERVER_JS = """() => {
+  if (window.__pxObserverInstalled) return;
+  window.__pxObserverInstalled = true;
+
+  function pxCheckAndNotify() {
+    if (window.__pxSolving) return;  // solver is already running
+    var found = false;
+    if (document.getElementById('px-captcha')) found = true;
+    else if (document.getElementById('px-captcha-modal')) found = true;
+    else {
+      var el = document.querySelector('[data-px-captcha]');
+      if (el) { var r = el.getBoundingClientRect(); if (r.width > 10) found = true; }
+      if (!found) {
+        el = document.querySelector('.px-challenge');
+        if (el) { var r = el.getBoundingClientRect(); if (r.width > 10) found = true; }
+      }
+      if (!found) {
+        var body = (document.body ? document.body.innerText : '') || '';
+        var t = body.toLowerCase();
+        found = t.includes('activate and hold') || t.includes('press and hold')
+             || t.includes('pressione e segure') || t.includes('robot or human');
+      }
+    }
+    if (found && window.__pxNotify) {
+      window.__pxSolving = true;
+      window.__pxNotify();
+    }
+  }
+
+  // Observe DOM changes
+  var observer = new MutationObserver(function(mutations) {
+    for (var i = 0; i < mutations.length; i++) {
+      for (var j = 0; j < (mutations[i].addedNodes || []).length; j++) {
+        var n = mutations[i].addedNodes[j];
+        if (n.nodeType === 1 && (n.id === 'px-captcha' || n.id === 'px-captcha-modal'
+            || n.matches && n.matches('[data-px-captcha], .px-challenge'))) {
+          pxCheckAndNotify();
+          return;
+        }
+      }
+    }
+  });
+  if (document.body) {
+    observer.observe(document.body, { childList: true, subtree: true });
+  } else {
+    document.addEventListener('DOMContentLoaded', function() {
+      observer.observe(document.body, { childList: true, subtree: true });
+      pxCheckAndNotify();
+    });
+  }
+
+  // Also check periodically as a fallback (every 3 seconds)
+  setInterval(pxCheckAndNotify, 3000);
+}"""
+
 
 class PxEngine:
     """Orchestrates detection and solving of PerimeterX challenges.
@@ -45,6 +103,9 @@ class PxEngine:
         1. Try site-specific handlers (Walmart, iFood, etc.) in priority order
         2. If no site matches, fall back to generic CompositeDetector/Solver
         3. detect() returns handler + result → solve() uses handler's solver
+
+    Detection uses MutationObserver injected into the page's JS context,
+    so it works across all navigations without cross-thread issues.
     """
 
     def __init__(self, cfg: PxConfig | None = None):
@@ -122,11 +183,53 @@ class PxEngine:
         logger.info("Using generic solver")
         return self.generic_solver.solve(page, self.cfg, detect_result)
 
+    def install_observer(self, page: Any) -> None:
+        """Inject MutationObserver into the page and expose Python callback.
+
+        Safe to call multiple times — only installs once per page.
+
+        Args:
+            page: Playwright Page object.
+        """
+        if getattr(page, '_px_observer_installed', False):
+            return
+        page._px_observer_installed = True
+
+        # Expose a Python callback that JS can call via window.__pxNotify()
+        page.expose_binding("__pxNotify", lambda: self._on_px_detected(page))
+
+        # When navigation happens, the observer may need to be re-injected
+        # because the execution context is destroyed.
+        page.on("load", lambda: self._reinject_observer(page))
+
+        # Inject the observer JS
+        self._reinject_observer(page)
+
+    def _reinject_observer(self, page: Any) -> None:
+        """Re-inject the MutationObserver after navigation."""
+        try:
+            page.evaluate(_PX_MUTATION_OBSERVER_JS)
+        except Exception:
+            pass
+
+    def _on_px_detected(self, page: Any) -> None:
+        """Called from JS when PX is detected via MutationObserver."""
+        try:
+            self.check_and_solve(page)
+        except Exception as exc:
+            logger.debug("PX solve failed (non-fatal): %s", exc)
+        finally:
+            # Reset the solving flag so observer can fire again next time
+            try:
+                page.evaluate("window.__pxSolving = false")
+            except Exception:
+                pass
+
     def check_and_solve(self, page: Any) -> bool:
         """Check if PX is present and solve it.
 
         One-shot: checks the current page state and solves if PX is there.
-        Does NOT wait. Used by the background monitor.
+        Does NOT wait.
 
         Args:
             page: Playwright Page object.
@@ -137,11 +240,9 @@ class PxEngine:
         if not self.cfg.enabled:
             return True
 
-        # Quick check: is PX UI visible right now?
         try:
             px_visible = bool(page.evaluate(_PX_UI_WATCHER_JS))
         except Exception:
-            # Page might be closed or navigating
             return True
         if not px_visible:
             return True
@@ -161,44 +262,40 @@ class PxEngine:
                            solve_result.method, solve_result.error)
         return solve_result.solved
 
-    def start_monitoring(self, page: Any) -> None:
-        """Start background monitoring for PX on this page (sync API).
-
-        The monitor runs in a daemon thread, polling the page every
-        ``monitor_interval`` seconds. It auto-stops when the page is closed.
-
-        Safe to call multiple times — only starts once per page.
-        """
-        if getattr(page, '_px_monitor_active', False):
+    async def install_observer_async(self, page: Any) -> None:
+        """Async version of install_observer."""
+        if getattr(page, '_px_observer_installed', False):
             return
-        page._px_monitor_active = True
+        page._px_observer_installed = True
 
-        interval = self.cfg.monitor_interval
+        await page.expose_binding("__pxNotify", lambda: self._on_px_detected_async(page))
 
-        def _loop() -> None:
-            logger.debug("PX monitor started for page (sync)")
-            try:
-                while getattr(page, '_px_monitor_active', False):
-                    # Check if page is still alive
-                    try:
-                        _ = page.url
-                    except Exception:
-                        break
+        page.on("load", lambda: asyncio.create_task(self._reinject_observer_async(page)))
 
-                    self.check_and_solve(page)
+        await self._reinject_observer_async(page)
 
-                    import time as _time
-                    _time.sleep(interval)
-            except Exception:
-                pass
-            finally:
-                logger.debug("PX monitor stopped for page (sync)")
+    async def _reinject_observer_async(self, page: Any) -> None:
+        try:
+            await page.evaluate(_PX_MUTATION_OBSERVER_JS)
+        except Exception:
+            pass
 
-        t = threading.Thread(target=_loop, daemon=True)
-        t.start()
+    def _on_px_detected_async(self, page: Any) -> None:
+        """Called from JS when PX is detected (async variant)."""
+        try:
+            asyncio.create_task(self._solve_async(page))
+        except Exception as exc:
+            logger.debug("PX solve failed (async, non-fatal): %s", exc)
+
+    async def _solve_async(self, page: Any) -> None:
+        await self.check_and_solve_async(page)
+        try:
+            await page.evaluate("window.__pxSolving = false")
+        except Exception:
+            pass
 
     async def check_and_solve_async(self, page: Any) -> bool:
-        """Async version of check_and_solve. Used by async monitor."""
+        """Async version of check_and_solve."""
         if not self.cfg.enabled:
             return True
 
@@ -223,40 +320,3 @@ class PxEngine:
             logger.warning("PX solve failed via %s (async): %s",
                            solve_result.method, solve_result.error)
         return solve_result.solved
-
-    async def start_monitoring_async(self, page: Any) -> None:
-        """Start background monitoring for PX on this page (async API).
-
-        Spawns an asyncio task that polls the page every ``monitor_interval``
-        seconds. The task auto-cancels when the page is closed.
-
-        Safe to call multiple times — only starts once per page.
-        """
-        if getattr(page, '_px_monitor_task', None) is not None:
-            return
-
-        interval = self.cfg.monitor_interval
-
-        async def _monitor_loop() -> None:
-            import asyncio
-            logger.debug("PX monitor started for page (async)")
-            try:
-                while True:
-                    # Check if page is still alive
-                    try:
-                        _ = page.url
-                    except Exception:
-                        break
-
-                    await self.check_and_solve_async(page)
-                    await asyncio.sleep(interval)
-            except asyncio.CancelledError:
-                pass
-            except Exception:
-                pass
-            finally:
-                page._px_monitor_task = None
-                logger.debug("PX monitor stopped for page (async)")
-
-        import asyncio
-        page._px_monitor_task = asyncio.create_task(_monitor_loop())

--- a/cloakbrowser/pxbypass/engine.py
+++ b/cloakbrowser/pxbypass/engine.py
@@ -1,0 +1,138 @@
+"""PxEngine: orchestrates detection → solving for PerimeterX challenges.
+
+Auto-detects the PX variant using site-specific handlers and generic
+detectors, then selects the best solving strategy.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from .config import PxConfig
+from .detect.base import BaseDetector, DetectResult
+from .detect.composite import CompositeDetector
+from .detect.keyword import DetectPxByKeyword
+from .detect.dom_element import DetectPxByDomElement
+from .detect.script_src import DetectPxByScriptSrc
+from .solve.base import BaseSolver, SolveResult
+from .solve.composite import CompositeSolver
+from .solve.press_hold_button import SolveByHoldButton
+from .solve.press_hold_container import SolveByHoldContainer
+from .site.base import SiteHandler
+
+logger = logging.getLogger("cloakbrowser.pxbypass.engine")
+
+
+class PxEngine:
+    """Orchestrates detection and solving of PerimeterX challenges.
+
+    Flow:
+        1. Try site-specific handlers (Walmart, iFood, etc.) in priority order
+        2. If no site matches, fall back to generic CompositeDetector/Solver
+        3. detect() returns handler + result → solve() uses handler's solver
+    """
+
+    def __init__(self, cfg: PxConfig | None = None):
+        self.cfg = cfg or PxConfig()
+        self._site_handlers: list[SiteHandler] = []
+        self._detect_only = False
+
+    def register_handler(self, handler: SiteHandler) -> None:
+        """Register a site-specific handler."""
+        self._site_handlers.append(handler)
+        self._site_handlers.sort(key=lambda h: h.priority, reverse=True)
+
+    @property
+    def generic_detector(self) -> BaseDetector:
+        """Fallback detector used when no site handler matches."""
+        return CompositeDetector([
+            DetectPxByKeyword(),
+            DetectPxByDomElement(),
+            DetectPxByScriptSrc(),
+        ])
+
+    @property
+    def generic_solver(self) -> BaseSolver:
+        """Fallback solver used when no site handler matches."""
+        return CompositeSolver([
+            SolveByHoldButton(),
+            SolveByHoldContainer(),
+        ])
+
+    def detect(self, page: Any) -> tuple[SiteHandler | None, DetectResult]:
+        """Detect PX challenge and identify the best handler.
+
+        Args:
+            page: Playwright Page object.
+
+        Returns:
+            (handler, result) — handler may be None if no specific site matches.
+        """
+        # Try site-specific handlers first
+        for handler in self._site_handlers:
+            result = handler.detect(page)
+            if result.detected and result.confidence >= 0.3:
+                logger.debug("Site handler '%s' matched (confidence=%.2f)",
+                             handler.name, result.confidence)
+                return handler, result
+
+        # Fallback: generic detection
+        generic_result = self.generic_detector.detect(page)
+        if generic_result.detected:
+            logger.debug("Generic detector matched (confidence=%.2f)",
+                         generic_result.confidence)
+            return None, generic_result
+
+        return None, DetectResult()
+
+    def solve(self, page: Any, handler: SiteHandler | None,
+              detect_result: DetectResult) -> SolveResult:
+        """Solve the detected PX challenge.
+
+        Args:
+            page: Playwright Page object.
+            handler: SiteHandler from detect(), or None for generic.
+            detect_result: DetectResult from detect().
+
+        Returns:
+            SolveResult indicating success/failure.
+        """
+        if not self.cfg.enabled:
+            return SolveResult(method="PxEngine", error="disabled")
+
+        if handler is not None:
+            logger.info("Using site handler '%s' for solving", handler.name)
+            return handler.solve(page, self.cfg, detect_result)
+
+        logger.info("Using generic solver")
+        return self.generic_solver.solve(page, self.cfg, detect_result)
+
+    def detect_and_solve(self, page: Any) -> bool:
+        """Convenience: detect and solve in one call.
+
+        Args:
+            page: Playwright Page object.
+
+        Returns:
+            True if PX was solved or not present.
+        """
+        if not self.cfg.enabled:
+            return True
+
+        handler, result = self.detect(page)
+        if not result.detected:
+            logger.debug("No PX detected, skipping solve")
+            return True
+
+        logger.info("PX detected (confidence=%.2f), solving...", result.confidence)
+        solve_result = self.solve(page, handler, result)
+
+        if solve_result.solved:
+            logger.info("PX solved via %s in %.1fs",
+                        solve_result.method, solve_result.duration)
+        else:
+            logger.warning("PX solve failed via %s: %s",
+                           solve_result.method, solve_result.error)
+
+        return solve_result.solved

--- a/cloakbrowser/pxbypass/engine.py
+++ b/cloakbrowser/pxbypass/engine.py
@@ -166,8 +166,8 @@ class PxEngine:
     def detect(self, page: Any) -> tuple[SiteHandler | None, DetectResult]:
         """Detect PX challenge and identify the best handler.
 
-        First verifies that PX UI is actually visible (not just scripts loaded),
-        then tries site-specific handlers, then falls back to generic detection.
+        First checks the page URL to find matching site handlers,
+        then verifies PX UI is actually visible.
 
         Args:
             page: Playwright Page object.
@@ -175,24 +175,24 @@ class PxEngine:
         Returns:
             (handler, result) — handler may be None if no specific site matches.
         """
-        # Gating: must have visible PX UI or meaningful page content
-        if not self._px_ui_visible(page):
-            return None, DetectResult()
-
-        # Try site-specific handlers first
+        # Try site-specific handlers that match the current URL
         for handler in self._site_handlers:
+            if not handler.match_url(page):
+                logger.debug("Site handler '%s' skipped (URL mismatch)", handler.name)
+                continue
             result = handler.detect(page)
             if result.detected and result.confidence >= 0.3:
                 logger.debug("Site handler '%s' matched (confidence=%.2f)",
                              handler.name, result.confidence)
                 return handler, result
 
-        # Fallback: generic detection
-        generic_result = self.generic_detector.detect(page)
-        if generic_result.detected:
-            logger.debug("Generic detector matched (confidence=%.2f)",
-                         generic_result.confidence)
-            return None, generic_result
+        # Fallback: generic detection (only if PX UI is visible)
+        if self._px_ui_visible(page):
+            generic_result = self.generic_detector.detect(page)
+            if generic_result.detected:
+                logger.debug("Generic detector matched (confidence=%.2f)",
+                             generic_result.confidence)
+                return None, generic_result
 
         return None, DetectResult()
 

--- a/cloakbrowser/pxbypass/engine.py
+++ b/cloakbrowser/pxbypass/engine.py
@@ -23,10 +23,18 @@ from .site.base import SiteHandler
 
 logger = logging.getLogger("cloakbrowser.pxbypass.engine")
 
-# JS expression that checks whether PX challenge UI is actually visible on the page.
-# This checks for REAL DOM elements, not just script preloading.
+# Keywords that indicate PX/security challenge is active on the page.
+_PX_CHALLENGE_KEYWORDS = [
+    'activate and hold', 'press and hold', 'pressione e segure',
+    'robot or human', 'verificação de segurança', 'segurança',
+    'press & hold', 'perimeterx', 'px-captcha',
+    'antes de continuarmos', 'confirmar que você',
+    'não é um robô', 'não um robô',
+]
+
+# JS expression that checks whether PX challenge UI is visible on the page.
 _PX_UI_WATCHER_JS = """() => {
-  // Check known container/overlay elements that appear only when challenge is active
+  // Check known container/overlay elements
   var px = document.getElementById('px-captcha');
   if (px) { var r = px.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return true; }
   px = document.getElementById('px-captcha-modal');
@@ -35,14 +43,14 @@ _PX_UI_WATCHER_JS = """() => {
   if (el) { var r = el.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return true; }
   el = document.querySelector('.px-challenge');
   if (el) { var r = el.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return true; }
-  // Check body text for active challenge markers (must be long enough to be real page)
+  // Check body text for challenge markers
   var body = (document.body ? document.body.innerText : '') || '';
-  if (body.length < 20) return false;  // empty/loading page
   var t = body.toLowerCase();
-  return t.includes('activate and hold')
-      || t.includes('press and hold')
-      || t.includes('pressione e segure')
-      || t.includes('robot or human');
+  return t.includes('activate and hold') || t.includes('press and hold')
+      || t.includes('pressione e segure') || t.includes('robot or human')
+      || t.includes('verifica') || (t.includes('segurança') && body.length < 500)
+      || t.includes('px-captcha') || t.includes('perimeterx')
+      || t.includes('antes de continuarmos');
 }"""
 
 # MutationObserver script injected into the page.
@@ -63,13 +71,13 @@ _PX_MUTATION_OBSERVER_JS = """() => {
       var el = document.querySelector('[data-px-captcha], .px-challenge');
       if (el) { var r = el.getBoundingClientRect(); if (r.width > 10 && r.height > 10) found = true; }
     }
-    if (!found) {
+    if (!found && document.body) {
       var body = (document.body ? document.body.innerText : '') || '';
-      if (body.length >= 20) {
-        var t = body.toLowerCase();
-        found = t.includes('activate and hold') || t.includes('press and hold')
-             || t.includes('pressione e segure') || t.includes('robot or human');
-      }
+      var t = body.toLowerCase();
+      found = t.includes('activate and hold') || t.includes('press and hold')
+           || t.includes('pressione e segure') || t.includes('robot or human')
+           || (t.includes('verifica') && body.length < 800)
+           || t.includes('px-captcha') || t.includes('antes de continuarmos');
     }
     if (found && window.__pxNotify) {
       window.__pxSolving = true;
@@ -77,27 +85,20 @@ _PX_MUTATION_OBSERVER_JS = """() => {
     }
   }
 
+  // Observe DOM AND text changes
   var observer = new MutationObserver(function(mutations) {
-    for (var i = 0; i < mutations.length; i++) {
-      for (var j = 0; j < (mutations[i].addedNodes || []).length; j++) {
-        var n = mutations[i].addedNodes[j];
-        if (n.nodeType === 1 && (n.id === 'px-captcha' || n.id === 'px-captcha-modal'
-            || n.matches && n.matches('[data-px-captcha], .px-challenge'))) {
-          pxCheckAndNotify();
-          return;
-        }
-      }
-    }
+    pxCheckAndNotify();
   });
   if (document.body) {
-    observer.observe(document.body, { childList: true, subtree: true });
+    observer.observe(document.body, { childList: true, subtree: true, characterData: true });
   } else {
     document.addEventListener('DOMContentLoaded', function() {
-      observer.observe(document.body, { childList: true, subtree: true });
+      observer.observe(document.body, { childList: true, subtree: true, characterData: true });
       pxCheckAndNotify();
     });
   }
-  setInterval(pxCheckAndNotify, 3000);
+  // Also poll every 2 seconds as fallback
+  setInterval(pxCheckAndNotify, 2000);
 }"""
 
 

--- a/cloakbrowser/pxbypass/engine.py
+++ b/cloakbrowser/pxbypass/engine.py
@@ -23,15 +23,6 @@ from .site.base import SiteHandler
 
 logger = logging.getLogger("cloakbrowser.pxbypass.engine")
 
-# Keywords that indicate PX/security challenge is active on the page.
-_PX_CHALLENGE_KEYWORDS = [
-    'activate and hold', 'press and hold', 'pressione e segure',
-    'robot or human', 'verificação de segurança', 'segurança',
-    'press & hold', 'perimeterx', 'px-captcha',
-    'antes de continuarmos', 'confirmar que você',
-    'não é um robô', 'não um robô',
-]
-
 # JS expression that checks whether PX challenge UI is visible on the page.
 _PX_UI_WATCHER_JS = """() => {
   // Check known container/overlay elements
@@ -45,12 +36,12 @@ _PX_UI_WATCHER_JS = """() => {
   if (el) { var r = el.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return true; }
   // Check body text for challenge markers
   var body = (document.body ? document.body.innerText : '') || '';
+  if (!body) return false;
   var t = body.toLowerCase();
   return t.includes('activate and hold') || t.includes('press and hold')
       || t.includes('pressione e segure') || t.includes('robot or human')
-      || t.includes('verifica') || (t.includes('segurança') && body.length < 500)
-      || t.includes('px-captcha') || t.includes('perimeterx')
-      || t.includes('antes de continuarmos');
+      || t.includes('verifica') || t.includes('px-captcha')
+      || t.includes('perimeterx') || t.includes('antes de continuarmos');
 }"""
 
 # MutationObserver script injected into the page.
@@ -61,6 +52,7 @@ _PX_MUTATION_OBSERVER_JS = """() => {
   function pxCheckAndNotify() {
     if (window.__pxSolving) return;
     var found = false;
+    // Check DOM elements
     var px = document.getElementById('px-captcha');
     if (px) { var r = px.getBoundingClientRect(); if (r.width > 10 && r.height > 10) found = true; }
     if (!found) {
@@ -71,13 +63,16 @@ _PX_MUTATION_OBSERVER_JS = """() => {
       var el = document.querySelector('[data-px-captcha], .px-challenge');
       if (el) { var r = el.getBoundingClientRect(); if (r.width > 10 && r.height > 10) found = true; }
     }
+    // Check body text
     if (!found && document.body) {
       var body = (document.body ? document.body.innerText : '') || '';
-      var t = body.toLowerCase();
-      found = t.includes('activate and hold') || t.includes('press and hold')
-           || t.includes('pressione e segure') || t.includes('robot or human')
-           || (t.includes('verifica') && body.length < 800)
-           || t.includes('px-captcha') || t.includes('antes de continuarmos');
+      if (body) {
+        var t = body.toLowerCase();
+        found = t.includes('activate and hold') || t.includes('press and hold')
+             || t.includes('pressione e segure') || t.includes('robot or human')
+             || t.includes('verifica') || t.includes('px-captcha')
+             || t.includes('antes de continuarmos');
+      }
     }
     if (found && window.__pxNotify) {
       window.__pxSolving = true;
@@ -136,39 +131,11 @@ class PxEngine:
             SolveByHoldContainer(),
         ])
 
-    def _px_ui_visible(self, page: Any) -> bool:
-        """Check if PX challenge UI is actually visible on the page.
-        
-        Returns False if page is empty, loading, or has no PX challenge.
-        This is the gating check to prevent false positives from script detection.
-        """
-        try:
-            body = page.evaluate("""() => {
-                var body = (document.body ? document.body.innerText : '') || '';
-                if (body.length < 20) return 'empty';
-                // Check for real PX elements
-                var px = document.getElementById('px-captcha');
-                if (px) { var r = px.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return 'element'; }
-                px = document.getElementById('px-captcha-modal');
-                if (px) { var r = px.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return 'element'; }
-                var el = document.querySelector('[data-px-captcha], .px-challenge');
-                if (el) { var r = el.getBoundingClientRect(); if (r.width > 10 && r.height > 10) return 'element'; }
-                var t = body.toLowerCase();
-                if (t.includes('activate and hold') || t.includes('press and hold')
-                    || t.includes('pressione e segure') || t.includes('robot or human')) {
-                    return 'text';
-                }
-                return 'none';
-            }""")
-            return body in ('element', 'text')
-        except Exception:
-            return False
-
     def detect(self, page: Any) -> tuple[SiteHandler | None, DetectResult]:
         """Detect PX challenge and identify the best handler.
 
-        First checks the page URL to find matching site handlers,
-        then verifies PX UI is actually visible.
+        Tries site-specific handlers that match the current page URL,
+        then falls back to generic detection.
 
         Args:
             page: Playwright Page object.
@@ -179,7 +146,6 @@ class PxEngine:
         # Try site-specific handlers that match the current URL
         for handler in self._site_handlers:
             if not handler.match_url(page):
-                logger.debug("Site handler '%s' skipped (URL mismatch)", handler.name)
                 continue
             result = handler.detect(page)
             if result.detected and result.confidence >= 0.3:
@@ -187,13 +153,12 @@ class PxEngine:
                              handler.name, result.confidence)
                 return handler, result
 
-        # Fallback: generic detection (only if PX UI is visible)
-        if self._px_ui_visible(page):
-            generic_result = self.generic_detector.detect(page)
-            if generic_result.detected:
-                logger.debug("Generic detector matched (confidence=%.2f)",
-                             generic_result.confidence)
-                return None, generic_result
+        # Fallback: generic detection
+        generic_result = self.generic_detector.detect(page)
+        if generic_result.detected:
+            logger.debug("Generic detector matched (confidence=%.2f)",
+                         generic_result.confidence)
+            return None, generic_result
 
         return None, DetectResult()
 

--- a/cloakbrowser/pxbypass/scripts/px_probe_dump.js
+++ b/cloakbrowser/pxbypass/scripts/px_probe_dump.js
@@ -1,0 +1,91 @@
+// PX DOM 探测器 —— 全面扫描页面判断 PX 挑战状态
+(function() {
+  var result = {
+    url: window.location.href,
+    diagnosis: 'unknown',
+    modalVisible: false,
+    onIfoodApp: false,
+    isCf: false,
+    isBlockPage: false,
+    pxGlobals: [],
+    shadowHosts: [],
+    main: { title: document.title, markersFound: [], bodyPreview: '' },
+  };
+
+  // 检测 Cloudflare 阻断页
+  var cfId = document.getElementById('cf-please-wait');
+  if (cfId || document.querySelector('.cf-browser-verification')) {
+    result.isCf = true;
+    result.diagnosis = 'cf_challenge';
+  }
+
+  // 检测整页 PX 阻断（body 只有简短验证信息）
+  var bodyText = (document.body ? document.body.innerText : '') || '';
+  result.main.bodyPreview = bodyText.slice(0, 300);
+  var markers = ['activate and hold', 'press and hold', 'pressione e segure',
+    'antes de continuarmos', 'confirmar que você', 'robot or human',
+    'px-captcha'];
+  for (var i = 0; i < markers.length; i++) {
+    if (bodyText.toLowerCase().includes(markers[i])) {
+      result.main.markersFound.push(markers[i]);
+    }
+  }
+  // 如果 body 文本很短且包含验证关键词，可能是整页阻断
+  if (bodyText.length < 500 && result.main.markersFound.length > 0) {
+    result.isBlockPage = true;
+    result.diagnosis = 'px_block_page';
+  }
+
+  // 检测 PX 弹层 / 容器
+  var modal = document.getElementById('px-captcha-modal');
+  if (modal) {
+    var mr = modal.getBoundingClientRect();
+    if (mr.width > 10 && mr.height > 10) {
+      result.modalVisible = true;
+      result.diagnosis = 'px_modal';
+    }
+  }
+  var captcha = document.getElementById('px-captcha');
+  if (captcha) {
+    var cr = captcha.getBoundingClientRect();
+    if (cr.width > 10 && cr.height > 10) {
+      result.modalVisible = true;
+      result.diagnosis = 'px_captcha';
+    }
+  }
+  var pxEl = document.querySelector('[data-px-captcha], .px-challenge');
+  if (pxEl) {
+    var pr = pxEl.getBoundingClientRect();
+    if (pr.width > 10 && pr.height > 10) {
+      result.modalVisible = true;
+      result.diagnosis = 'px_element';
+    }
+  }
+
+  // 检测 Shadow DOM 中的 PX
+  try {
+    document.querySelectorAll('*').forEach(function(el) {
+      if (el.shadowRoot) {
+        var sr = el.shadowRoot;
+        if (sr.getElementById('px-captcha') || sr.getElementById('px-captcha-modal')
+            || sr.querySelector('[data-px-captcha]')) {
+          result.shadowHosts.push(el.tagName);
+          result.modalVisible = true;
+          result.diagnosis = 'px_shadow';
+        }
+      }
+    });
+  } catch(e) {}
+
+  // 检测 PX 全局变量
+  var pxKeys = ['_pxApp', '_pxUuid', '_pxCss', '_pxCaptcha', '_px', 'PerimeterX'];
+  for (var j = 0; j < pxKeys.length; j++) {
+    if (window[pxKeys[j]] !== undefined) result.pxGlobals.push(pxKeys[j]);
+  }
+
+  // 检测 iFood webpack app
+  result.onIfoodApp = typeof window.__NEXT_DATA__ !== 'undefined'
+    || (window.webpackChunk_N_E && window.webpackChunk_N_E.length > 0);
+
+  return result;
+})();

--- a/cloakbrowser/pxbypass/site/__init__.py
+++ b/cloakbrowser/pxbypass/site/__init__.py
@@ -1,0 +1,6 @@
+"""Site-specific PX detection and solving configurations."""
+from .base import SiteHandler
+from .walmart import WalmartHandler
+from .ifood import IfoodHandler
+
+__all__ = ["SiteHandler", "WalmartHandler", "IfoodHandler"]

--- a/cloakbrowser/pxbypass/site/base.py
+++ b/cloakbrowser/pxbypass/site/base.py
@@ -44,6 +44,10 @@ class SiteHandler:
         """Run detection for this site."""
         return self.build_detector().detect(page)
 
+    async def detect_async(self, page: object) -> DetectResult:
+        """Run detection for an async Playwright page."""
+        return await self.build_detector().detect_async(page)
+
     def solve(self, page: object, cfg: object, detect_result: DetectResult | None = None) -> SolveResult:
         """Run solving for this site."""
         return self.build_solver().solve(page, cfg, detect_result)

--- a/cloakbrowser/pxbypass/site/base.py
+++ b/cloakbrowser/pxbypass/site/base.py
@@ -1,0 +1,33 @@
+"""Base SiteHandler class."""
+from __future__ import annotations
+from ..detect.base import BaseDetector, DetectResult
+from ..detect.composite import CompositeDetector
+from ..solve.base import BaseSolver, SolveResult
+from ..solve.composite import CompositeSolver
+
+
+class SiteHandler:
+    """Base class for site-specific PX configurations.
+
+    Each subclass defines which detectors and solvers to use,
+    including site-specific keywords, selectors, and parameters.
+    """
+
+    name: str = "generic"
+    priority: int = 0  # Higher = tried first
+
+    def build_detector(self) -> BaseDetector:
+        """Build the detection strategy for this site."""
+        raise NotImplementedError
+
+    def build_solver(self) -> BaseSolver:
+        """Build the solving strategy for this site."""
+        raise NotImplementedError
+
+    def detect(self, page: object) -> DetectResult:
+        """Run detection for this site."""
+        return self.build_detector().detect(page)
+
+    def solve(self, page: object, cfg: object, detect_result: DetectResult | None = None) -> SolveResult:
+        """Run solving for this site."""
+        return self.build_solver().solve(page, cfg, detect_result)

--- a/cloakbrowser/pxbypass/site/base.py
+++ b/cloakbrowser/pxbypass/site/base.py
@@ -9,12 +9,28 @@ from ..solve.composite import CompositeSolver
 class SiteHandler:
     """Base class for site-specific PX configurations.
 
-    Each subclass defines which detectors and solvers to use,
-    including site-specific keywords, selectors, and parameters.
+    Each subclass defines:
+    - A URL pattern to restrict handler to a specific domain
+    - Which detectors and solvers to use for that site
     """
 
     name: str = "generic"
     priority: int = 0  # Higher = tried first
+    url_pattern: str | None = None  # e.g. "ifood.com.br"
+
+    def match_url(self, page: object) -> bool:
+        """Check if this handler should run on the current page.
+
+        Returns True if the page URL matches this handler's domain.
+        If url_pattern is None, matches any page.
+        """
+        if self.url_pattern is None:
+            return True
+        try:
+            url = page.url
+            return self.url_pattern in url
+        except Exception:
+            return False
 
     def build_detector(self) -> BaseDetector:
         """Build the detection strategy for this site."""

--- a/cloakbrowser/pxbypass/site/ifood.py
+++ b/cloakbrowser/pxbypass/site/ifood.py
@@ -1,0 +1,28 @@
+"""iFood-specific PX handler."""
+from __future__ import annotations
+from ..detect.base import BaseDetector
+from ..detect.composite import CompositeDetector
+from ..detect.keyword import DetectPxByKeyword
+from ..detect.dom_element import DetectPxByDomElement
+from ..solve.base import BaseSolver
+from ..solve.composite import CompositeSolver
+from ..solve.press_hold_button import SolveByHoldButton
+from .base import SiteHandler
+
+
+class IfoodHandler(SiteHandler):
+    """iFood.com.br uses PerimeterX with iframe modal (same-origin)."""
+
+    name = "ifood"
+    priority = 10
+
+    def build_detector(self) -> BaseDetector:
+        return CompositeDetector([
+            DetectPxByKeyword(["pressione e segure", "antes de continuarmos", "confirmar que você"]),
+            DetectPxByDomElement(["#px-captcha-modal", "#px-captcha"]),
+        ])
+
+    def build_solver(self) -> BaseSolver:
+        return CompositeSolver([
+            SolveByHoldButton(["Pressione e segure", "Press and hold"]),
+        ])

--- a/cloakbrowser/pxbypass/site/ifood.py
+++ b/cloakbrowser/pxbypass/site/ifood.py
@@ -7,6 +7,7 @@ from ..detect.dom_element import DetectPxByDomElement
 from ..solve.base import BaseSolver
 from ..solve.composite import CompositeSolver
 from ..solve.press_hold_button import SolveByHoldButton
+from ..solve.press_hold_container import SolveByHoldContainer
 from .base import SiteHandler
 
 
@@ -15,6 +16,7 @@ class IfoodHandler(SiteHandler):
 
     name = "ifood"
     priority = 10
+    url_pattern = "ifood.com"  # Only runs on iFood pages
 
     def build_detector(self) -> BaseDetector:
         return CompositeDetector([
@@ -25,4 +27,6 @@ class IfoodHandler(SiteHandler):
     def build_solver(self) -> BaseSolver:
         return CompositeSolver([
             SolveByHoldButton(["Pressione e segure", "Press and hold"]),
+            # Fallback to container click if button not found
+            SolveByHoldContainer("#px-captcha"),
         ])

--- a/cloakbrowser/pxbypass/site/walmart.py
+++ b/cloakbrowser/pxbypass/site/walmart.py
@@ -1,0 +1,32 @@
+"""Walmart-specific PX handler."""
+from __future__ import annotations
+from ..detect.base import BaseDetector
+from ..detect.composite import CompositeDetector
+from ..detect.keyword import DetectPxByKeyword
+from ..detect.dom_element import DetectPxByDomElement
+from ..detect.script_src import DetectPxByScriptSrc
+from ..solve.base import BaseSolver
+from ..solve.composite import CompositeSolver
+from ..solve.press_hold_button import SolveByHoldButton
+from ..solve.press_hold_container import SolveByHoldContainer
+from .base import SiteHandler
+
+
+class WalmartHandler(SiteHandler):
+    """Walmart.com uses PerimeterX Cloud with cross-origin iframe."""
+
+    name = "walmart"
+    priority = 10
+
+    def build_detector(self) -> BaseDetector:
+        return CompositeDetector([
+            DetectPxByKeyword(["activate and hold", "robot or human", "Activate and hold the button"]),
+            DetectPxByDomElement(["#px-captcha", ".re-captcha"]),
+            DetectPxByScriptSrc(["px-cloud.net", "client.px-cloud.net"]),
+        ])
+
+    def build_solver(self) -> BaseSolver:
+        return CompositeSolver([
+            SolveByHoldButton(["Activate and hold"]),
+            SolveByHoldContainer("#px-captcha"),
+        ])

--- a/cloakbrowser/pxbypass/site/walmart.py
+++ b/cloakbrowser/pxbypass/site/walmart.py
@@ -4,7 +4,6 @@ from ..detect.base import BaseDetector
 from ..detect.composite import CompositeDetector
 from ..detect.keyword import DetectPxByKeyword
 from ..detect.dom_element import DetectPxByDomElement
-from ..detect.script_src import DetectPxByScriptSrc
 from ..solve.base import BaseSolver
 from ..solve.composite import CompositeSolver
 from ..solve.press_hold_button import SolveByHoldButton
@@ -20,10 +19,11 @@ class WalmartHandler(SiteHandler):
     url_pattern = "walmart.com"  # Only runs on walmart pages
 
     def build_detector(self) -> BaseDetector:
+        # Loading the PX SDK is normal on Walmart; only visible challenge text
+        # or DOM is an active captcha.
         return CompositeDetector([
             DetectPxByKeyword(["activate and hold", "robot or human", "Activate and hold the button"]),
             DetectPxByDomElement(["#px-captcha", ".re-captcha"]),
-            DetectPxByScriptSrc(["px-cloud.net", "client.px-cloud.net"]),
         ])
 
     def build_solver(self) -> BaseSolver:

--- a/cloakbrowser/pxbypass/site/walmart.py
+++ b/cloakbrowser/pxbypass/site/walmart.py
@@ -17,6 +17,7 @@ class WalmartHandler(SiteHandler):
 
     name = "walmart"
     priority = 10
+    url_pattern = "walmart.com"  # Only runs on walmart pages
 
     def build_detector(self) -> BaseDetector:
         return CompositeDetector([

--- a/cloakbrowser/pxbypass/solve/__init__.py
+++ b/cloakbrowser/pxbypass/solve/__init__.py
@@ -1,0 +1,11 @@
+"""Solving strategies for PerimeterX challenges."""
+from .base import BaseSolver, SolveResult, HoldTarget
+from .press_hold_button import SolveByHoldButton
+from .press_hold_container import SolveByHoldContainer
+from .composite import CompositeSolver
+
+__all__ = [
+    "BaseSolver", "SolveResult", "HoldTarget",
+    "SolveByHoldButton", "SolveByHoldContainer",
+    "CompositeSolver",
+]

--- a/cloakbrowser/pxbypass/solve/base.py
+++ b/cloakbrowser/pxbypass/solve/base.py
@@ -47,3 +47,7 @@ class BaseSolver:
             SolveResult indicating success/failure.
         """
         raise NotImplementedError
+
+    async def async_solve(self, page: Any, cfg: Any, detect_result: Any = None) -> SolveResult:
+        """Attempt to solve the challenge with async Playwright."""
+        raise NotImplementedError

--- a/cloakbrowser/pxbypass/solve/base.py
+++ b/cloakbrowser/pxbypass/solve/base.py
@@ -1,0 +1,49 @@
+"""Base solver class and result types."""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class HoldTarget:
+    """Position of the click/hold target in viewport coordinates."""
+    x: float
+    y: float
+    width: float
+    height: float
+    source: str = ""
+
+
+@dataclass
+class SolveResult:
+    """Result from a solving attempt.
+
+    Attributes:
+        solved: Whether the challenge was solved.
+        attempts: Number of attempts made.
+        method: Name of the solver method used.
+        duration: Total time spent solving (seconds).
+        error: Error message if failed.
+    """
+    solved: bool = False
+    attempts: int = 0
+    method: str = ""
+    duration: float = 0.0
+    error: str | None = None
+
+
+class BaseSolver:
+    """Abstract base class for PX solving strategies."""
+
+    def solve(self, page: Any, cfg: Any, detect_result: Any = None) -> SolveResult:
+        """Attempt to solve the PX challenge.
+
+        Args:
+            page: Playwright Page object.
+            cfg: PxConfig instance.
+            detect_result: Optional DetectResult from detection phase.
+
+        Returns:
+            SolveResult indicating success/failure.
+        """
+        raise NotImplementedError

--- a/cloakbrowser/pxbypass/solve/composite.py
+++ b/cloakbrowser/pxbypass/solve/composite.py
@@ -1,0 +1,46 @@
+"""Composite solver that tries multiple strategies in order."""
+from __future__ import annotations
+import logging, time
+from typing import Any
+from .base import BaseSolver, SolveResult
+
+logger = logging.getLogger("cloakbrowser.pxbypass.solve")
+
+
+class CompositeSolver(BaseSolver):
+    """Try multiple solvers in order until one succeeds.
+
+    Usage:
+        solver = CompositeSolver([
+            SolveByHoldButton(),
+            SolveByHoldContainer(),
+        ])
+    """
+
+    def __init__(self, solvers: list[BaseSolver], stop_on_first: bool = True):
+        """
+        Args:
+            solvers: List of solver instances, tried in order.
+            stop_on_first: If True, stop after first success.
+        """
+        self.solvers = solvers
+        self.stop_on_first = stop_on_first
+
+    def solve(self, page: Any, cfg: Any, detect_result: Any = None) -> SolveResult:
+        results = []
+        for solver in self.solvers:
+            logger.debug("Trying solver: %s", solver.__class__.__name__)
+            result = solver.solve(page, cfg, detect_result)
+            results.append(result)
+            if result.solved and self.stop_on_first:
+                logger.info("Solver %s succeeded", solver.__class__.__name__)
+                return result
+            if not result.solved:
+                logger.debug("Solver %s failed: %s", solver.__class__.__name__, result.error)
+        # Return best result
+        solved = [r for r in results if r.solved]
+        if solved:
+            return solved[0]
+        if results:
+            return results[-1]
+        return SolveResult(method="CompositeSolver", error="no_solvers")

--- a/cloakbrowser/pxbypass/solve/composite.py
+++ b/cloakbrowser/pxbypass/solve/composite.py
@@ -44,3 +44,21 @@ class CompositeSolver(BaseSolver):
         if results:
             return results[-1]
         return SolveResult(method="CompositeSolver", error="no_solvers")
+
+    async def async_solve(self, page: Any, cfg: Any, detect_result: Any = None) -> SolveResult:
+        results = []
+        for solver in self.solvers:
+            logger.debug("Trying async solver: %s", solver.__class__.__name__)
+            result = await solver.async_solve(page, cfg, detect_result)
+            results.append(result)
+            if result.solved and self.stop_on_first:
+                logger.info("Async solver %s succeeded", solver.__class__.__name__)
+                return result
+            if not result.solved:
+                logger.debug("Async solver %s failed: %s", solver.__class__.__name__, result.error)
+        solved = [result for result in results if result.solved]
+        if solved:
+            return solved[0]
+        if results:
+            return results[-1]
+        return SolveResult(method="CompositeSolver", error="no_solvers")

--- a/cloakbrowser/pxbypass/solve/press_hold_button.py
+++ b/cloakbrowser/pxbypass/solve/press_hold_button.py
@@ -1,13 +1,24 @@
-"""Solve PX by locating hold button text and simulating press-and-hold."""
+"""Solve PX by locating hold button text and simulating press-and-hold.
+
+Uses refined button detection that distinguishes actual hold buttons
+from instruction paragraphs — prevents false positive on text like
+"Pressione e segure para confirmar que você não é um bot".
+"""
 from __future__ import annotations
-import logging, random, time
+import logging, random, re
 from typing import Any
 from .base import BaseSolver, SolveResult, HoldTarget
 from ..config import PX_HOLD_BUTTON_LABELS
 
 logger = logging.getLogger("cloakbrowser.pxbypass.solve")
 
-# JS: find hold button in main document / iframe modal
+# Regex matching ONLY the short button label (not instruction paragraph)
+_HOLD_BTN_RE = re.compile(
+    r"^\s*(pressione e segure|press and hold|press & hold)\s*$",
+    re.IGNORECASE,
+)
+
+# JS scorer: score elements, penalizing instruction paragraphs
 _PICK_HOLD_BUTTON_JS = """
 () => {
   const btnLabels = ['pressione e segure', 'press and hold', 'press & hold', 'activate and hold'];
@@ -27,7 +38,7 @@ _PICK_HOLD_BUTTON_JS = """
     if (el.tagName === 'DIV' || el.tagName === 'A') s += 15;
     return s;
   }
-  function scanDoc(doc) {
+  function scanDoc(doc, offsetLeft, offsetTop) {
     let best = null, bestScore = -1;
     for (const el of doc.querySelectorAll('button, [role="button"], a, div, span')) {
       const s = scoreHoldButton(el);
@@ -35,37 +46,74 @@ _PICK_HOLD_BUTTON_JS = """
     }
     if (!best) return null;
     const r = best.getBoundingClientRect();
-    return { x: r.left + r.width/2, y: r.top + r.height/2, w: r.width, h: r.height,
-             text: (best.innerText||'').slice(0,40), tag: best.tagName, source: 'px-hold-button' };
+    return {
+      x: offsetLeft + r.left + r.width/2,
+      y: offsetTop + r.top + r.height/2,
+      w: r.width, h: r.height,
+      text: (best.innerText||'').slice(0,40), tag: best.tagName,
+      source: 'px-hold-button'
+    };
   }
+  // Check iframe modal first (iFood style)
   var modal = document.getElementById('px-captcha-modal');
   if (modal && modal.contentDocument) {
     var ir = modal.getBoundingClientRect();
-    var hit = scanDoc(modal.contentDocument);
-    if (hit) { hit.x += ir.left; hit.y += ir.top; return hit; }
+    var hit = scanDoc(modal.contentDocument, ir.left, ir.top);
+    if (hit) return hit;
   }
-  return scanDoc(document);
+  return scanDoc(document, 0, 0);
 }
 """
+
+# JS: check if element is a real hold button (not instruction text)
+_IS_REAL_HOLD_BTN_JS = """(el) => {
+  const t = (el.innerText || '').trim();
+  const r = el.getBoundingClientRect();
+  const tag = el.tagName;
+  const role = el.getAttribute('role');
+  const exactHold = /^(pressione e segure|press and hold|press & hold)$/i.test(t);
+  const isInstruction = /antes de continuarmos|confirmar que voc\u00ea|n\u00e3o um bot|thank you/i.test(t);
+  const isParagraph = ['P','H1','H2','H3'].includes(tag) && t.length > 40;
+  const sizeOk = r.width >= 70 && r.height >= 22 && r.height <= 90;
+  return {
+    ok: sizeOk && !isInstruction && !isParagraph && (
+      exactHold ||
+      role === 'button' || tag === 'BUTTON' ||
+      (t.length <= 40 && /segure|hold/i.test(t))
+    ),
+    text: t.slice(0, 60),
+    w: r.width, h: r.height, tag: tag,
+  };
+}"""
 
 
 class SolveByHoldButton(BaseSolver):
     """Solve "Press & Hold" by locating button text and simulating hold.
 
     Works for same-origin and iframe-modal PX variants (iFood, etc.).
+    Uses refined detection to avoid confusing instruction text with buttons.
     """
 
     def __init__(self, labels: list[str] | None = None):
         self.labels = labels or list(PX_HOLD_BUTTON_LABELS)
 
+    def _is_real_button(self, page: Any, locator: Any) -> bool:
+        """Check if a Playwright locator points to a real hold button."""
+        try:
+            meta = locator.evaluate(_IS_REAL_HOLD_BTN_JS)
+            return bool(meta and meta.get("ok"))
+        except Exception:
+            return False
+
     def find_target(self, page: Any) -> HoldTarget | None:
-        # Strategy A: Playwright exact text locator
+        # Strategy A: Playwright locator via exact text match (most reliable)
         try:
             for label in self.labels:
                 loc = page.get_by_text(label, exact=True).first
-                if loc.count() and loc.is_visible():
+                if loc.count() and loc.is_visible() and self._is_real_button(page, loc):
                     box = loc.bounding_box()
                     if box and box["width"] >= 70 and box["height"] >= 22:
+                        logger.debug("Button found via exact text: %s", label)
                         return HoldTarget(
                             x=box["x"] + box["width"] / 2,
                             y=box["y"] + box["height"] / 2,
@@ -74,7 +122,60 @@ class SolveByHoldButton(BaseSolver):
                         )
         except Exception:
             pass
-        # Strategy B: JS scorer
+
+        # Strategy B: role=button with regex name
+        try:
+            loc = page.get_by_role(
+                "button",
+                name=re.compile(r"pressione e segure|press and hold|press & hold", re.I),
+            ).first
+            if loc.count() and loc.is_visible() and self._is_real_button(page, loc):
+                box = loc.bounding_box()
+                if box and box["width"] >= 70:
+                    return HoldTarget(
+                        x=box["x"] + box["width"] / 2,
+                        y=box["y"] + box["height"] / 2,
+                        width=box["width"], height=box["height"],
+                        source="role:button",
+                    )
+        except Exception:
+            pass
+
+        # Strategy C: filter locator with exact regex
+        try:
+            loc = page.locator("button, [role='button'], div, a").filter(
+                has_text=_HOLD_BTN_RE,
+            ).first
+            if loc.count() and loc.is_visible() and self._is_real_button(page, loc):
+                box = loc.bounding_box()
+                if box and box["width"] >= 70:
+                    return HoldTarget(
+                        x=box["x"] + box["width"] / 2,
+                        y=box["y"] + box["height"] / 2,
+                        width=box["width"], height=box["height"],
+                        source="filter:hold-btn",
+                    )
+        except Exception:
+            pass
+
+        # Strategy D: iframe modal (iFood #px-captcha-modal)
+        try:
+            modal_frame = page.frame_locator("#px-captcha-modal")
+            for label in self.labels:
+                loc = modal_frame.get_by_text(label, exact=True).first
+                if loc.count() and loc.is_visible() and self._is_real_button(page, loc):
+                    box = loc.bounding_box()
+                    if box and box["width"] >= 70:
+                        return HoldTarget(
+                            x=box["x"] + box["width"] / 2,
+                            y=box["y"] + box["height"] / 2,
+                            width=box["width"], height=box["height"],
+                            source=f"modal:{label[:12]}",
+                        )
+        except Exception:
+            pass
+
+        # Strategy E: JS scorer (covers all remaining cases)
         try:
             raw = page.evaluate(_PICK_HOLD_BUTTON_JS)
             if raw and raw.get("w") and raw["w"] >= 70:
@@ -85,65 +186,108 @@ class SolveByHoldButton(BaseSolver):
                 )
         except Exception:
             pass
+
         return None
 
-    def simulate_hold(self, page: Any, target: HoldTarget, hold_min: float, hold_max: float, attempt: int) -> None:
+    def simulate_hold(self, page: Any, target: HoldTarget,
+                      hold_min: float, hold_max: float, attempt: int,
+                      locator: Any = None) -> None:
+        """Simulate press-and-hold with human-like mouse movements."""
         hold_sec = random.uniform(hold_min, hold_max)
         tx = target.x + random.uniform(-target.width * 0.06, target.width * 0.06)
         ty = target.y + random.uniform(-target.height * 0.05, target.height * 0.05)
-        logger.info("Hold %d: (%.0f,%.0f) %.1fs via %s", attempt, tx, ty, hold_sec, target.source)
+
+        # Scroll into view if locator is available
+        if locator is not None:
+            try:
+                locator.scroll_into_view_if_needed(timeout=5000)
+            except Exception:
+                pass
+
+        logger.info("Hold %d: (%.0f,%.0f) %.1fs via %s",
+                     attempt, tx, ty, hold_sec, target.source)
+
+        # Human-like movement to target
         self._human_move_to(page, tx, ty)
-        time.sleep(random.uniform(0.06, 0.14))
+
+        # Hover on locator for precise iframe targeting
+        if locator is not None:
+            try:
+                locator.hover(timeout=3000, force=True)
+                box = locator.bounding_box()
+                if box:
+                    tx = box["x"] + box["width"] / 2 + random.uniform(-2, 2)
+                    ty = box["y"] + box["height"] / 2 + random.uniform(-2, 2)
+                    page.mouse.move(tx, ty)
+            except Exception:
+                pass
+
+        import time as _time
+        _time.sleep(random.uniform(0.06, 0.14))
         page.mouse.down(button="left")
+
+        # Hold with micro-movements
         elapsed = 0.0
         while elapsed < hold_sec:
             chunk = random.uniform(0.12, 0.32)
-            time.sleep(chunk)
+            _time.sleep(chunk)
             elapsed += chunk
             try:
-                page.mouse.move(tx + random.uniform(-3.5, 3.5), ty + random.uniform(-2.5, 2.5))
+                page.mouse.move(tx + random.uniform(-3.5, 3.5),
+                                 ty + random.uniform(-2.5, 2.5))
             except Exception:
                 pass
-        time.sleep(random.uniform(0.05, 0.15))
+
+        _time.sleep(random.uniform(0.05, 0.15))
         page.mouse.up(button="left")
         logger.info("Hold %d: done (%.1fs)", attempt, hold_sec)
 
     def _human_move_to(self, page: Any, tx: float, ty: float) -> None:
+        """Move mouse to target with Bezier-like trajectory."""
         vp = page.viewport_size or {"width": 1280, "height": 720}
         sx = random.uniform(vp["width"] * 0.2, vp["width"] * 0.8)
         sy = random.uniform(vp["height"] * 0.2, vp["height"] * 0.8)
         steps = random.randint(10, 18)
         page.mouse.move(sx, sy)
-        time.sleep(random.uniform(0.08, 0.2))
+        import time as _time
+        _time.sleep(random.uniform(0.08, 0.2))
         for i in range(1, steps + 1):
             t = i / steps
             ease = t * t * (3 - 2 * t)
             cx = sx + (tx - sx) * ease + random.uniform(-2.5, 2.5)
             cy = sy + (ty - sy) * ease + random.uniform(-2.5, 2.5)
             page.mouse.move(cx, cy)
-            time.sleep(random.uniform(0.015, 0.04))
+            _time.sleep(random.uniform(0.015, 0.04))
         page.mouse.move(tx, ty)
-        time.sleep(random.uniform(0.05, 0.12))
+        _time.sleep(random.uniform(0.05, 0.12))
 
     def solve(self, page: Any, cfg: Any, detect_result: Any = None) -> SolveResult:
         import time as _time
         start = _time.monotonic()
         target = self.find_target(page)
         if target is None:
-            return SolveResult(method="SolveByHoldButton", duration=_time.monotonic() - start, error="no_target")
+            return SolveResult(method="SolveByHoldButton",
+                               duration=_time.monotonic() - start,
+                               error="no_target")
+
         for attempt in range(1, cfg.max_attempts + 1):
             try:
                 self.simulate_hold(page, target, cfg.hold_min, cfg.hold_max, attempt)
             except Exception as e:
-                return SolveResult(method="SolveByHoldButton", attempts=attempt, duration=_time.monotonic() - start, error=str(e))
-            # Check clear
+                return SolveResult(method="SolveByHoldButton", attempts=attempt,
+                                   duration=_time.monotonic() - start, error=str(e))
+            # Check if PX cleared
             deadline = _time.monotonic() + cfg.post_wait
             while _time.monotonic() < deadline:
                 if not self._is_px_visible(page):
-                    return SolveResult(solved=True, method="SolveByHoldButton", attempts=attempt, duration=_time.monotonic() - start)
+                    return SolveResult(solved=True, method="SolveByHoldButton",
+                                       attempts=attempt,
+                                       duration=_time.monotonic() - start)
                 _time.sleep(0.5)
             _time.sleep(random.uniform(1.5, 3.0))
-        return SolveResult(method="SolveByHoldButton", attempts=cfg.max_attempts, duration=_time.monotonic() - start, error="max_attempts")
+
+        return SolveResult(method="SolveByHoldButton", attempts=cfg.max_attempts,
+                           duration=_time.monotonic() - start, error="max_attempts")
 
     def _is_px_visible(self, page: Any) -> bool:
         try:
@@ -151,7 +295,8 @@ class SolveByHoldButton(BaseSolver):
                 if (document.getElementById('px-captcha')) return true;
                 if (document.getElementById('px-captcha-modal')) return true;
                 const body = (document.body ? document.body.innerText : '') || '';
-                return body.toLowerCase().includes('activate and hold') || body.toLowerCase().includes('press and hold');
+                return body.toLowerCase().includes('activate and hold')
+                    || body.toLowerCase().includes('press and hold');
             }"""))
         except Exception:
             return True

--- a/cloakbrowser/pxbypass/solve/press_hold_button.py
+++ b/cloakbrowser/pxbypass/solve/press_hold_button.py
@@ -5,7 +5,11 @@ from instruction paragraphs — prevents false positive on text like
 "Pressione e segure para confirmar que você não é um bot".
 """
 from __future__ import annotations
-import logging, random, re
+import asyncio
+import logging
+import random
+import re
+import time
 from typing import Any
 from .base import BaseSolver, SolveResult, HoldTarget
 from ..config import PX_HOLD_BUTTON_LABELS
@@ -92,6 +96,7 @@ class SolveByHoldButton(BaseSolver):
 
     Works for same-origin and iframe-modal PX variants (iFood, etc.).
     Uses refined detection to avoid confusing instruction text with buttons.
+    Supports both sync and async solving.
     """
 
     def __init__(self, labels: list[str] | None = None):
@@ -101,6 +106,14 @@ class SolveByHoldButton(BaseSolver):
         """Check if a Playwright locator points to a real hold button."""
         try:
             meta = locator.evaluate(_IS_REAL_HOLD_BTN_JS)
+            return bool(meta and meta.get("ok"))
+        except Exception:
+            return False
+
+    async def _is_real_button_async(self, page: Any, locator: Any) -> bool:
+        """Check if a Playwright locator points to a real hold button (async)."""
+        try:
+            meta = await locator.evaluate(_IS_REAL_HOLD_BTN_JS)
             return bool(meta and meta.get("ok"))
         except Exception:
             return False
@@ -189,6 +202,86 @@ class SolveByHoldButton(BaseSolver):
 
         return None
 
+    async def find_target_async(self, page: Any) -> HoldTarget | None:
+        """Async version of find_target."""
+        try:
+            for label in self.labels:
+                loc = page.get_by_text(label, exact=True).first
+                if await loc.count() and await loc.is_visible() and await self._is_real_button_async(page, loc):
+                    box = await loc.bounding_box()
+                    if box and box["width"] >= 70 and box["height"] >= 22:
+                        logger.debug("Button found via exact text (async): %s", label)
+                        return HoldTarget(
+                            x=box["x"] + box["width"] / 2,
+                            y=box["y"] + box["height"] / 2,
+                            width=box["width"], height=box["height"],
+                            source=f"playwright:{label[:12]}",
+                        )
+        except Exception:
+            pass
+
+        try:
+            loc = page.get_by_role(
+                "button",
+                name=re.compile(r"pressione e segure|press and hold|press & hold", re.I),
+            ).first
+            if await loc.count() and await loc.is_visible() and await self._is_real_button_async(page, loc):
+                box = await loc.bounding_box()
+                if box and box["width"] >= 70:
+                    return HoldTarget(
+                        x=box["x"] + box["width"] / 2,
+                        y=box["y"] + box["height"] / 2,
+                        width=box["width"], height=box["height"],
+                        source="role:button",
+                    )
+        except Exception:
+            pass
+
+        try:
+            loc = page.locator("button, [role='button'], div, a").filter(
+                has_text=_HOLD_BTN_RE,
+            ).first
+            if await loc.count() and await loc.is_visible() and await self._is_real_button_async(page, loc):
+                box = await loc.bounding_box()
+                if box and box["width"] >= 70:
+                    return HoldTarget(
+                        x=box["x"] + box["width"] / 2,
+                        y=box["y"] + box["height"] / 2,
+                        width=box["width"], height=box["height"],
+                        source="filter:hold-btn",
+                    )
+        except Exception:
+            pass
+
+        try:
+            modal_frame = page.frame_locator("#px-captcha-modal")
+            for label in self.labels:
+                loc = modal_frame.get_by_text(label, exact=True).first
+                if await loc.count() and await loc.is_visible() and await self._is_real_button_async(page, loc):
+                    box = await loc.bounding_box()
+                    if box and box["width"] >= 70:
+                        return HoldTarget(
+                            x=box["x"] + box["width"] / 2,
+                            y=box["y"] + box["height"] / 2,
+                            width=box["width"], height=box["height"],
+                            source=f"modal:{label[:12]}",
+                        )
+        except Exception:
+            pass
+
+        try:
+            raw = await page.evaluate(_PICK_HOLD_BUTTON_JS)
+            if raw and raw.get("w") and raw["w"] >= 70:
+                return HoldTarget(
+                    x=float(raw["x"]), y=float(raw["y"]),
+                    width=float(raw["w"]), height=float(raw["h"]),
+                    source=f"js:{raw.get('source', 'px-btn')}",
+                )
+        except Exception:
+            pass
+
+        return None
+
     def simulate_hold(self, page: Any, target: HoldTarget,
                       hold_min: float, hold_max: float, attempt: int,
                       locator: Any = None) -> None:
@@ -222,15 +315,14 @@ class SolveByHoldButton(BaseSolver):
             except Exception:
                 pass
 
-        import time as _time
-        _time.sleep(random.uniform(0.06, 0.14))
+        time.sleep(random.uniform(0.06, 0.14))
         page.mouse.down(button="left")
 
         # Hold with micro-movements
         elapsed = 0.0
         while elapsed < hold_sec:
             chunk = random.uniform(0.12, 0.32)
-            _time.sleep(chunk)
+            time.sleep(chunk)
             elapsed += chunk
             try:
                 page.mouse.move(tx + random.uniform(-3.5, 3.5),
@@ -238,8 +330,56 @@ class SolveByHoldButton(BaseSolver):
             except Exception:
                 pass
 
-        _time.sleep(random.uniform(0.05, 0.15))
+        time.sleep(random.uniform(0.05, 0.15))
         page.mouse.up(button="left")
+        logger.info("Hold %d: done (%.1fs)", attempt, hold_sec)
+
+    async def simulate_hold_async(self, page: Any, target: HoldTarget,
+                                   hold_min: float, hold_max: float, attempt: int,
+                                   locator: Any = None) -> None:
+        """Simulate press-and-hold with human-like mouse movements (async)."""
+        hold_sec = random.uniform(hold_min, hold_max)
+        tx = target.x + random.uniform(-target.width * 0.06, target.width * 0.06)
+        ty = target.y + random.uniform(-target.height * 0.05, target.height * 0.05)
+
+        if locator is not None:
+            try:
+                await locator.scroll_into_view_if_needed(timeout=5000)
+            except Exception:
+                pass
+
+        logger.info("Hold %d: (%.0f,%.0f) %.1fs via %s",
+                     attempt, tx, ty, hold_sec, target.source)
+
+        await self._human_move_to_async(page, tx, ty)
+
+        if locator is not None:
+            try:
+                await locator.hover(timeout=3000, force=True)
+                box = await locator.bounding_box()
+                if box:
+                    tx = box["x"] + box["width"] / 2 + random.uniform(-2, 2)
+                    ty = box["y"] + box["height"] / 2 + random.uniform(-2, 2)
+                    await page.mouse.move(tx, ty)
+            except Exception:
+                pass
+
+        await asyncio.sleep(random.uniform(0.06, 0.14))
+        await page.mouse.down(button="left")
+
+        elapsed = 0.0
+        while elapsed < hold_sec:
+            chunk = random.uniform(0.12, 0.32)
+            await asyncio.sleep(chunk)
+            elapsed += chunk
+            try:
+                await page.mouse.move(tx + random.uniform(-3.5, 3.5),
+                                       ty + random.uniform(-2.5, 2.5))
+            except Exception:
+                pass
+
+        await asyncio.sleep(random.uniform(0.05, 0.15))
+        await page.mouse.up(button="left")
         logger.info("Hold %d: done (%.1fs)", attempt, hold_sec)
 
     def _human_move_to(self, page: Any, tx: float, ty: float) -> None:
@@ -249,54 +389,190 @@ class SolveByHoldButton(BaseSolver):
         sy = random.uniform(vp["height"] * 0.2, vp["height"] * 0.8)
         steps = random.randint(10, 18)
         page.mouse.move(sx, sy)
-        import time as _time
-        _time.sleep(random.uniform(0.08, 0.2))
+        time.sleep(random.uniform(0.08, 0.2))
         for i in range(1, steps + 1):
-            t = i / steps
-            ease = t * t * (3 - 2 * t)
+            t_val = i / steps
+            ease = t_val * t_val * (3 - 2 * t_val)
             cx = sx + (tx - sx) * ease + random.uniform(-2.5, 2.5)
             cy = sy + (ty - sy) * ease + random.uniform(-2.5, 2.5)
             page.mouse.move(cx, cy)
-            _time.sleep(random.uniform(0.015, 0.04))
+            time.sleep(random.uniform(0.015, 0.04))
         page.mouse.move(tx, ty)
-        _time.sleep(random.uniform(0.05, 0.12))
+        time.sleep(random.uniform(0.05, 0.12))
 
-    def solve(self, page: Any, cfg: Any, detect_result: Any = None) -> SolveResult:
-        import time as _time
-        start = _time.monotonic()
-        target = self.find_target(page)
-        if target is None:
-            return SolveResult(method="SolveByHoldButton",
-                               duration=_time.monotonic() - start,
-                               error="no_target")
-
-        for attempt in range(1, cfg.max_attempts + 1):
-            try:
-                self.simulate_hold(page, target, cfg.hold_min, cfg.hold_max, attempt)
-            except Exception as e:
-                return SolveResult(method="SolveByHoldButton", attempts=attempt,
-                                   duration=_time.monotonic() - start, error=str(e))
-            # Check if PX cleared
-            deadline = _time.monotonic() + cfg.post_wait
-            while _time.monotonic() < deadline:
-                if not self._is_px_visible(page):
-                    return SolveResult(solved=True, method="SolveByHoldButton",
-                                       attempts=attempt,
-                                       duration=_time.monotonic() - start)
-                _time.sleep(0.5)
-            _time.sleep(random.uniform(1.5, 3.0))
-
-        return SolveResult(method="SolveByHoldButton", attempts=cfg.max_attempts,
-                           duration=_time.monotonic() - start, error="max_attempts")
+    async def _human_move_to_async(self, page: Any, tx: float, ty: float) -> None:
+        """Move mouse to target with Bezier-like trajectory (async)."""
+        vp = page.viewport_size or {"width": 1280, "height": 720}
+        sx = random.uniform(vp["width"] * 0.2, vp["width"] * 0.8)
+        sy = random.uniform(vp["height"] * 0.2, vp["height"] * 0.8)
+        steps = random.randint(10, 18)
+        await page.mouse.move(sx, sy)
+        await asyncio.sleep(random.uniform(0.08, 0.2))
+        for i in range(1, steps + 1):
+            t_val = i / steps
+            ease = t_val * t_val * (3 - 2 * t_val)
+            cx = sx + (tx - sx) * ease + random.uniform(-2.5, 2.5)
+            cy = sy + (ty - sy) * ease + random.uniform(-2.5, 2.5)
+            await page.mouse.move(cx, cy)
+            await asyncio.sleep(random.uniform(0.015, 0.04))
+        await page.mouse.move(tx, ty)
+        await asyncio.sleep(random.uniform(0.05, 0.12))
 
     def _is_px_visible(self, page: Any) -> bool:
+        """Check if PX UI is still visible."""
         try:
             return bool(page.evaluate("""() => {
                 if (document.getElementById('px-captcha')) return true;
                 if (document.getElementById('px-captcha-modal')) return true;
                 const body = (document.body ? document.body.innerText : '') || '';
                 return body.toLowerCase().includes('activate and hold')
-                    || body.toLowerCase().includes('press and hold');
+                    || body.toLowerCase().includes('press and hold')
+                    || body.toLowerCase().includes('pressione e segure');
             }"""))
         except Exception:
             return True
+
+    async def _is_px_visible_async(self, page: Any) -> bool:
+        """Check if PX UI is still visible (async)."""
+        try:
+            return bool(await page.evaluate("""() => {
+                if (document.getElementById('px-captcha')) return true;
+                if (document.getElementById('px-captcha-modal')) return true;
+                const body = (document.body ? document.body.innerText : '') || '';
+                return body.toLowerCase().includes('activate and hold')
+                    || body.toLowerCase().includes('press and hold')
+                    || body.toLowerCase().includes('pressione e segure');
+            }"""))
+        except Exception:
+            return True
+
+    def _wait_until_ready(self, page: Any, cfg: Any) -> bool:
+        checker = getattr(cfg, "checker", None)
+        if checker is None:
+            return True
+        deadline = time.monotonic() + getattr(cfg, "app_ready_timeout", 60.0)
+        while True:
+            try:
+                if checker(page):
+                    return True
+            except Exception:
+                pass
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(0.8)
+
+    async def _wait_until_ready_async(self, page: Any, cfg: Any) -> bool:
+        checker = getattr(cfg, "checker", None)
+        if checker is None:
+            return True
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + getattr(cfg, "app_ready_timeout", 60.0)
+        while True:
+            try:
+                ready = checker(page)
+                if hasattr(ready, "__await__"):
+                    ready = await ready
+                if ready:
+                    return True
+            except Exception:
+                pass
+            if loop.time() >= deadline:
+                return False
+            await asyncio.sleep(0.8)
+
+    def _success_result(self, page: Any, cfg: Any, attempt: int, start: float) -> SolveResult:
+        if not self._wait_until_ready(page, cfg):
+            return SolveResult(method="SolveByHoldButton", attempts=attempt,
+                               duration=time.monotonic() - start, error="app_not_ready")
+        return SolveResult(solved=True, method="SolveByHoldButton", attempts=attempt,
+                           duration=time.monotonic() - start)
+
+    async def _success_result_async(self, page: Any, cfg: Any, attempt: int, start: float) -> SolveResult:
+        if not await self._wait_until_ready_async(page, cfg):
+            return SolveResult(method="SolveByHoldButton", attempts=attempt,
+                               duration=time.monotonic() - start, error="app_not_ready")
+        return SolveResult(solved=True, method="SolveByHoldButton", attempts=attempt,
+                           duration=time.monotonic() - start)
+
+    def solve(self, page: Any, cfg: Any, detect_result: Any = None) -> SolveResult:
+        import time as _time
+        start = _time.monotonic()
+
+        # Wait for a target to appear
+        target = None
+        button_wait = getattr(cfg, 'button_wait_timeout', 20.0)
+        deadline = _time.monotonic() + button_wait
+        while _time.monotonic() < deadline:
+            target = self.find_target(page)
+            if target is not None:
+                break
+            _time.sleep(0.5)
+
+        if target is None:
+            return SolveResult(method="SolveByHoldButton",
+                               duration=_time.monotonic() - start,
+                               error="no_target")
+
+        for attempt in range(1, cfg.max_attempts + 1):
+            if not self._is_px_visible(page):
+                return self._success_result(page, cfg, attempt, start)
+
+            # Re-find target before each attempt
+            current = self.find_target(page) or target
+            try:
+                self.simulate_hold(page, current, cfg.hold_min, cfg.hold_max, attempt)
+            except Exception as e:
+                return SolveResult(method="SolveByHoldButton", attempts=attempt,
+                                   duration=_time.monotonic() - start, error=str(e))
+            # Check if PX cleared
+            post_deadline = _time.monotonic() + cfg.post_wait
+            while _time.monotonic() < post_deadline:
+                if not self._is_px_visible(page):
+                    return self._success_result(page, cfg, attempt, start)
+                _time.sleep(0.5)
+            _time.sleep(random.uniform(1.5, 3.0))
+
+        return SolveResult(method="SolveByHoldButton", attempts=cfg.max_attempts,
+                           duration=_time.monotonic() - start, error="max_attempts")
+
+    async def async_solve(self, page: Any, cfg: Any, detect_result: Any = None) -> SolveResult:
+        """Async version of solve()."""
+        import time as _time
+        start = _time.monotonic()
+
+        # Wait for a target to appear
+        target = None
+        button_wait = getattr(cfg, 'button_wait_timeout', 20.0)
+        deadline = _time.monotonic() + button_wait
+        while _time.monotonic() < deadline:
+            target = await self.find_target_async(page)
+            if target is not None:
+                break
+            await asyncio.sleep(0.5)
+
+        if target is None:
+            return SolveResult(method="SolveByHoldButton",
+                               duration=_time.monotonic() - start,
+                               error="no_target")
+
+        for attempt in range(1, cfg.max_attempts + 1):
+            if not await self._is_px_visible_async(page):
+                return await self._success_result_async(page, cfg, attempt, start)
+
+            # Re-find target before each attempt
+            current = await self.find_target_async(page) or target
+            try:
+                await self.simulate_hold_async(page, current, cfg.hold_min, cfg.hold_max, attempt)
+            except Exception as e:
+                return SolveResult(method="SolveByHoldButton", attempts=attempt,
+                                   duration=_time.monotonic() - start, error=str(e))
+
+            post_deadline = _time.monotonic() + cfg.post_wait
+            while _time.monotonic() < post_deadline:
+                if not await self._is_px_visible_async(page):
+                    return await self._success_result_async(page, cfg, attempt, start)
+                await asyncio.sleep(0.5)
+            await asyncio.sleep(random.uniform(1.5, 3.0))
+
+        return SolveResult(method="SolveByHoldButton", attempts=cfg.max_attempts,
+                           duration=_time.monotonic() - start, error="max_attempts")

--- a/cloakbrowser/pxbypass/solve/press_hold_button.py
+++ b/cloakbrowser/pxbypass/solve/press_hold_button.py
@@ -1,0 +1,157 @@
+"""Solve PX by locating hold button text and simulating press-and-hold."""
+from __future__ import annotations
+import logging, random, time
+from typing import Any
+from .base import BaseSolver, SolveResult, HoldTarget
+from ..config import PX_HOLD_BUTTON_LABELS
+
+logger = logging.getLogger("cloakbrowser.pxbypass.solve")
+
+# JS: find hold button in main document / iframe modal
+_PICK_HOLD_BUTTON_JS = """
+() => {
+  const btnLabels = ['pressione e segure', 'press and hold', 'press & hold', 'activate and hold'];
+  const instructionRe = /antes de continuarmos|confirmar que voc\u00ea|n\u00e3o um bot|thank you/i;
+  function scoreHoldButton(el) {
+    const t = (el.innerText || '').trim();
+    const r = el.getBoundingClientRect();
+    if (r.width < 70 || r.height < 22 || r.height > 90) return -1;
+    if (instructionRe.test(t)) return -1;
+    if (['P','H1','H2','H3'].includes(el.tagName) && t.length > 40) return -1;
+    const tLow = t.toLowerCase();
+    let s = -1;
+    if (btnLabels.some(l => tLow === l)) s = 200;
+    else if (btnLabels.some(l => tLow.includes(l)) && t.length <= 40) s = 80;
+    else return -1;
+    if (el.getAttribute('role') === 'button' || el.tagName === 'BUTTON') s += 60;
+    if (el.tagName === 'DIV' || el.tagName === 'A') s += 15;
+    return s;
+  }
+  function scanDoc(doc) {
+    let best = null, bestScore = -1;
+    for (const el of doc.querySelectorAll('button, [role="button"], a, div, span')) {
+      const s = scoreHoldButton(el);
+      if (s > bestScore) { bestScore = s; best = el; }
+    }
+    if (!best) return null;
+    const r = best.getBoundingClientRect();
+    return { x: r.left + r.width/2, y: r.top + r.height/2, w: r.width, h: r.height,
+             text: (best.innerText||'').slice(0,40), tag: best.tagName, source: 'px-hold-button' };
+  }
+  var modal = document.getElementById('px-captcha-modal');
+  if (modal && modal.contentDocument) {
+    var ir = modal.getBoundingClientRect();
+    var hit = scanDoc(modal.contentDocument);
+    if (hit) { hit.x += ir.left; hit.y += ir.top; return hit; }
+  }
+  return scanDoc(document);
+}
+"""
+
+
+class SolveByHoldButton(BaseSolver):
+    """Solve "Press & Hold" by locating button text and simulating hold.
+
+    Works for same-origin and iframe-modal PX variants (iFood, etc.).
+    """
+
+    def __init__(self, labels: list[str] | None = None):
+        self.labels = labels or list(PX_HOLD_BUTTON_LABELS)
+
+    def find_target(self, page: Any) -> HoldTarget | None:
+        # Strategy A: Playwright exact text locator
+        try:
+            for label in self.labels:
+                loc = page.get_by_text(label, exact=True).first
+                if loc.count() and loc.is_visible():
+                    box = loc.bounding_box()
+                    if box and box["width"] >= 70 and box["height"] >= 22:
+                        return HoldTarget(
+                            x=box["x"] + box["width"] / 2,
+                            y=box["y"] + box["height"] / 2,
+                            width=box["width"], height=box["height"],
+                            source=f"playwright:{label[:12]}",
+                        )
+        except Exception:
+            pass
+        # Strategy B: JS scorer
+        try:
+            raw = page.evaluate(_PICK_HOLD_BUTTON_JS)
+            if raw and raw.get("w") and raw["w"] >= 70:
+                return HoldTarget(
+                    x=float(raw["x"]), y=float(raw["y"]),
+                    width=float(raw["w"]), height=float(raw["h"]),
+                    source=f"js:{raw.get('source', 'px-btn')}",
+                )
+        except Exception:
+            pass
+        return None
+
+    def simulate_hold(self, page: Any, target: HoldTarget, hold_min: float, hold_max: float, attempt: int) -> None:
+        hold_sec = random.uniform(hold_min, hold_max)
+        tx = target.x + random.uniform(-target.width * 0.06, target.width * 0.06)
+        ty = target.y + random.uniform(-target.height * 0.05, target.height * 0.05)
+        logger.info("Hold %d: (%.0f,%.0f) %.1fs via %s", attempt, tx, ty, hold_sec, target.source)
+        self._human_move_to(page, tx, ty)
+        time.sleep(random.uniform(0.06, 0.14))
+        page.mouse.down(button="left")
+        elapsed = 0.0
+        while elapsed < hold_sec:
+            chunk = random.uniform(0.12, 0.32)
+            time.sleep(chunk)
+            elapsed += chunk
+            try:
+                page.mouse.move(tx + random.uniform(-3.5, 3.5), ty + random.uniform(-2.5, 2.5))
+            except Exception:
+                pass
+        time.sleep(random.uniform(0.05, 0.15))
+        page.mouse.up(button="left")
+        logger.info("Hold %d: done (%.1fs)", attempt, hold_sec)
+
+    def _human_move_to(self, page: Any, tx: float, ty: float) -> None:
+        vp = page.viewport_size or {"width": 1280, "height": 720}
+        sx = random.uniform(vp["width"] * 0.2, vp["width"] * 0.8)
+        sy = random.uniform(vp["height"] * 0.2, vp["height"] * 0.8)
+        steps = random.randint(10, 18)
+        page.mouse.move(sx, sy)
+        time.sleep(random.uniform(0.08, 0.2))
+        for i in range(1, steps + 1):
+            t = i / steps
+            ease = t * t * (3 - 2 * t)
+            cx = sx + (tx - sx) * ease + random.uniform(-2.5, 2.5)
+            cy = sy + (ty - sy) * ease + random.uniform(-2.5, 2.5)
+            page.mouse.move(cx, cy)
+            time.sleep(random.uniform(0.015, 0.04))
+        page.mouse.move(tx, ty)
+        time.sleep(random.uniform(0.05, 0.12))
+
+    def solve(self, page: Any, cfg: Any, detect_result: Any = None) -> SolveResult:
+        import time as _time
+        start = _time.monotonic()
+        target = self.find_target(page)
+        if target is None:
+            return SolveResult(method="SolveByHoldButton", duration=_time.monotonic() - start, error="no_target")
+        for attempt in range(1, cfg.max_attempts + 1):
+            try:
+                self.simulate_hold(page, target, cfg.hold_min, cfg.hold_max, attempt)
+            except Exception as e:
+                return SolveResult(method="SolveByHoldButton", attempts=attempt, duration=_time.monotonic() - start, error=str(e))
+            # Check clear
+            deadline = _time.monotonic() + cfg.post_wait
+            while _time.monotonic() < deadline:
+                if not self._is_px_visible(page):
+                    return SolveResult(solved=True, method="SolveByHoldButton", attempts=attempt, duration=_time.monotonic() - start)
+                _time.sleep(0.5)
+            _time.sleep(random.uniform(1.5, 3.0))
+        return SolveResult(method="SolveByHoldButton", attempts=cfg.max_attempts, duration=_time.monotonic() - start, error="max_attempts")
+
+    def _is_px_visible(self, page: Any) -> bool:
+        try:
+            return bool(page.evaluate("""() => {
+                if (document.getElementById('px-captcha')) return true;
+                if (document.getElementById('px-captcha-modal')) return true;
+                const body = (document.body ? document.body.innerText : '') || '';
+                return body.toLowerCase().includes('activate and hold') || body.toLowerCase().includes('press and hold');
+            }"""))
+        except Exception:
+            return True

--- a/cloakbrowser/pxbypass/solve/press_hold_container.py
+++ b/cloakbrowser/pxbypass/solve/press_hold_container.py
@@ -1,6 +1,9 @@
 """Solve PX by position of #px-captcha container (Walmart cloud variant)."""
 from __future__ import annotations
-import logging, random, time
+import asyncio
+import logging
+import random
+import time
 from typing import Any
 from .base import BaseSolver, SolveResult, HoldTarget
 
@@ -35,6 +38,7 @@ class SolveByHoldContainer(BaseSolver):
     For cross-origin cloud variants where the hold button is inside
     a cross-origin iframe (Walmart). We position relative to the
     container div which is always visible.
+    Supports both sync and async solving.
     """
 
     def __init__(self, container_selector: str = "#px-captcha"):
@@ -55,6 +59,22 @@ class SolveByHoldContainer(BaseSolver):
             logger.debug("Container lookup failed: %s", exc)
         return None
 
+    async def find_target_async(self, page: Any) -> HoldTarget | None:
+        """Async version of find_target."""
+        try:
+            raw = await page.evaluate(_GET_PX_CONTAINER_POSITION_JS)
+            if raw and raw.get("w") and raw["w"] >= 70:
+                logger.debug("Container target (async): %.0fx%.0f at (%.0f,%.0f) via %s",
+                             raw["w"], raw["h"], raw["x"], raw["y"], raw.get("source", ""))
+                return HoldTarget(
+                    x=float(raw["x"]), y=float(raw["y"]),
+                    width=float(raw["w"]), height=float(raw["h"]),
+                    source=f"container:{raw.get('source', 'px')}",
+                )
+        except Exception as exc:
+            logger.debug("Container lookup failed (async): %s", exc)
+        return None
+
     def _human_move_to(self, page: Any, tx: float, ty: float) -> None:
         vp = page.viewport_size or {"width": 1280, "height": 720}
         sx = random.uniform(vp["width"] * 0.2, vp["width"] * 0.8)
@@ -71,6 +91,24 @@ class SolveByHoldContainer(BaseSolver):
             time.sleep(random.uniform(0.015, 0.04))
         page.mouse.move(tx, ty)
         time.sleep(random.uniform(0.05, 0.12))
+
+    async def _human_move_to_async(self, page: Any, tx: float, ty: float) -> None:
+        """Async version of _human_move_to."""
+        vp = page.viewport_size or {"width": 1280, "height": 720}
+        sx = random.uniform(vp["width"] * 0.2, vp["width"] * 0.8)
+        sy = random.uniform(vp["height"] * 0.2, vp["height"] * 0.8)
+        steps = random.randint(10, 18)
+        await page.mouse.move(sx, sy)
+        await asyncio.sleep(random.uniform(0.08, 0.2))
+        for i in range(1, steps + 1):
+            t = i / steps
+            ease = t * t * (3 - 2 * t)
+            cx = sx + (tx - sx) * ease + random.uniform(-2.5, 2.5)
+            cy = sy + (ty - sy) * ease + random.uniform(-2.5, 2.5)
+            await page.mouse.move(cx, cy)
+            await asyncio.sleep(random.uniform(0.015, 0.04))
+        await page.mouse.move(tx, ty)
+        await asyncio.sleep(random.uniform(0.05, 0.12))
 
     def simulate_hold(self, page: Any, target: HoldTarget, hold_min: float, hold_max: float, attempt: int) -> None:
         hold_sec = random.uniform(hold_min, hold_max)
@@ -93,6 +131,28 @@ class SolveByHoldContainer(BaseSolver):
         page.mouse.up(button="left")
         logger.info("Container hold %d: done (%.1fs)", attempt, hold_sec)
 
+    async def simulate_hold_async(self, page: Any, target: HoldTarget, hold_min: float, hold_max: float, attempt: int) -> None:
+        """Async version of simulate_hold."""
+        hold_sec = random.uniform(hold_min, hold_max)
+        tx = target.x + random.uniform(-target.width * 0.06, target.width * 0.06)
+        ty = target.y + random.uniform(-target.height * 0.05, target.height * 0.05)
+        logger.info("Container hold %d: (%.0f,%.0f) %.1fs via %s", attempt, tx, ty, hold_sec, target.source)
+        await self._human_move_to_async(page, tx, ty)
+        await asyncio.sleep(random.uniform(0.06, 0.14))
+        await page.mouse.down(button="left")
+        elapsed = 0.0
+        while elapsed < hold_sec:
+            chunk = random.uniform(0.12, 0.32)
+            await asyncio.sleep(chunk)
+            elapsed += chunk
+            try:
+                await page.mouse.move(tx + random.uniform(-3.5, 3.5), ty + random.uniform(-2.5, 2.5))
+            except Exception:
+                pass
+        await asyncio.sleep(random.uniform(0.05, 0.15))
+        await page.mouse.up(button="left")
+        logger.info("Container hold %d: done (%.1fs)", attempt, hold_sec)
+
     def _is_px_visible(self, page: Any) -> bool:
         try:
             return bool(page.evaluate("""() => {
@@ -105,26 +165,148 @@ class SolveByHoldContainer(BaseSolver):
                 var body = (document.body ? document.body.innerText : '') || '';
                 return body.toLowerCase().includes('activate and hold')
                     || body.toLowerCase().includes('press and hold')
-                    || body.toLowerCase().includes('robot or human');
+                    || body.toLowerCase().includes('robot or human')
+                    || body.toLowerCase().includes('pressione e segure');
             }"""))
         except Exception:
             return True
 
+    async def _is_px_visible_async(self, page: Any) -> bool:
+        """Async version of _is_px_visible."""
+        try:
+            return bool(await page.evaluate("""() => {
+                if (document.getElementById('px-captcha-modal')) return true;
+                var px = document.getElementById('px-captcha');
+                if (px) {
+                    var r = px.getBoundingClientRect();
+                    if (r.width > 10) return true;
+                }
+                var body = (document.body ? document.body.innerText : '') || '';
+                return body.toLowerCase().includes('activate and hold')
+                    || body.toLowerCase().includes('press and hold')
+                    || body.toLowerCase().includes('robot or human')
+                    || body.toLowerCase().includes('pressione e segure');
+            }"""))
+        except Exception:
+            return True
+
+    def _wait_until_ready(self, page: Any, cfg: Any) -> bool:
+        checker = getattr(cfg, "checker", None)
+        if checker is None:
+            return True
+        deadline = time.monotonic() + getattr(cfg, "app_ready_timeout", 60.0)
+        while True:
+            try:
+                if checker(page):
+                    return True
+            except Exception:
+                pass
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(0.8)
+
+    async def _wait_until_ready_async(self, page: Any, cfg: Any) -> bool:
+        checker = getattr(cfg, "checker", None)
+        if checker is None:
+            return True
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + getattr(cfg, "app_ready_timeout", 60.0)
+        while True:
+            try:
+                ready = checker(page)
+                if hasattr(ready, "__await__"):
+                    ready = await ready
+                if ready:
+                    return True
+            except Exception:
+                pass
+            if loop.time() >= deadline:
+                return False
+            await asyncio.sleep(0.8)
+
+    def _success_result(self, page: Any, cfg: Any, attempt: int, start: float) -> SolveResult:
+        if not self._wait_until_ready(page, cfg):
+            return SolveResult(method="SolveByHoldContainer", attempts=attempt,
+                               duration=time.monotonic() - start, error="app_not_ready")
+        return SolveResult(solved=True, method="SolveByHoldContainer", attempts=attempt,
+                           duration=time.monotonic() - start)
+
+    async def _success_result_async(self, page: Any, cfg: Any, attempt: int, start: float) -> SolveResult:
+        if not await self._wait_until_ready_async(page, cfg):
+            return SolveResult(method="SolveByHoldContainer", attempts=attempt,
+                               duration=time.monotonic() - start, error="app_not_ready")
+        return SolveResult(solved=True, method="SolveByHoldContainer", attempts=attempt,
+                           duration=time.monotonic() - start)
+
     def solve(self, page: Any, cfg: Any, detect_result: Any = None) -> SolveResult:
         import time as _time
         start = _time.monotonic()
-        target = self.find_target(page)
+
+        # Wait for a target to appear
+        target = None
+        button_wait = getattr(cfg, 'button_wait_timeout', 20.0)
+        deadline = _time.monotonic() + button_wait
+        while _time.monotonic() < deadline:
+            target = self.find_target(page)
+            if target is not None:
+                break
+            _time.sleep(0.5)
+
         if target is None:
             return SolveResult(method="SolveByHoldContainer", duration=_time.monotonic() - start, error="no_target")
+
         for attempt in range(1, cfg.max_attempts + 1):
+            if not self._is_px_visible(page):
+                return self._success_result(page, cfg, attempt, start)
+
+            # Re-find target before each attempt
+            current = self.find_target(page) or target
             try:
-                self.simulate_hold(page, target, cfg.hold_min, cfg.hold_max, attempt)
+                self.simulate_hold(page, current, cfg.hold_min, cfg.hold_max, attempt)
             except Exception as e:
                 return SolveResult(method="SolveByHoldContainer", attempts=attempt, duration=_time.monotonic() - start, error=str(e))
-            deadline = _time.monotonic() + cfg.post_wait
-            while _time.monotonic() < deadline:
+
+            post_deadline = _time.monotonic() + cfg.post_wait
+            while _time.monotonic() < post_deadline:
                 if not self._is_px_visible(page):
-                    return SolveResult(solved=True, method="SolveByHoldContainer", attempts=attempt, duration=_time.monotonic() - start)
+                    return self._success_result(page, cfg, attempt, start)
                 _time.sleep(0.5)
             _time.sleep(random.uniform(1.5, 3.0))
+
+        return SolveResult(method="SolveByHoldContainer", attempts=cfg.max_attempts, duration=_time.monotonic() - start, error="max_attempts")
+
+    async def async_solve(self, page: Any, cfg: Any, detect_result: Any = None) -> SolveResult:
+        """Async version of solve()."""
+        import time as _time
+        start = _time.monotonic()
+
+        target = None
+        button_wait = getattr(cfg, 'button_wait_timeout', 20.0)
+        deadline = _time.monotonic() + button_wait
+        while _time.monotonic() < deadline:
+            target = await self.find_target_async(page)
+            if target is not None:
+                break
+            await asyncio.sleep(0.5)
+
+        if target is None:
+            return SolveResult(method="SolveByHoldContainer", duration=_time.monotonic() - start, error="no_target")
+
+        for attempt in range(1, cfg.max_attempts + 1):
+            if not await self._is_px_visible_async(page):
+                return await self._success_result_async(page, cfg, attempt, start)
+
+            current = await self.find_target_async(page) or target
+            try:
+                await self.simulate_hold_async(page, current, cfg.hold_min, cfg.hold_max, attempt)
+            except Exception as e:
+                return SolveResult(method="SolveByHoldContainer", attempts=attempt, duration=_time.monotonic() - start, error=str(e))
+
+            post_deadline = _time.monotonic() + cfg.post_wait
+            while _time.monotonic() < post_deadline:
+                if not await self._is_px_visible_async(page):
+                    return await self._success_result_async(page, cfg, attempt, start)
+                await asyncio.sleep(0.5)
+            await asyncio.sleep(random.uniform(1.5, 3.0))
+
         return SolveResult(method="SolveByHoldContainer", attempts=cfg.max_attempts, duration=_time.monotonic() - start, error="max_attempts")

--- a/cloakbrowser/pxbypass/solve/press_hold_container.py
+++ b/cloakbrowser/pxbypass/solve/press_hold_container.py
@@ -1,0 +1,130 @@
+"""Solve PX by position of #px-captcha container (Walmart cloud variant)."""
+from __future__ import annotations
+import logging, random, time
+from typing import Any
+from .base import BaseSolver, SolveResult, HoldTarget
+
+logger = logging.getLogger("cloakbrowser.pxbypass.solve")
+
+_GET_PX_CONTAINER_POSITION_JS = """
+(function() {
+  var pxCaptcha = document.getElementById('px-captcha');
+  if (!pxCaptcha) {
+    // try the modal
+    pxCaptcha = document.getElementById('px-captcha-modal');
+    if (!pxCaptcha) return null;
+  }
+  try {
+    var r = pxCaptcha.getBoundingClientRect();
+    if (!r || typeof r.width === 'undefined' || r.width < 10 || r.height < 10) return null;
+    return {
+      x: r.left + r.width / 2,
+      y: r.top + r.height / 2,
+      w: r.width,
+      h: r.height,
+      source: 'px-container'
+    };
+  } catch(e) { return null; }
+})()
+"""
+
+
+class SolveByHoldContainer(BaseSolver):
+    """Solve PX by holding at the #px-captcha container center.
+
+    For cross-origin cloud variants where the hold button is inside
+    a cross-origin iframe (Walmart). We position relative to the
+    container div which is always visible.
+    """
+
+    def __init__(self, container_selector: str = "#px-captcha"):
+        self.container_selector = container_selector
+
+    def find_target(self, page: Any) -> HoldTarget | None:
+        try:
+            raw = page.evaluate(_GET_PX_CONTAINER_POSITION_JS)
+            if raw and raw.get("w") and raw["w"] >= 70:
+                logger.debug("Container target: %.0fx%.0f at (%.0f,%.0f) via %s",
+                             raw["w"], raw["h"], raw["x"], raw["y"], raw.get("source", ""))
+                return HoldTarget(
+                    x=float(raw["x"]), y=float(raw["y"]),
+                    width=float(raw["w"]), height=float(raw["h"]),
+                    source=f"container:{raw.get('source', 'px')}",
+                )
+        except Exception as exc:
+            logger.debug("Container lookup failed: %s", exc)
+        return None
+
+    def _human_move_to(self, page: Any, tx: float, ty: float) -> None:
+        vp = page.viewport_size or {"width": 1280, "height": 720}
+        sx = random.uniform(vp["width"] * 0.2, vp["width"] * 0.8)
+        sy = random.uniform(vp["height"] * 0.2, vp["height"] * 0.8)
+        steps = random.randint(10, 18)
+        page.mouse.move(sx, sy)
+        time.sleep(random.uniform(0.08, 0.2))
+        for i in range(1, steps + 1):
+            t = i / steps
+            ease = t * t * (3 - 2 * t)
+            cx = sx + (tx - sx) * ease + random.uniform(-2.5, 2.5)
+            cy = sy + (ty - sy) * ease + random.uniform(-2.5, 2.5)
+            page.mouse.move(cx, cy)
+            time.sleep(random.uniform(0.015, 0.04))
+        page.mouse.move(tx, ty)
+        time.sleep(random.uniform(0.05, 0.12))
+
+    def simulate_hold(self, page: Any, target: HoldTarget, hold_min: float, hold_max: float, attempt: int) -> None:
+        hold_sec = random.uniform(hold_min, hold_max)
+        tx = target.x + random.uniform(-target.width * 0.06, target.width * 0.06)
+        ty = target.y + random.uniform(-target.height * 0.05, target.height * 0.05)
+        logger.info("Container hold %d: (%.0f,%.0f) %.1fs via %s", attempt, tx, ty, hold_sec, target.source)
+        self._human_move_to(page, tx, ty)
+        time.sleep(random.uniform(0.06, 0.14))
+        page.mouse.down(button="left")
+        elapsed = 0.0
+        while elapsed < hold_sec:
+            chunk = random.uniform(0.12, 0.32)
+            time.sleep(chunk)
+            elapsed += chunk
+            try:
+                page.mouse.move(tx + random.uniform(-3.5, 3.5), ty + random.uniform(-2.5, 2.5))
+            except Exception:
+                pass
+        time.sleep(random.uniform(0.05, 0.15))
+        page.mouse.up(button="left")
+        logger.info("Container hold %d: done (%.1fs)", attempt, hold_sec)
+
+    def _is_px_visible(self, page: Any) -> bool:
+        try:
+            return bool(page.evaluate("""() => {
+                if (document.getElementById('px-captcha-modal')) return true;
+                var px = document.getElementById('px-captcha');
+                if (px) {
+                    var r = px.getBoundingClientRect();
+                    if (r.width > 10) return true;
+                }
+                var body = (document.body ? document.body.innerText : '') || '';
+                return body.toLowerCase().includes('activate and hold')
+                    || body.toLowerCase().includes('press and hold')
+                    || body.toLowerCase().includes('robot or human');
+            }"""))
+        except Exception:
+            return True
+
+    def solve(self, page: Any, cfg: Any, detect_result: Any = None) -> SolveResult:
+        import time as _time
+        start = _time.monotonic()
+        target = self.find_target(page)
+        if target is None:
+            return SolveResult(method="SolveByHoldContainer", duration=_time.monotonic() - start, error="no_target")
+        for attempt in range(1, cfg.max_attempts + 1):
+            try:
+                self.simulate_hold(page, target, cfg.hold_min, cfg.hold_max, attempt)
+            except Exception as e:
+                return SolveResult(method="SolveByHoldContainer", attempts=attempt, duration=_time.monotonic() - start, error=str(e))
+            deadline = _time.monotonic() + cfg.post_wait
+            while _time.monotonic() < deadline:
+                if not self._is_px_visible(page):
+                    return SolveResult(solved=True, method="SolveByHoldContainer", attempts=attempt, duration=_time.monotonic() - start)
+                _time.sleep(0.5)
+            _time.sleep(random.uniform(1.5, 3.0))
+        return SolveResult(method="SolveByHoldContainer", attempts=cfg.max_attempts, duration=_time.monotonic() - start, error="max_attempts")

--- a/cloakbrowser/pxbypass/solver.py
+++ b/cloakbrowser/pxbypass/solver.py
@@ -1,0 +1,518 @@
+"""PerimeterX "Press & Hold" challenge solver.
+
+Implements automatic detection and solving of PerimeterX
+"Press & Hold" / "Pressione e segure" / "Activate and hold"
+challenges using human-like mouse movements and hold timing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import random
+import re
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable
+
+from .config import (
+    PxConfig,
+    PX_TEXT_MARKERS,
+    PX_HOLD_BUTTON_LABELS,
+)
+from .detector import is_px_visible, is_px_block_page
+
+logger = logging.getLogger("cloakbrowser.pxbypass.solver")
+
+# ---------------------------------------------------------------------------
+# JS snippets
+# ---------------------------------------------------------------------------
+
+# JS: find hold button text in main document / iframe modal (iFood variant)
+_PICK_HOLD_BUTTON_JS = """
+() => {
+  const btnLabels = ['pressione e segure', 'press and hold', 'press & hold', 'activate and hold'];
+  const instructionRe = /antes de continuarmos|confirmar que você|não um bot|thank you/i;
+
+  function scoreHoldButton(el) {
+    const t = (el.innerText || '').trim();
+    const r = el.getBoundingClientRect();
+    if (r.width < 70 || r.height < 22 || r.height > 90) return -1;
+    if (instructionRe.test(t)) return -1;
+    if (['P', 'H1', 'H2', 'H3'].includes(el.tagName) && t.length > 40) return -1;
+    const tLow = t.toLowerCase();
+    let s = -1;
+    if (btnLabels.some((l) => tLow === l)) s = 200;
+    else if (btnLabels.some((l) => tLow.includes(l)) && t.length <= 40) s = 80;
+    else return -1;
+    if (el.getAttribute('role') === 'button' || el.tagName === 'BUTTON') s += 60;
+    if (el.tagName === 'DIV' || el.tagName === 'A') s += 15;
+    return s;
+  }
+
+  function scanDoc(doc) {
+    let best = null; let bestScore = -1;
+    for (const el of doc.querySelectorAll('button, [role="button"], a, div, span')) {
+      const s = scoreHoldButton(el);
+      if (s > bestScore) { bestScore = s; best = el; }
+    }
+    if (!best) return null;
+    const r = best.getBoundingClientRect();
+    return { x: r.left + r.width/2, y: r.top + r.height/2, w: r.width, h: r.height,
+             text: (best.innerText||'').slice(0,40), tag: best.tagName, source: 'px-hold-button' };
+  }
+
+  // iFood variant: modal iframe
+  var modal = document.getElementById('px-captcha-modal');
+  if (modal && modal.contentDocument) {
+    var ir = modal.getBoundingClientRect();
+    var hit = scanDoc(modal.contentDocument);
+    if (hit) { hit.x += ir.left; hit.y += ir.top; return hit; }
+  }
+  return scanDoc(document);
+}
+"""
+
+# JS: get PX captcha container position (Walmart cloud variant - safe, no cross-origin access)
+_GET_PX_CONTAINER_POSITION_JS = """
+(function() {
+  // Try iframe first
+  var pxCaptcha = document.getElementById('px-captcha');
+  if (!pxCaptcha) return null;
+  // Use the container div - it's always visible even when iframe is display:none
+  try {
+    var r = pxCaptcha.getBoundingClientRect();
+    if (!r || typeof r.width === 'undefined') return null;
+    // Only valid if the container has some size
+    if (r.width < 10 || r.height < 10) return null;
+    return {
+      x: r.left + r.width / 2,
+      y: r.top + r.height / 2,
+      w: r.width,
+      h: r.height,
+      source: 'px-container'
+    };
+  } catch(e) {
+    return null;
+  }
+})()
+"""
+
+# ---------------------------------------------------------------------------
+# Hold target dataclass
+# ---------------------------------------------------------------------------
+
+from dataclasses import dataclass
+
+
+@dataclass
+class HoldTarget:
+    """Position of the hold button in viewport coordinates."""
+    x: float
+    y: float
+    width: float
+    height: float
+    source: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Human mouse movement (sync)
+# ---------------------------------------------------------------------------
+
+
+def _human_move_to(page: Any, tx: float, ty: float) -> None:
+    """Move mouse to target with a human-like Bezier trajectory (sync)."""
+    import math
+    vp = page.viewport_size or {"width": 1280, "height": 720}
+    sx = random.uniform(vp["width"] * 0.2, vp["width"] * 0.8)
+    sy = random.uniform(vp["height"] * 0.2, vp["height"] * 0.8)
+    steps = random.randint(10, 18)
+
+    page.mouse.move(sx, sy)
+    time.sleep(random.uniform(0.08, 0.2))
+    for i in range(1, steps + 1):
+        t_val = i / steps
+        ease = t_val * t_val * (3 - 2 * t_val)
+        cx = sx + (tx - sx) * ease + random.uniform(-2.5, 2.5)
+        cy = sy + (ty - sy) * ease + random.uniform(-2.5, 2.5)
+        page.mouse.move(cx, cy)
+        time.sleep(random.uniform(0.015, 0.04))
+    page.mouse.move(tx, ty)
+    time.sleep(random.uniform(0.05, 0.12))
+
+
+async def _async_human_move_to(page: Any, tx: float, ty: float) -> None:
+    """Move mouse to target with a human-like Bezier trajectory (async)."""
+    import math
+    vp = page.viewport_size or {"width": 1280, "height": 720}
+    sx = random.uniform(vp["width"] * 0.2, vp["width"] * 0.8)
+    sy = random.uniform(vp["height"] * 0.2, vp["height"] * 0.8)
+    steps = random.randint(10, 18)
+
+    await page.mouse.move(sx, sy)
+    await asyncio.sleep(random.uniform(0.08, 0.2))
+    for i in range(1, steps + 1):
+        t_val = i / steps
+        ease = t_val * t_val * (3 - 2 * t_val)
+        cx = sx + (tx - sx) * ease + random.uniform(-2.5, 2.5)
+        cy = sy + (ty - sy) * ease + random.uniform(-2.5, 2.5)
+        await page.mouse.move(cx, cy)
+        await asyncio.sleep(random.uniform(0.015, 0.04))
+    await page.mouse.move(tx, ty)
+    await asyncio.sleep(random.uniform(0.05, 0.12))
+
+
+# ---------------------------------------------------------------------------
+# Target finding: hold button text → container position → iframe position
+# ---------------------------------------------------------------------------
+
+
+def _find_hold_target(page: Any) -> HoldTarget | None:
+    """Locate the PX target using multi-strategy approach (sync).
+
+    Priority:
+      1. Playwright exact text locator (same-origin buttons)
+      2. JS button scorer (iframe modal variants like iFood)
+      3. PX container bounding rect (cloud cross-origin variants like Walmart)
+
+    Returns:
+        HoldTarget with viewport coordinates, or None if not found.
+    """
+    # Strategy 1: Playwright exact text locator
+    try:
+        for label in PX_HOLD_BUTTON_LABELS:
+            try:
+                loc = page.get_by_text(label, exact=True).first
+                if loc.count() and loc.is_visible():
+                    box = loc.bounding_box()
+                    if box and box["width"] >= 70 and box["height"] >= 22:
+                        return HoldTarget(
+                            x=box["x"] + box["width"] / 2,
+                            y=box["y"] + box["height"] / 2,
+                            width=box["width"], height=box["height"],
+                            source=f"playwright:{label[:12]}",
+                        )
+            except Exception:
+                continue
+    except Exception:
+        pass
+
+    # Strategy 2: JS button scorer
+    try:
+        raw: dict[str, Any] | None = page.evaluate(_PICK_HOLD_BUTTON_JS)
+        if raw and raw.get("w") and raw["w"] >= 70:
+            return HoldTarget(
+                x=float(raw["x"]), y=float(raw["y"]),
+                width=float(raw["w"]), height=float(raw["h"]),
+                source=f"js:{raw.get('source', 'px-btn')}",
+            )
+    except Exception:
+        pass
+
+    # Strategy 3: PX container position (Walmart cloud variant)
+    try:
+        raw = page.evaluate(_GET_PX_CONTAINER_POSITION_JS)
+        if raw and raw.get("w") and raw["w"] >= 70:
+            logger.debug("Found PX target via container position: %.0fx%.0f at (%.0f,%.0f)",
+                         raw["w"], raw["h"], raw["x"], raw["y"])
+            return HoldTarget(
+                x=float(raw["x"]), y=float(raw["y"]),
+                width=float(raw["w"]), height=float(raw["h"]),
+                source=f"container:{raw.get('source', 'px-container')}",
+            )
+    except Exception as exc:
+        logger.debug("Container position lookup failed: %s", exc)
+
+    return None
+
+
+async def _async_find_hold_target(page: Any) -> HoldTarget | None:
+    """Locate the PX target (async version)."""
+    try:
+        for label in PX_HOLD_BUTTON_LABELS:
+            try:
+                loc = page.get_by_text(label, exact=True).first
+                if await loc.count() and await loc.is_visible():
+                    box = await loc.bounding_box()
+                    if box and box["width"] >= 70 and box["height"] >= 22:
+                        return HoldTarget(
+                            x=box["x"] + box["width"] / 2,
+                            y=box["y"] + box["height"] / 2,
+                            width=box["width"], height=box["height"],
+                            source=f"playwright:{label[:12]}",
+                        )
+            except Exception:
+                continue
+    except Exception:
+        pass
+
+    try:
+        raw: dict[str, Any] | None = await page.evaluate(_PICK_HOLD_BUTTON_JS)
+        if raw and raw.get("w") and raw["w"] >= 70:
+            return HoldTarget(
+                x=float(raw["x"]), y=float(raw["y"]),
+                width=float(raw["w"]), height=float(raw["h"]),
+                source=f"js:{raw.get('source', 'px-btn')}",
+            )
+    except Exception:
+        pass
+
+    try:
+        raw = await page.evaluate(_GET_PX_CONTAINER_POSITION_JS)
+        if raw and raw.get("w") and raw["w"] >= 70:
+            return HoldTarget(
+                x=float(raw["x"]), y=float(raw["y"]),
+                width=float(raw["w"]), height=float(raw["h"]),
+                source=f"container:{raw.get('source', 'px-container')}",
+            )
+    except Exception:
+        pass
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Press & Hold simulation
+# ---------------------------------------------------------------------------
+
+
+def _simulate_press_and_hold(
+    page: Any,
+    target: HoldTarget,
+    cfg: PxConfig,
+    attempt: int = 0,
+) -> None:
+    """Simulate a human press-and-hold on the target element (sync)."""
+    hold_sec = random.uniform(cfg.hold_min, cfg.hold_max)
+    tx = target.x + random.uniform(-target.width * 0.06, target.width * 0.06)
+    ty = target.y + random.uniform(-target.height * 0.05, target.height * 0.05)
+
+    logger.info(
+        "PX hold attempt %d: moving to (%.0f, %.0f) via %s, holding %.1fs",
+        attempt, tx, ty, target.source, hold_sec,
+    )
+
+    _human_move_to(page, tx, ty)
+    time.sleep(random.uniform(0.06, 0.14))
+    page.mouse.down(button="left")
+
+    elapsed = 0.0
+    while elapsed < hold_sec:
+        chunk = random.uniform(0.12, 0.32)
+        time.sleep(chunk)
+        elapsed += chunk
+        try:
+            page.mouse.move(
+                tx + random.uniform(-3.5, 3.5),
+                ty + random.uniform(-2.5, 2.5),
+            )
+        except Exception:
+            pass
+
+    time.sleep(random.uniform(0.05, 0.15))
+    page.mouse.up(button="left")
+    logger.info("PX hold attempt %d: mouse.up after %.1fs", attempt, hold_sec)
+
+
+async def _async_simulate_press_and_hold(
+    page: Any,
+    target: HoldTarget,
+    cfg: PxConfig,
+    attempt: int = 0,
+) -> None:
+    """Simulate a human press-and-hold on the target element (async)."""
+    hold_sec = random.uniform(cfg.hold_min, cfg.hold_max)
+    tx = target.x + random.uniform(-target.width * 0.06, target.width * 0.06)
+    ty = target.y + random.uniform(-target.height * 0.05, target.height * 0.05)
+
+    logger.info(
+        "PX hold attempt %d: moving to (%.0f, %.0f) via %s, holding %.1fs",
+        attempt, tx, ty, target.source, hold_sec,
+    )
+
+    await _async_human_move_to(page, tx, ty)
+    await asyncio.sleep(random.uniform(0.06, 0.14))
+    await page.mouse.down(button="left")
+
+    elapsed = 0.0
+    while elapsed < hold_sec:
+        chunk = random.uniform(0.12, 0.32)
+        await asyncio.sleep(chunk)
+        elapsed += chunk
+        try:
+            await page.mouse.move(
+                tx + random.uniform(-3.5, 3.5),
+                ty + random.uniform(-2.5, 2.5),
+            )
+        except Exception:
+            pass
+
+    await asyncio.sleep(random.uniform(0.05, 0.15))
+    await page.mouse.up(button="left")
+    logger.info("PX hold attempt %d: mouse.up after %.1fs", attempt, hold_sec)
+
+
+def _wait_px_cleared(page: Any, timeout: float) -> bool:
+    """Wait for PX challenge UI to disappear (sync)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not is_px_visible(page):
+            return True
+        time.sleep(0.5)
+    return not is_px_visible(page)
+
+
+async def _async_wait_px_cleared(page: Any, timeout: float) -> bool:
+    """Wait for PX challenge UI to disappear (async)."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if not is_px_visible(page):
+            return True
+        await asyncio.sleep(0.5)
+    return not is_px_visible(page)
+
+
+# ---------------------------------------------------------------------------
+# Main solver entry points
+# ---------------------------------------------------------------------------
+
+
+def attempt_px_solve(page: Any, cfg: PxConfig) -> bool:
+    """Attempt to solve a PerimeterX challenge on the current page (sync).
+
+    Args:
+        page: Playwright Page object.
+        cfg: PxConfig with solving parameters.
+
+    Returns:
+        True if the challenge was solved successfully. False if failed.
+    """
+    if not cfg.enabled:
+        return True
+
+    if not is_px_visible(page):
+        logger.debug("No PX challenge visible, skipping solve")
+        return True
+
+    logger.info("PerimeterX challenge detected, attempting to solve...")
+
+    if cfg.reload_if_hidden and is_px_block_page(page):
+        logger.info("PX block page detected, reloading to load challenge...")
+        try:
+            page.reload(wait_until="load", timeout=90000)
+        except Exception:
+            page.reload(wait_until="domcontentloaded", timeout=90000)
+        time.sleep(random.uniform(2.5, 4.5))
+
+    # Wait for a target to appear
+    target = None
+    for _ in range(int(cfg.button_wait_timeout / 0.5)):
+        if is_px_visible(page):
+            target = _find_hold_target(page)
+            if target is not None:
+                break
+        time.sleep(0.5)
+
+    if target is None:
+        logger.warning("PX hold target did not appear within timeout")
+        return False
+
+    # Perform press-and-hold attempts
+    for attempt in range(1, cfg.max_attempts + 1):
+        if not is_px_visible(page):
+            logger.info("PX cleared before attempt %d", attempt)
+            return True
+
+        current_target = _find_hold_target(page)
+        if current_target is None:
+            current_target = target  # reuse last known position
+            time.sleep(random.uniform(0.5, 1.0))
+
+        try:
+            _simulate_press_and_hold(page, current_target, cfg, attempt=attempt)
+        except Exception as exc:
+            logger.warning("Attempt %d failed: %s", attempt, exc)
+            continue
+
+        if _wait_px_cleared(page, cfg.post_wait):
+            logger.info("PX solved after %d attempt(s)", attempt)
+            if cfg.checker is not None:
+                checker: Callable[[Any], bool] = cfg.checker
+                check_deadline = time.monotonic() + cfg.app_ready_timeout
+                while time.monotonic() < check_deadline:
+                    if checker(page):
+                        return True
+                    time.sleep(0.8)
+                logger.warning("Checker did not pass within timeout")
+                return False
+            return True
+
+        logger.warning("Attempt %d: PX still visible", attempt)
+
+    logger.error("All %d attempts failed", cfg.max_attempts)
+    return False
+
+
+async def async_attempt_px_solve(page: Any, cfg: PxConfig) -> bool:
+    """Attempt to solve a PerimeterX challenge (async).
+
+    Args:
+        page: Playwright Page object (async API).
+        cfg: PxConfig with solving parameters.
+
+    Returns:
+        True if solved, False if failed.
+    """
+    if not cfg.enabled:
+        return True
+    if not is_px_visible(page):
+        logger.debug("No PX visible, skipping")
+        return True
+
+    logger.info("PX detected, solving...")
+
+    if cfg.reload_if_hidden and is_px_block_page(page):
+        logger.info("Reloading...")
+        try:
+            await page.reload(wait_until="load", timeout=90000)
+        except Exception:
+            await page.reload(wait_until="domcontentloaded", timeout=90000)
+        await asyncio.sleep(random.uniform(2.5, 4.5))
+
+    target = None
+    for _ in range(int(cfg.button_wait_timeout / 0.5)):
+        if is_px_visible(page):
+            target = await _async_find_hold_target(page)
+            if target is not None:
+                break
+        await asyncio.sleep(0.5)
+    if target is None:
+        logger.warning("Target not found")
+        return False
+
+    for attempt in range(1, cfg.max_attempts + 1):
+        if not is_px_visible(page):
+            return True
+        current = await _async_find_hold_target(page) or target
+        try:
+            await _async_simulate_press_and_hold(page, current, cfg, attempt=attempt)
+        except Exception as exc:
+            logger.warning("Attempt %d failed: %s", attempt, exc)
+            continue
+        if await _async_wait_px_cleared(page, cfg.post_wait):
+            logger.info("Solved after %d attempt(s)", attempt)
+            if cfg.checker is not None:
+                checker: Callable[[Any], bool] = cfg.checker
+                loop = asyncio.get_running_loop()
+                deadline = loop.time() + cfg.app_ready_timeout
+                while loop.time() < deadline:
+                    if checker(page):
+                        return True
+                    await asyncio.sleep(0.8)
+                return False
+            return True
+
+    return False

--- a/examples/ifood_px_bypass.py
+++ b/examples/ifood_px_bypass.py
@@ -1,0 +1,132 @@
+"""Live iFood smoke test for issue #448 PerimeterX auto bypass.
+
+This is intentionally a manual/live example rather than a pytest: PX triggering
+is adaptive and depends on IP reputation, address state, and traffic volume.
+Set IFOOD_PROXY_URL to use a residential proxy. The script never logs credentials.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import random
+import time
+
+from cloakbrowser import launch
+from cloakbrowser.pxbypass import PxConfig, detect_px
+
+IFOOD_URL = "https://www.ifood.com.br/restaurantes"
+
+
+def _app_ready(page) -> bool:
+    """Generic iFood recovery signal used after the PX modal disappears."""
+    try:
+        return bool(
+            page.evaluate(
+                """() => location.hostname.endsWith('ifood.com.br') &&
+                    !!(self.webpackChunk_N_E && self.webpackChunk_N_E.length)"""
+            )
+        )
+    except Exception:
+        return False
+
+
+def _trigger_activity(page, rounds: int) -> None:
+    """Generate normal page activity; PX may or may not challenge the session."""
+    for index in range(rounds):
+        candidates = []
+        try:
+            for element in page.query_selector_all(
+                "a, button, [role='tab'], [role='button']"
+            ):
+                try:
+                    if element.is_visible():
+                        candidates.append(element)
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
+        if candidates:
+            try:
+                random.choice(candidates).click(timeout=5_000)
+            except Exception:
+                pass
+        else:
+            try:
+                page.mouse.wheel(0, random.randint(250, 600))
+            except Exception:
+                pass
+
+        time.sleep(random.uniform(0.5, 1.4))
+        if detect_px(page):
+            logging.warning("PX challenge detected after activity round %d", index + 1)
+            return
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Live iFood PX bypass smoke test")
+    parser.add_argument("--headless", action="store_true")
+    parser.add_argument("--rounds", type=int, default=25)
+    parser.add_argument("--wait", type=float, default=120.0)
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    logging.getLogger("cloakbrowser.pxbypass").setLevel(logging.DEBUG)
+
+    proxy = os.environ.get("IFOOD_PROXY_URL") or None
+    browser = launch(
+        headless=args.headless,
+        proxy=proxy,
+        humanize=True,
+        locale="pt-BR",
+        bypass_px=True,
+        px_config=PxConfig(
+            max_attempts=3,
+            hold_min=3.8,
+            hold_max=6.5,
+            post_wait=30.0,
+            button_wait_timeout=20.0,
+            checker=_app_ready,
+        ),
+    )
+    page = browser.new_page()
+    try:
+        page.goto(IFOOD_URL, timeout=120_000, wait_until="domcontentloaded")
+        _trigger_activity(page, args.rounds)
+
+        # ``page`` methods are monkey-patched by the bypass layer; using normal
+        # attribute lookup here can return a stale Playwright wrapper after a
+        # navigation. Read the Python instance dictionary so the exact helper
+        # installed by ``_patch_methods_for_px_polling`` is invoked.
+        wait_for_px_solved = page.__dict__.get("wait_for_px_solved")
+        if not callable(wait_for_px_solved):
+            logging.error("PX solver helper was not installed on the page")
+            return 1
+        px_detected = bool(detect_px(page))
+        if px_detected and not wait_for_px_solved(timeout=args.wait):
+            logging.error("PX remained visible after %.0fs", args.wait)
+            return 1
+
+        if detect_px(page):
+            logging.error("PX is still detected")
+            return 1
+        if not _app_ready(page):
+            logging.warning(
+                "No active PX challenge, but the iFood app is not ready; "
+                "the session may be on Cloudflare/address setup"
+            )
+            return 2
+
+        logging.info("Page is usable; PX is absent or was solved")
+        return 0
+    finally:
+        browser.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/px_bypass_test.py
+++ b/examples/px_bypass_test.py
@@ -1,0 +1,176 @@
+"""PerimeterX (PX) 验证码自动求解测试示例。
+
+测试目标: https://www.walmart.com/blocked?url=Lw==
+Walmart 使用 PerimeterX 的 "Activate and hold" 验证码，
+验证码通过跨域 iframe (px-cloud.net) 加载。
+
+用法:
+    python examples/px_bypass_test.py
+
+说明:
+    该示例测试 CloakBrowser 的 bypass_px=True 功能。
+    如果 PX 验证码成功通过，页面内容会变为正常的 Walmart 首页。
+    如果验证失败，页面会停留在 "Robot or human?" 拦截页。
+
+注意:
+    PX 验证码自动求解是实验性功能，成功率受网络、IP、浏览器等因素影响。
+    失败时外层代码应换 IP 并重试。
+"""
+
+import logging
+import sys
+import time
+from pathlib import Path
+
+# 设置日志，便于观察 PX 求解过程
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    stream=sys.stderr,
+)
+
+# 让 cloakbrowser.pxbypass 的日志更详细
+logging.getLogger("cloakbrowser.pxbypass").setLevel(logging.DEBUG)
+
+from cloakbrowser import launch
+from cloakbrowser.pxbypass import detect_px
+from cloakbrowser.pxbypass.config import PxConfig
+
+
+TARGET_URL = (
+    "https://www.walmart.com/blocked"
+    "?url=Lw=="
+    "&uuid=7883d050-4d11-11ec-8c63-8fa6a26a652a"
+    "&vid=a0f5dbf2-3c8c-11ec-b175-787445664d76"
+    "&g=b"
+)
+
+
+def test_px_bypass(headless: bool = True) -> bool:
+    """测试 PX 验证码自动求解。
+
+    流程：
+        1. 启动 CloakBrowser（带 bypass_px=True）
+        2. 访问 Walmart 的 PX 拦截页
+        3. bypass_px 会自动检测 PX 挑战
+        4. 执行 "Activate and hold" 验证
+        5. 验证通过后页面应跳转到 Walmart 首页
+
+    Args:
+        headless: 是否无头模式。设为 False 可观察浏览器操作。
+
+    Returns:
+        True 表示 PX 验证成功，False 表示验证失败。
+    """
+    screenshot_dir = Path("/tmp/cloakbrowser_px_test")
+    screenshot_dir.mkdir(parents=True, exist_ok=True)
+
+    print("=" * 60)
+    print("PerimeterX 自动求解测试")
+    print("=" * 60)
+    print(f"目标URL: {TARGET_URL}")
+    print(f"Headless: {headless}")
+    print()
+
+    # 自定义 PX 配置（可根据需要调整）
+    px_config = PxConfig(
+        max_attempts=3,          # 最多尝试 3 次
+        hold_min=3.5,            # 最短按住 3.5 秒
+        hold_max=6.0,            # 最长按住 6.0 秒
+        post_wait=30.0,          # 松开后最多等 30 秒
+        button_wait_timeout=25.0, # 等待按钮出现最多 25 秒
+        reload_if_hidden=True,   # 如果没看到 PX UI 就刷新页面
+    )
+
+    browser = launch(
+        headless=headless,
+        bypass_px=True,
+        px_config=px_config,
+    )
+
+    page = browser.new_page()
+
+    # 阶段1: 访问目标页面
+    print("\n[阶段1] 正在访问 Walmart PX 拦截页...")
+    try:
+        page.goto(TARGET_URL, timeout=90_000, wait_until="load")
+    except Exception as e:
+        print(f"  ⚠ 页面加载超时（这在 PX 页面常见）: {e}")
+
+    # 阶段2: 等待 PX 检测与求解
+    print("\n[阶段2] 等待 PX 检测与自动求解...")
+    print("  (bypass_px 已启用，检测到 PX 后会自动执行按住验证)")
+
+    # 等待 15 秒给 PX 求解足够时间
+    for i in range(30):
+        time.sleep(1)
+        current_url = page.url
+        title = page.title()
+
+        # 截图保存当前状态
+        if i % 5 == 0:
+            screenshot_path = screenshot_dir / f"step_{i:02d}.png"
+            try:
+                page.screenshot(path=str(screenshot_path))
+                print(f"  截图已保存: {screenshot_path}")
+            except Exception:
+                pass
+
+        # 检测是否已通过 PX (页面跳转到了正常的 Walmart 页面)
+        if "walmart.com/blocked" not in current_url and "walmart.com" in current_url:
+            print(f"\n  ✅ PX 已通过! 当前页面: {current_url}")
+            print(f"  页面标题: {title}")
+            page.screenshot(path=str(screenshot_dir / "px_passed.png"))
+            browser.close()
+            return True
+
+        # 每 5 秒打印一次状态
+        if i % 5 == 0:
+            px_detected = detect_px(page)
+            print(f"  [{i}s] 标题={title[:60]}, PX检测={px_detected}, URL长度={len(current_url)}")
+
+    # 超时检查最终状态
+    print("\n[阶段3] 超时 - 检查最终状态")
+    final_url = page.url
+    final_title = page.title
+    px_still_detected = detect_px(page)
+
+    print(f"  最终 URL: {final_url}")
+    print(f"  最终标题: {final_title}")
+    print(f"  PX 检测: {px_still_detected}")
+    page.screenshot(path=str(screenshot_dir / "final.png"))
+
+    result = "walmart.com/blocked" not in final_url
+
+    browser.close()
+    return result
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="PerimeterX 自动求解测试")
+    parser.add_argument(
+        "--headed",
+        action="store_true",
+        help="使用有头模式（可观察浏览器操作）",
+    )
+    args = parser.parse_args()
+
+    success = test_px_bypass(headless=not args.headed)
+
+    print()
+    print("=" * 60)
+    if success:
+        print("  ✅ 测试通过: PX 验证码已成功解决")
+    else:
+        print("  ❌ 测试失败: PX 验证码未能在超时内解决")
+        print()
+        print("  可能的原因:")
+        print("  1. 网络环境问题 - 尝试使用住宅代理")
+        print("  2. PX 已更新验证逻辑 - 需要更新求解器")
+        print("  3. 当前 IP 被 PX 标记 - 换 IP 重试")
+        print("  4. 按住时间/次数需要调整 - 修改 px_config")
+    print("=" * 60)
+
+    sys.exit(0 if success else 1)

--- a/tests/fixtures/px_challenge.html
+++ b/tests/fixtures/px_challenge.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Robot or human?</title>
+<style>
+  body { text-align: center; font-family: Roboto, sans-serif; }
+  header { background: #811F08; padding: 16px; color: white; }
+  #px-captcha { max-width: 600px; margin: 40px auto; padding: 30px; }
+  #hold-btn {
+    display: block;
+    margin: 24px auto;
+    width: 240px;
+    height: 44px;
+    border: 1px solid #0071ce;
+    background: #fff;
+    color: #0071ce;
+    font-size: 17px;
+    font-weight: 500;
+    cursor: pointer;
+    border-radius: 4px;
+  }
+  #hold-btn:hover { background: #f0f7fc; }
+  p { padding: 8px; }
+</style>
+</head>
+<body>
+  <header>Test Site</header>
+  <div id="px-captcha">
+    <p>Robot or human?</p>
+    <p>Activate and hold the button to confirm that you're human.</p>
+    <button id="hold-btn" type="button">Activate and hold</button>
+  </div>
+  <script>
+    // On hold completion, drop the captcha and replace the body with success.
+    // The bypass only sends mouse.down/up; we simulate the per-pixel hit by
+    // listening for mouseup and waiting 4s of down time before succeeding.
+    const btn = document.getElementById('hold-btn');
+    let downAt = 0;
+    btn.addEventListener('mousedown', () => { downAt = Date.now(); });
+    btn.addEventListener('mouseup', () => {
+      const held = (Date.now() - downAt) / 1000;
+      if (held >= 3.5) {
+        document.body.innerHTML = '<header>Test Site</header><p id="ok">Success — captcha cleared</p>';
+      } else {
+        const old = document.getElementById('px-captcha');
+        const div = document.createElement('p');
+        div.textContent = 'Hold longer please';
+        old.appendChild(div);
+      }
+    });
+  </script>
+</body>
+</html>

--- a/tests/test_pxbypass.py
+++ b/tests/test_pxbypass.py
@@ -1,0 +1,294 @@
+"""Regression tests for issue #448 PerimeterX auto bypass."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from cloakbrowser.pxbypass import PxConfig
+from cloakbrowser.pxbypass.detect.base import DetectResult
+from cloakbrowser.pxbypass.detect.keyword import DetectPxByKeyword
+from cloakbrowser.pxbypass.engine import PxEngine
+from cloakbrowser.pxbypass.site.ifood import IfoodHandler
+from cloakbrowser.pxbypass.solve.base import BaseSolver, HoldTarget, SolveResult
+from cloakbrowser.pxbypass.solve.composite import CompositeSolver
+from cloakbrowser.pxbypass.solve.press_hold_button import SolveByHoldButton
+
+
+class AsyncTextPage:
+    """Small async Playwright-like page used by detector tests."""
+
+    url = "https://www.ifood.com.br/restaurantes"
+    frames: list = []
+    main_frame = object()
+
+    def __init__(self, body: str):
+        self.body = body
+
+    async def evaluate(self, script, arg=None):
+        if "document.body" in script:
+            return self.body
+        if "querySelectorAll" in script:
+            return 0
+        return False
+
+
+@pytest.mark.asyncio
+async def test_keyword_detector_supports_async_playwright_page():
+    detector = DetectPxByKeyword()
+    result = await detector.detect_async(
+        AsyncTextPage("Antes de continuarmos, pressione e segure")
+    )
+    assert result.detected is True
+    assert result.confidence >= 0.5
+
+
+@pytest.mark.asyncio
+async def test_ifood_handler_supports_async_detection():
+    result = await IfoodHandler().detect_async(
+        AsyncTextPage("Pressione e segure para confirmar que você é humano")
+    )
+    assert result.detected is True
+
+
+class _AsyncSuccessSolver(BaseSolver):
+    def __init__(self, name: str, solved: bool):
+        self.name = name
+        self.solved = solved
+        self.sync_called = False
+
+    def solve(self, page, cfg, detect_result=None):
+        self.sync_called = True
+        raise AssertionError("async path must not call sync solve()")
+
+    async def async_solve(self, page, cfg, detect_result=None):
+        return SolveResult(solved=self.solved, method=self.name)
+
+
+@pytest.mark.asyncio
+async def test_composite_solver_awaits_async_child_solvers():
+    first = _AsyncSuccessSolver("first", False)
+    second = _AsyncSuccessSolver("second", True)
+    result = await CompositeSolver([first, second]).async_solve(
+        object(), PxConfig(), DetectResult(detected=True)
+    )
+    assert result.solved is True
+    assert result.method == "second"
+    assert first.sync_called is False
+    assert second.sync_called is False
+
+
+def test_sync_page_patch_installs_wait_for_px_solved_immediately(monkeypatch):
+    from cloakbrowser import pxbypass
+
+    page = MagicMock()
+    page._px_patched = False
+    page._px_methods_patched = False
+    page.goto = MagicMock(return_value=None)
+    engine = MagicMock()
+    monkeypatch.setattr(pxbypass, "_get_engine", lambda cfg: engine)
+
+    pxbypass.patch_page(page, PxConfig())
+
+    assert callable(page.wait_for_px_solved)
+    engine.install_observer.assert_called_once_with(page)
+
+
+def test_wait_for_px_solved_does_not_accept_transient_visibility_gap(monkeypatch):
+    from cloakbrowser.pxbypass.engine import _patch_methods_for_px_polling
+
+    page = MagicMock()
+    page._px_methods_patched = False
+    engine = MagicMock()
+    visibility = iter([True, False])
+    engine._is_px_visible.side_effect = lambda page: next(visibility, False)
+    engine.check_and_solve.return_value = True
+    engine.detect.return_value = (
+        None,
+        DetectResult(detected=True, confidence=0.9),
+    )
+    _patch_methods_for_px_polling(page, engine)
+
+    monkeypatch.setattr("time.sleep", lambda delay: None)
+    assert page.wait_for_px_solved(timeout=0.01) is False
+
+
+class _ObserverPage:
+    def __init__(self):
+        self.binding = None
+        self.handlers = {}
+
+    def expose_binding(self, name, callback):
+        assert name == "__pxNotify"
+        self.binding = callback
+
+    def on(self, event, callback):
+        self.handlers[event] = callback
+
+    def evaluate(self, script):
+        return None
+
+
+
+def test_sync_observer_binding_accepts_playwright_source_argument():
+    page = _ObserverPage()
+    engine = PxEngine()
+    engine._on_px_detected = MagicMock()
+    engine.install_observer(page)
+
+    page.binding({"page": page})
+
+    engine._on_px_detected.assert_called_once_with(page)
+
+
+class _AsyncObserverPage:
+    def __init__(self):
+        self.binding = None
+        self.handlers = {}
+
+    async def expose_binding(self, name, callback):
+        assert name == "__pxNotify"
+        self.binding = callback
+
+    def on(self, event, callback):
+        self.handlers[event] = callback
+
+    async def evaluate(self, script):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_async_observer_binding_accepts_playwright_source_argument():
+    page = _AsyncObserverPage()
+    engine = PxEngine()
+    engine._on_px_detected_async = MagicMock()
+    await engine.install_observer_async(page)
+
+    page.binding({"page": page})
+
+    engine._on_px_detected_async.assert_called_once_with(page)
+
+
+class _ScriptOnlyPage:
+    url = "https://example.test/"
+    main_frame = object()
+    frames = [main_frame]
+
+    def evaluate(self, script, arg=None):
+        if "querySelectorAll('script')" in script:
+            return ["https://client.px-cloud.net/main.min.js"]
+        if arg is not None:
+            return 0
+        if "document.body" in script:
+            return "Normal application content"
+        return False
+
+
+
+def test_engine_does_not_treat_loaded_px_sdk_as_active_challenge():
+    handler, result = PxEngine().detect(_ScriptOnlyPage())
+    assert handler is None
+    assert result.detected is False
+
+
+class _Frame:
+    url = "https://captcha.px-cloud.net/challenge"
+
+    def evaluate(self, script):
+        return True
+
+
+class _FrameOnlyPage:
+    url = "https://example.test/"
+
+    def __init__(self):
+        self.main_frame = object()
+        self.frames = [self.main_frame, _Frame()]
+
+    def evaluate(self, script, arg=None):
+        if arg is not None:
+            return 0
+        if "querySelectorAll('script')" in script:
+            return []
+        if "document.body" in script:
+            return ""
+        return False
+
+
+
+def test_engine_detects_challenge_visible_only_in_child_frame():
+    handler, result = PxEngine().detect(_FrameOnlyPage())
+    assert handler is None
+    assert result.detected is True
+    assert result.evidence["frame_url"].startswith("https://captcha.px-cloud.net")
+
+
+class _Mouse:
+    def move(self, *args, **kwargs):
+        return None
+
+    def down(self, *args, **kwargs):
+        return None
+
+    def up(self, *args, **kwargs):
+        return None
+
+
+class _SolvePage:
+    viewport_size = {"width": 1280, "height": 720}
+    mouse = _Mouse()
+
+
+
+def test_solver_does_not_report_success_until_checker_is_ready(monkeypatch):
+    solver = SolveByHoldButton()
+    target = HoldTarget(x=100, y=100, width=100, height=30)
+    monkeypatch.setattr(solver, "find_target", lambda page: target)
+    monkeypatch.setattr(solver, "simulate_hold", lambda *args, **kwargs: None)
+    visibility = iter([True, False])
+    monkeypatch.setattr(solver, "_is_px_visible", lambda page: next(visibility, False))
+
+    cfg = PxConfig(
+        max_attempts=1,
+        post_wait=0.01,
+        app_ready_timeout=0,
+        checker=lambda page: False,
+    )
+    result = solver.solve(_SolvePage(), cfg)
+
+    assert result.solved is False
+    assert result.error == "app_not_ready"
+
+
+@pytest.mark.asyncio
+async def test_async_engine_uses_async_detection_and_solving(monkeypatch):
+    page = AsyncTextPage("Pressione e segure")
+    engine = PxEngine(PxConfig())
+    monkeypatch.setattr(engine, "_is_px_visible_async", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        engine,
+        "solve_async",
+        AsyncMock(return_value=SolveResult(solved=True, method="test")),
+    )
+
+    ok = await engine.check_and_solve_async(page)
+
+    assert ok is True
+    engine.solve_async.assert_awaited_once()
+
+
+
+def test_camel_case_px_bypass_alias_is_not_forwarded_to_context(monkeypatch):
+    from cloakbrowser import browser as browser_module
+
+    fake_browser = MagicMock()
+    fake_context = MagicMock()
+    fake_browser.new_context.return_value = fake_context
+    launch_mock = MagicMock(return_value=fake_browser)
+    monkeypatch.setattr(browser_module, "launch", launch_mock)
+
+    browser_module.launch_context(pxBypass=True)
+
+    assert launch_mock.call_args.kwargs["bypass_px"] is True
+    assert "pxBypass" not in fake_browser.new_context.call_args.kwargs

--- a/tests/test_pxbypass_fixture.py
+++ b/tests/test_pxbypass_fixture.py
@@ -1,0 +1,148 @@
+"""Issue #448 regression: load a PX press-and-hold fixture and verify the
+bypass detects it, finds the button, holds the mouse for >3.5s, and the
+challenge disappears (the page exposes #px-captcha with 'Activate and hold').
+
+This is a true end-to-end smoke test that does NOT depend on PerimeterX's
+network or the iFood/Walmart IP-rating flow.  Run:
+
+    pytest tests/test_pxbypass_fixture.py -q -s
+
+The bypass fires the moment the page loads (5.6s end-to-end in the manual
+run), so we install a JS observer that captures the bypass's detection /
+solve signals from the page side and assert the page state was reached.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from cloakbrowser import launch
+from cloakbrowser.pxbypass import PxConfig, detect_px
+from cloakbrowser.pxbypass.engine import PxEngine
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "px_challenge.html"
+
+
+def _new_browser(headless: bool, *, max_attempts: int = 1):
+    return launch(
+        headless=headless,
+        bypass_px=True,
+        px_config=PxConfig(
+            max_attempts=max_attempts,
+            hold_min=4.0,
+            hold_max=5.0,
+            post_wait=2.0,
+            button_wait_timeout=10.0,
+        ),
+    )
+
+
+def test_fixture_page_loads_with_challenge():
+    """Sanity: the fixture actually serves a visible #px-captcha with the
+    expected text so we know any failure in the real test is bypass code,
+    not test-fixture setup."""
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as pw:
+        # Use system Chromium (not CloakBrowser) — fixture should be neutral
+        browser = pw.chromium.launch(headless=True)
+        try:
+            page = browser.new_page()
+            page.goto(FIXTURE.as_uri(), wait_until="domcontentloaded")
+            assert page.locator("#px-captcha").is_visible()
+            text = page.evaluate("() => document.body.innerText")
+            assert "activate and hold" in text.lower()
+            assert page.locator("#hold-btn").is_visible()
+        finally:
+            browser.close()
+
+
+def _exercise_bypass(headless: bool) -> dict:
+    """Drive CloakBrowser against the fixture, return a small report dict.
+
+    The bypass solves the challenge in ~5.5s end-to-end: detection fires
+    from the JS observer the moment the page loads, button is found, mouse
+    moves to it via Bezier trajectory, mousedown for 4.0s, mouseup, page
+    flips to "Success".  We assert on the side-effects, not the snapshot.
+    """
+    browser = _new_browser(headless)
+    try:
+        page = browser.new_page()
+        # Install a recorder BEFORE goto so we capture every mouse event
+        # the bypass produces on the actual button.
+        page.add_init_script(
+            """
+            window.__pxTrace = { events: [], success: false };
+            const rec = (label) => (e) => {
+              window.__pxTrace.events.push({
+                type: label,
+                x: e.clientX, y: e.clientY,
+                target: e.target && (e.target.tagName + (e.target.id ? '#' + e.target.id : '')),
+                ts: Date.now(),
+              });
+            };
+            const obs = new MutationObserver(() => {
+              if (document.getElementById('ok')) {
+                window.__pxTrace.success = true;
+                obs.disconnect();
+              }
+            });
+            document.addEventListener('DOMContentLoaded', () => {
+              obs.observe(document.body, { childList: true, subtree: true });
+              const btn = document.getElementById('hold-btn');
+              if (btn) {
+                ['mousedown', 'mouseup', 'click'].forEach(t =>
+                  btn.addEventListener(t, rec(t), { capture: true }));
+              }
+            });
+            """
+        )
+        page.goto(FIXTURE.as_uri(), wait_until="domcontentloaded")
+        t0 = time.monotonic()
+        try:
+            page.wait_for_selector("#ok", timeout=20_000)
+        except Exception:
+            pass
+        duration = time.monotonic() - t0
+        trace = page.evaluate("() => window.__pxTrace || {}")
+        return {
+            "duration": duration,
+            "cleared": page.locator("#ok").count() > 0,
+            "trace": trace,
+        }
+    finally:
+        browser.close()
+
+
+def test_bypass_dismisses_fixture_challenge():
+    """End-to-end: load the fixture, let the bypass take over, assert the
+    page flipped to "Success — captcha cleared" with a real press-and-hold
+    on the button (≥1 mousedown + 1 mouseup on BUTTON#hold-btn ≥3s apart)."""
+    report = _exercise_bypass(headless=True)
+    print("fixture smoke report:", json.dumps(report, indent=2, default=str))
+    assert report["cleared"] is True, (
+        f"challenge not cleared within 20s; bypass probably never solved it. "
+        f"duration={report['duration']:.2f}s trace={report['trace']!r}"
+    )
+    events = report["trace"].get("events", [])
+    mousedowns = [e for e in events if e["type"] == "mousedown"
+                  and e.get("target") == "BUTTON#hold-btn"]
+    mouseups = [e for e in events if e["type"] == "mouseup"
+                and e.get("target") == "BUTTON#hold-btn"]
+    assert len(mousedowns) >= 1, (
+        f"no mousedown on the hold button; bypass aimed somewhere else. "
+        f"events={events!r}"
+    )
+    assert len(mouseups) >= 1, (
+        f"no mouseup on the hold button; bypass never released. events={events!r}"
+    )
+    held_ms = mouseups[0]["ts"] - mousedowns[0]["ts"]
+    assert held_ms >= 3500, (
+        f"hold too short: {held_ms}ms; PX requires ~3.5s+ to register a real "
+        f"press. events={events!r}"
+    )


### PR DESCRIPTION
## Summary
- adds `bypass_px=True` plus the requested `pxBypass=True` compatibility alias across sync/async and context launch APIs
- continuously detects visible PerimeterX press-and-hold challenges, including iframe variants, and solves them with real mouse movement/hold telemetry
- ports the proven iFood flow: precise button scoring, async support, post-solve application readiness checks, and false-positive protection for pages that merely load the PX SDK
- adds an end-to-end regression test that drives the full bypass against a local fixture of the press-and-hold challenge and asserts a real mousedown/mouseup ≥3.5s landed on the actual button
- rebased onto current `main` / v0.4.11, preserving license, proxy-auth, viewport and maximize changes

## Verification
- `python -m pytest tests/test_pxbypass_fixture.py tests/test_pxbypass.py tests/test_launch_context.py tests/test_persistent_context.py tests/test_config.py tests/test_build_args.py tests/test_proxy.py tests/test_license.py tests/test_license_error.py -q` — **235 passed**
- end-to-end fixture run: 8s wall-clock, mousedown (643,275) on `BUTTON#hold-btn` → mouseup (647,274) on `BUTTON#hold-btn` 4962ms later, page flipped to "Success — captcha cleared"
- live iFood + Brazilian residential proxy, headless, 25 activity rounds — exit 0 (`Page is usable; PX is absent or was solved`)

The new `tests/test_pxbypass_fixture.py` is the **first test that proves the bypass actually presses a real button** — it does not rely on PerimeterX server interaction, iFood IP-rating, or Walmart Akamai fronting.  Anyone running the test on any machine in any network can reproduce the proof in ~8s.

Closes #448