### PR TITLE
fix(cli): run main() when invoked via a symlinked bin (npx) (#427)

### DIFF
--- a/js/src/cli.ts
+++ b/js/src/cli.ts
@@ -25,7 +25,7 @@ import { countFontsPresent, WINDOWS_FONT_TELLS, OFFICE_FONT_TELLS } from "./font
 import { resolveLicenseKey, validateLicense, getProLatestVersion, getActiveSessionCount, type LicenseInfo } from "./license.js";
 import { execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -427,10 +427,26 @@ async function main(): Promise<void> {
 }
 
 // Only run when invoked as the CLI entry point — not when imported by tests.
-// import.meta.url is resolved through symlinks by Node's ESM loader, but
-// process.argv[1] is left exactly as invoked — so realpath both sides before
-// comparing, otherwise every symlinked bin (npm/pnpm/npx) fails the check silently.
-const invokedPath = process.argv[1];
-if (invokedPath && import.meta.url === pathToFileURL(fs.realpathSync(invokedPath)).href) {
+// import.meta.url and process.argv[1] may each be a symlink (npm/pnpm/npx bin
+// shims resolve through node_modules/.bin), and the two need not start equal,
+// so realpath BOTH sides before comparing. This is what lets `npx cloakbrowser
+// info` (and every other subcommand) actually run instead of exiting 0 with no
+// output (#427).
+export function isCliEntry(invokedPath: string | undefined, metaUrl: string): boolean {
+  if (!invokedPath) {
+    return false;
+  }
+  try {
+    const invokedReal = fs.realpathSync(invokedPath);
+    const thisReal = fs.realpathSync(fileURLToPath(metaUrl));
+    return invokedReal === thisReal;
+  } catch {
+    // If either path can't be resolved (e.g. a shim that doesn't exist yet),
+    // don't auto-run main() — safer to do nothing than to run with a bad path.
+    return false;
+  }
+}
+
+if (isCliEntry(process.argv[1], import.meta.url)) {
   main();
 }

--- a/js/tests/cli.test.ts
+++ b/js/tests/cli.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 // collectDiagnostics reads the cache dir (license key file, binary path) and,
 // in --quick mode, never spawns the binary — so an isolated temp cache dir is
@@ -45,5 +46,41 @@ describe("collectDiagnostics", () => {
     else expect(diag.fonts).toBeUndefined();
     expect(typeof diag.geoip.db_present).toBe("boolean");
     expect(Object.keys(diag.modules).length).toBeGreaterThan(0);
+  });
+});
+
+describe("isCliEntry", () => {
+  const realCli = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../dist/cli.js");
+
+  it("returns false when no invoked path is provided", async () => {
+    const { isCliEntry } = await import("../src/cli.js");
+    expect(isCliEntry(undefined, import.meta.url)).toBe(false);
+  });
+
+  it("returns false for an unrelated invoked path", async () => {
+    const { isCliEntry } = await import("../src/cli.js");
+    // A different source file must not be treated as the cli.js entry.
+    const other = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../dist/config.js");
+    expect(fs.existsSync(other)).toBe(true);
+    expect(isCliEntry(other, import.meta.url)).toBe(false);
+  });
+
+  it("resolves symlinks on both sides before comparing (#427)", async () => {
+    const { isCliEntry } = await import("../src/cli.js");
+    // A bin shim (npm/pnpm/npx) is a symlink to the real cli.js; realpath both
+    // sides so the comparison still matches.
+    const linkDir = fs.mkdtempSync(path.join(os.tmpdir(), "cloak-entry-"));
+    const link = path.join(linkDir, "cloakbrowser");
+    fs.symlinkSync(realCli, link);
+    try {
+      expect(isCliEntry(link, `file://${realCli}`)).toBe(true);
+    } finally {
+      fs.rmSync(linkDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns false for a non-existent invoked path", async () => {
+    const { isCliEntry } = await import("../src/cli.js");
+    expect(isCliEntry("/nonexistent/path/cli.js", import.meta.url)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Fixes #427 — `npx cloakbrowser info` (and every subcommand) produced no output and exited 0. The CLI entry guard compared `import.meta.url` against `pathToFileURL(invokedPath)` but only realpathed the invoked side; under npx/pnpm-exec the bin is a symlink (`node_modules/.bin/cloakbrowser` -> `dist/cli.js`) and the two realpaths did not match, so `main()` never ran.

## Fix
- js/src/cli.ts: extract `isCliEntry(invokedPath, metaUrl)` which realpaths **both** sides before comparing and returns `false` (never auto-running `main()`) on any resolution error. The module-level guard now uses it.
- js/tests/cli.test.ts: unit tests for `isCliEntry` — symlink resolution, missing path, unrelated file, and undefined `argv[1]`.

## Validation
- `node_modules/.bin/vitest run tests/cli.test.ts` -> 6 passed.
- End-to-end: a symlinked bin shim invoking `dist/cli.js` now prints `CloakBrowser diagnostics` (exit 0) instead of silently exiting. Importing `cli.js` in tests does NOT auto-run `main()` (the import-by-test case stays safe).
- `tsc` build clean.

Closes #427.