### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ On first run, the stealth Chromium binary is automatically downloaded (~200MB, c
 **Optional:** Auto-detect timezone/locale from proxy IP:
 
 ```bash
-pip install cloakbrowser[geoip]
+pip install 'cloakbrowser[geoip]'
 ```
 
 **Migrating from Playwright?** One-line change:


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `README.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`