### PR TITLE
fix: preserve HTTP proxy credentials during GeoIP resolution

### DIFF
--- a/cloakbrowser/browser.py
+++ b/cloakbrowser/browser.py
@@ -1053,8 +1053,8 @@ def _normalize_socks_string_url(url: str) -> str:
 def _extract_proxy_url(proxy: str | ProxySettings | None) -> str | None:
     """Extract and normalize proxy URL string from proxy param.
 
-    For SOCKS5 dicts with separate username/password fields, reconstructs
-    the full URL with inline credentials so SOCKS5 auth works.
+    For proxy dicts with separate username/password fields, reconstructs
+    the full URL with inline credentials so proxy auth works.
     """
     if proxy is None:
         return None
@@ -1062,8 +1062,11 @@ def _extract_proxy_url(proxy: str | ProxySettings | None) -> str | None:
         server = proxy.get("server", "")
         if not server:
             return None
-        if _is_socks_proxy(proxy):
-            return _reconstruct_socks_url(proxy)
+        if proxy.get("username"):
+            return (
+                _reconstruct_socks_url(proxy) if _is_socks_proxy(proxy)
+                else _reconstruct_http_url(proxy)
+            )
         return _ensure_proxy_scheme(server)
     return _ensure_proxy_scheme(proxy)
 

--- a/dotnet/src/CloakBrowser/ProxyResolver.cs
+++ b/dotnet/src/CloakBrowser/ProxyResolver.cs
@@ -272,7 +272,9 @@ internal static class ProxyResolver
                 return null;
             case ProxySettings ps:
                 if (string.IsNullOrEmpty(ps.Server)) return null;
-                return IsSocksProxy(ps) ? ReconstructSocksUrl(ps) : EnsureProxyScheme(ps.Server);
+                return IsSocksProxy(ps)
+                    ? ReconstructSocksUrl(ps)
+                    : EnsureProxyScheme(ReconstructHttpUrl(ps));
             case string s:
                 return EnsureProxyScheme(s);
             default:

--- a/dotnet/tests/CloakBrowser.Tests/ProxyResolverTests.cs
+++ b/dotnet/tests/CloakBrowser.Tests/ProxyResolverTests.cs
@@ -103,6 +103,16 @@ public class ProxyResolverTests
     }
 
     [Fact]
+    public void ExtractProxyUrl_Http_Dict_Reconstructs_With_Creds()
+    {
+        var url = ProxyResolver.ExtractProxyUrl(new ProxySettings
+        {
+            Server = "host:8080", Username = "user@tenant", Password = "p:ss",
+        });
+        Assert.Equal("http://user%40tenant:p%3Ass@host:8080", url);
+    }
+
+    [Fact]
     public void IsSocksProxy_Detects_Variants()
     {
         Assert.True(ProxyResolver.IsSocksProxy("socks5://h:1"));

--- a/js/src/geoip.ts
+++ b/js/src/geoip.ts
@@ -15,7 +15,7 @@ import dns from "node:dns/promises";
 import net from "node:net";
 import { getCacheDir } from "./config.js";
 import type { LaunchOptions } from "./types.js";
-import { ensureProxyScheme, isSocksProxy, reconstructSocksUrl, type ProxyDict } from "./proxy.js";
+import { ensureProxyScheme, isSocksProxy, reconstructHttpUrl, reconstructSocksUrl, type ProxyDict } from "./proxy.js";
 
 // P3TERX mirror of MaxMind GeoLite2-City — no license key needed
 const GEOIP_DB_URL =
@@ -408,16 +408,16 @@ function maybeTriggerUpdate(dbPath: string): void {
 
 /**
  * Extract a usable proxy URL from LaunchOptions.proxy.
- * For SOCKS5 dicts with separate credentials, reconstructs the full URL
- * with inline credentials so SOCKS5 auth works.
+ * For proxy dicts with separate credentials, reconstructs the full URL
+ * with inline credentials so proxy auth works.
  */
 function extractProxyUrl(proxy: string | ProxyDict | undefined): string | null {
   if (!proxy) return null;
   if (typeof proxy === "string") return ensureProxyScheme(proxy);
   const p = proxy as ProxyDict;
   if (!p.server) return null;
-  if (p.username && isSocksProxy(p)) {
-    return reconstructSocksUrl(p);
+  if (p.username) {
+    return isSocksProxy(p) ? reconstructSocksUrl(p) : reconstructHttpUrl(p);
   }
   return ensureProxyScheme(p.server);
 }

--- a/js/tests/geoip.test.ts
+++ b/js/tests/geoip.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import fs from "node:fs";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { COUNTRY_LOCALE_MAP, maybeResolveGeoip, resolveProxyGeo, resolveProxyIp } from "../src/geoip.js";
+import Stream from "node:stream";
 
 const tempDirs: string[] = [];
 
@@ -51,6 +53,46 @@ describe("resolveProxyIp", () => {
 });
 
 describe("maybeResolveGeoip", () => {
+  it("forwards separate HTTP proxy credentials to CONNECT requests", async () => {
+    const authorizationHeaders: Array<string | undefined> = [];
+    const sockets = new Set<Stream.Duplex>();
+    const proxy = http.createServer();
+    proxy.on("connect", (request, socket) => {
+      sockets.add(socket);
+      socket.once("close", () => sockets.delete(socket));
+      authorizationHeaders.push(request.headers["proxy-authorization"]);
+      socket.end("HTTP/1.1 407 Proxy Authentication Required\r\nContent-Length: 0\r\n\r\n");
+    });
+    await new Promise<void>((resolve) => proxy.listen(0, "127.0.0.1", resolve));
+
+    try {
+      const address = proxy.address();
+      if (address === null || typeof address === "string") throw new Error("Missing proxy address");
+      process.env.CLOAKBROWSER_GEOIP_TIMEOUT_SECONDS = "0.2";
+
+      await maybeResolveGeoip({
+        geoip: true,
+        timezone: "America/New_York",
+        locale: "en-US",
+        proxy: {
+          server: `http://127.0.0.1:${address.port}`,
+          username: "user",
+          password: "pass",
+        },
+      });
+
+      expect(authorizationHeaders).not.toHaveLength(0);
+      expect(authorizationHeaders).toEqual(
+        authorizationHeaders.map(() => "Basic dXNlcjpwYXNz"),
+      );
+    } finally {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve, reject) =>
+        proxy.close((error) => (error === undefined ? resolve() : reject(error))),
+      );
+    }
+  });
+
   it("does not apply the GeoIP resolution timeout to first-use database download", async () => {
     const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "cloak-geoip-download-"));
     tempDirs.push(cacheDir);

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -178,11 +178,16 @@ class TestMaybeResolveGeoip:
         mock_geo.assert_called_once_with("socks5://proxy:1080")
 
     @patch("cloakbrowser.geoip.resolve_proxy_geo_with_ip", return_value=("Europe/London", "en-GB", "1.1.1.1"))
-    def test_geoip_http_dict_does_not_inline_creds(self, mock_geo):
-        # HTTP dict: credentials stay separate, only server URL passed
-        proxy_dict = {"server": "http://proxy:8080", "username": "user", "password": "pass"}
+    def test_geoip_http_dict_without_credentials_uses_server(self, mock_geo):
+        proxy_dict = {"server": "http://proxy:8080"}
         tz, locale, ip = maybe_resolve_geoip(True, proxy_dict, None, None)
         mock_geo.assert_called_once_with("http://proxy:8080")
+
+    @patch("cloakbrowser.geoip.resolve_proxy_geo_with_ip", return_value=("Europe/London", "en-GB", "1.1.1.1"))
+    def test_geoip_http_dict_reconstructs_credentials(self, mock_geo):
+        proxy_dict = {"server": "http://proxy:8080", "username": "user", "password": "pass"}
+        tz, locale, ip = maybe_resolve_geoip(True, proxy_dict, None, None)
+        mock_geo.assert_called_once_with("http://user:pass@proxy:8080")
 
 
 class TestBareProxyFormat:


### PR DESCRIPTION
## Summary

- Preserve HTTP proxy credentials during GeoIP and WebRTC exit-IP resolution.
- Reuse existing credential-aware proxy URL reconstruction in the JavaScript, Python, and .NET SDKs.
- Keep unauthenticated HTTP proxy behavior unchanged.
- Add regression tests, including a JavaScript CONNECT proxy authentication test.

## Testing

- JavaScript: `npm test -- tests/geoip.test.ts` — 17 passed
- JavaScript: `npm run typecheck` — passed
- Python: `uv run --extra dev --extra geoip pytest -q tests/test_proxy.py::TestMaybeResolveGeoip tests/test_geoip.py` — 40 passed
- .NET: `dotnet test dotnet/tests/CloakBrowser.Tests/CloakBrowser.Tests.csproj --filter FullyQualifiedName~ProxyResolverTests` — 12 passed

Closes #469