### PR TITLE
fix: align Windows font metrics when using fonts dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changes are tagged: **[wrapper]** for Python/JS wrapper, **[binary]** for Chromi
 
 ## [Unreleased]
 
+- **[wrapper]** When spoofing Windows on Linux with a user-provided Windows fonts directory, the wrappers now automatically add `--fingerprint-windows-font-metrics` unless you already set it. This keeps font names and text metrics aligned for aggressive font probes such as DataDome while preserving non-Windows personas and explicit user overrides (#471). Python, JavaScript, and .NET.
 - **[wrapper]** **`cloakbrowser info` no longer aborts partway through on a Windows console.** `cmd.exe` defaults to a code page that cannot represent the report's check mark and arrow, so the command stopped with an encoding error at the first one and the remaining diagnostics were never printed. Those marks now degrade to plain text when the console cannot take them, per character. UTF-8 consoles, including Linux, macOS and Windows Terminal, are unchanged. Python.
 - **[wrapper]** **`cloakbrowser info` no longer reports a false launch failure on Windows.** Chromium handles `--version` only on POSIX, so on Windows the switch was ignored and a browser started instead of printing — the probe then timed out and a healthy install was reported as broken, briefly putting a window on screen each run. The check now exits immediately on Windows, without a window, and still fails loudly on a genuinely broken binary; it reports no version there, since nothing is printed. Linux and macOS are unchanged. Python, JavaScript, and .NET.
 

--- a/cloakbrowser/browser.py
+++ b/cloakbrowser/browser.py
@@ -1233,6 +1233,22 @@ def build_args(
                 logger.debug("Arg override: %s -> %s", seen[key], flag)
             seen[key] = flag
 
+    # A caller-provided Windows fonts directory is an explicit request to make a
+    # Linux host look like a Windows desktop. Pair it with the Chromium 148+
+    # metrics alignment flag automatically; older binaries ignore it. This keeps
+    # DataDome-style font probes from seeing Windows font names with Linux text
+    # metrics (#471), while preserving non-Windows personas and explicit user
+    # choices.
+    effective_platform = seen.get("--fingerprint-platform")
+    if (
+        sys.platform.startswith("linux")
+        and effective_platform is not None
+        and effective_platform.split("=", 1)[-1].strip().lower() == "windows"
+        and "--fingerprint-fonts-dir" in seen
+        and "--fingerprint-windows-font-metrics" not in seen
+    ):
+        seen["--fingerprint-windows-font-metrics"] = "--fingerprint-windows-font-metrics"
+
     if extension_paths:
         abs_paths = [os.path.abspath(p) for p in extension_paths]
         ext_val = ",".join(abs_paths)

--- a/dotnet/src/CloakBrowser/CloakLauncher.cs
+++ b/dotnet/src/CloakBrowser/CloakLauncher.cs
@@ -385,6 +385,21 @@ public static class CloakLauncher
             Set("--fingerprint-locale", $"--fingerprint-locale={locale}");
         }
 
+        // A caller-provided Windows fonts directory is an explicit request to make a
+        // Linux host look like a Windows desktop. Pair it with the Chromium 148+
+        // metrics alignment flag automatically; older binaries ignore it. This keeps
+        // DataDome-style font probes from seeing Windows font names with Linux text
+        // metrics (#471), while preserving non-Windows personas and explicit user
+        // choices.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+            && seen.TryGetValue("--fingerprint-platform", out var effectivePlatform)
+            && effectivePlatform.Split('=', 2).Last().Trim().Equals("windows", StringComparison.OrdinalIgnoreCase)
+            && seen.ContainsKey("--fingerprint-fonts-dir")
+            && !seen.ContainsKey("--fingerprint-windows-font-metrics"))
+        {
+            Set("--fingerprint-windows-font-metrics", "--fingerprint-windows-font-metrics");
+        }
+
         if (extensionPaths != null && extensionPaths.Count > 0)
         {
             var absPaths = extensionPaths.Select(Path.GetFullPath);

--- a/dotnet/tests/CloakBrowser.Tests/BuildArgsTests.cs
+++ b/dotnet/tests/CloakBrowser.Tests/BuildArgsTests.cs
@@ -51,6 +51,45 @@ public class BuildArgsTests
     }
 
     [Fact]
+    public void WindowsFontsDir_Adds_WindowsFontMetrics_OnLinux()
+    {
+        var args = CloakLauncher.BuildArgs(
+            stealthArgs: true,
+            extraArgs: new List<string> { "--fingerprint-fonts-dir=/usr/share/fonts/windows" });
+        if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+                System.Runtime.InteropServices.OSPlatform.Linux))
+            Assert.Contains("--fingerprint-windows-font-metrics", args);
+        else
+            Assert.DoesNotContain("--fingerprint-windows-font-metrics", args);
+    }
+
+    [Fact]
+    public void WindowsFontMetrics_NotAdded_ForNonWindowsPersona()
+    {
+        var args = CloakLauncher.BuildArgs(
+            stealthArgs: true,
+            extraArgs: new List<string>
+            {
+                "--fingerprint-platform=linux",
+                "--fingerprint-fonts-dir=/usr/share/fonts/windows",
+            });
+        Assert.DoesNotContain("--fingerprint-windows-font-metrics", args);
+    }
+
+    [Fact]
+    public void WindowsFontMetrics_NotDoubled_WhenUserSuppliesIt()
+    {
+        var args = CloakLauncher.BuildArgs(
+            stealthArgs: true,
+            extraArgs: new List<string>
+            {
+                "--fingerprint-fonts-dir=/usr/share/fonts/windows",
+                "--fingerprint-windows-font-metrics",
+            });
+        Assert.Single(args, a => a == "--fingerprint-windows-font-metrics");
+    }
+
+    [Fact]
     public void ExtensionPaths_Produce_LoadExtension_And_DisableExcept()
     {
         var tmp = Directory.CreateTempSubdirectory().FullName;

--- a/js/src/args.ts
+++ b/js/src/args.ts
@@ -56,6 +56,22 @@ export function buildArgs(options: LaunchOptions): string[] {
     }
   }
 
+  // A caller-provided Windows fonts directory is an explicit request to make a
+  // Linux host look like a Windows desktop. Pair it with the Chromium 148+
+  // metrics alignment flag automatically; older binaries ignore it. This keeps
+  // DataDome-style font probes from seeing Windows font names with Linux text
+  // metrics (#471), while preserving non-Windows personas and explicit user
+  // choices.
+  const effectivePlatform = seen.get("--fingerprint-platform");
+  if (
+    process.platform === "linux" &&
+    effectivePlatform?.split("=")[1]?.trim().toLowerCase() === "windows" &&
+    seen.has("--fingerprint-fonts-dir") &&
+    !seen.has("--fingerprint-windows-font-metrics")
+  ) {
+    seen.set("--fingerprint-windows-font-metrics", "--fingerprint-windows-font-metrics");
+  }
+
   if (options.extensionPaths?.length) {
     const absPaths = options.extensionPaths.map(p => path.resolve(p));
     const joined = absPaths.join(",");

--- a/js/tests/config.test.ts
+++ b/js/tests/config.test.ts
@@ -216,6 +216,37 @@ describe("buildArgs deduplication", () => {
     expect(platArgs[0]).toBe("--fingerprint-platform=linux");
   });
 
+  it("adds Windows font metrics for Windows fonts dir on Linux", () => {
+    const args = _buildArgsForTest({
+      args: ["--fingerprint-fonts-dir=/usr/share/fonts/windows"],
+    });
+    if (process.platform === "linux") {
+      expect(args).toContain("--fingerprint-windows-font-metrics");
+    } else {
+      expect(args).not.toContain("--fingerprint-windows-font-metrics");
+    }
+  });
+
+  it("does not add Windows font metrics for a non-Windows persona", () => {
+    const args = _buildArgsForTest({
+      args: [
+        "--fingerprint-platform=linux",
+        "--fingerprint-fonts-dir=/usr/share/fonts/windows",
+      ],
+    });
+    expect(args).not.toContain("--fingerprint-windows-font-metrics");
+  });
+
+  it("does not duplicate user-supplied Windows font metrics flag", () => {
+    const args = _buildArgsForTest({
+      args: [
+        "--fingerprint-fonts-dir=/usr/share/fonts/windows",
+        "--fingerprint-windows-font-metrics",
+      ],
+    });
+    expect(args.filter(a => a === "--fingerprint-windows-font-metrics")).toHaveLength(1);
+  });
+
   it("timezone param overrides user --fingerprint-timezone arg", () => {
     const args = _buildArgsForTest({
       args: ["--fingerprint-timezone=Europe/London"],

--- a/tests/test_build_args.py
+++ b/tests/test_build_args.py
@@ -1,5 +1,7 @@
 """Unit tests for build_args timezone/locale injection and timezone alias."""
 
+import sys
+
 from cloakbrowser.browser import build_args, _resolve_timezone
 
 
@@ -102,6 +104,42 @@ def test_user_platform_overrides_default():
     platform_args = [a for a in args if a.startswith("--fingerprint-platform=")]
     assert len(platform_args) == 1
     assert platform_args[0] == "--fingerprint-platform=linux"
+
+
+def test_windows_fonts_dir_adds_windows_font_metrics_on_linux():
+    """Windows fonts dir on a Linux Windows persona should also align metrics."""
+    args = build_args(
+        stealth_args=True,
+        extra_args=["--fingerprint-fonts-dir=/usr/share/fonts/windows"],
+    )
+    if sys.platform.startswith("linux"):
+        assert "--fingerprint-windows-font-metrics" in args
+    else:
+        assert "--fingerprint-windows-font-metrics" not in args
+
+
+def test_windows_font_metrics_not_added_for_non_windows_persona():
+    """A Linux persona with a custom fonts dir should not get Windows metrics."""
+    args = build_args(
+        stealth_args=True,
+        extra_args=[
+            "--fingerprint-platform=linux",
+            "--fingerprint-fonts-dir=/usr/share/fonts/windows",
+        ],
+    )
+    assert "--fingerprint-windows-font-metrics" not in args
+
+
+def test_windows_font_metrics_not_duplicated_when_user_supplies_it():
+    """User-provided Windows metrics flag should not be duplicated."""
+    args = build_args(
+        stealth_args=True,
+        extra_args=[
+            "--fingerprint-fonts-dir=/usr/share/fonts/windows",
+            "--fingerprint-windows-font-metrics",
+        ],
+    )
+    assert args.count("--fingerprint-windows-font-metrics") == 1
 
 
 def test_timezone_param_overrides_user_arg():


### PR DESCRIPTION
## Summary
- auto-add `--fingerprint-windows-font-metrics` on Linux when the effective persona is Windows and `--fingerprint-fonts-dir` is provided
- keep non-Windows personas and explicit user-supplied metrics flags unchanged
- add Python, JavaScript, and .NET regression coverage

Fixes #471.

## Verification
- `. .venv/bin/activate && pytest tests/test_build_args.py -q`
- `. .venv/bin/activate && pytest tests/ -q -m "not slow"`
- `cd js && npm run build`
- `cd js && npm run typecheck && npm test`
- `dotnet test dotnet/CloakBrowser.sln -c Release --filter BuildArgsTests`
- `dotnet test dotnet/CloakBrowser.sln -c Release --no-build`