### PR TITLE
fix(cloakserve): evict poll()-alive but CDP-dead browsers instead of serving 502s

### DIFF
--- a/bin/cloakserve
+++ b/bin/cloakserve
@@ -319,7 +319,7 @@ class ChromePool:
             # Check if already running (including default fast-path)
             if seed_key in self._processes:
                 proc = self._processes[seed_key]
-                if proc.process.poll() is None:
+                if proc.process.poll() is None and await self._cdp_port_alive(proc.cdp_port):
                     if seed_key in self._idle_tasks:
                         self._schedule_idle_cleanup(seed_key)
                     if any([extra_args, timezone, locale, proxy, geoip]):
@@ -408,6 +408,45 @@ class ChromePool:
 
             logger.info("Chrome ready (seed=%s, port=%d, pid=%d)", actual_seed, port, process.pid)
             return cp
+
+    async def _cdp_port_alive(self, port: int, timeout: float = 0.5) -> bool:
+        """Return True only if the CDP port is accepting TCP connections.
+
+        A poll()-alive process is not proof of a usable browser. Chrome tears
+        down its DevTools/CDP socket seconds before the OS process actually
+        exits, and a wedged Chrome can keep the process alive with a dead port
+        indefinitely. Handing such a corpse back is what turns retry bursts into
+        a wall of dead-port 502s. A cheap local TCP connect lets the reuse path
+        tell a live browser from a dying one. The caller short-circuits on
+        poll() first, so an already-exited process never reaches this probe.
+        """
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection("127.0.0.1", port), timeout=timeout
+            )
+        except (OSError, asyncio.TimeoutError):
+            return False
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except (OSError, asyncio.TimeoutError):
+            pass
+        return True
+
+    def _pool_key_for(self, cp: ChromeProcess) -> str | None:
+        """Return the pool key whose value IS cp, or None if cp is not pooled.
+
+        Matches on object identity, never by recomputing the seed key: a
+        concurrent relaunch on the same seed may already have replaced the pool
+        entry with a fresh ChromeProcess, and re-deriving the key would evict
+        THAT healthy process. When cp is gone the caller must evict nothing.
+        Callers must not await between this lookup and the eviction so the entry
+        cannot be swapped underneath them.
+        """
+        for key, pooled in self._processes.items():
+            if pooled is cp:
+                return key
+        return None
 
     async def _cleanup_process(self, key: str) -> None:
         """Terminate a Chrome process and clean up."""
@@ -584,25 +623,37 @@ async def handle_json_version(request: web.Request) -> web.Response:
     pool: ChromePool = request.app["pool"]
     params = parse_connection_params(request.query_string)
 
-    cp = await pool.get_or_launch(
-        seed=params["seed"],
-        extra_args=params["extra_args"] or None,
-        timezone=params["timezone"],
-        locale=params["locale"],
-        proxy=params["proxy"],
-        geoip=params["geoip"],
-    )
+    data = None
+    for attempt in range(2):
+        cp = await pool.get_or_launch(
+            seed=params["seed"],
+            extra_args=params["extra_args"] or None,
+            timezone=params["timezone"],
+            locale=params["locale"],
+            proxy=params["proxy"],
+            geoip=params["geoip"],
+        )
 
-    try:
-        async with aiohttp.ClientSession() as session:
-            async with session.get(
-                f"http://127.0.0.1:{cp.cdp_port}/json/version",
-                timeout=aiohttp.ClientTimeout(total=5),
-            ) as resp:
-                data = await resp.json()
-    except Exception as exc:
-        logger.error("Failed to reach Chrome CDP (port %d): %s", cp.cdp_port, exc)
-        return web.json_response({"error": "CDP endpoint unreachable"}, status=502)
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"http://127.0.0.1:{cp.cdp_port}/json/version",
+                    timeout=aiohttp.ClientTimeout(total=5),
+                ) as resp:
+                    data = await resp.json()
+            break
+        except Exception as exc:
+            logger.error("Failed to reach Chrome CDP (port %d): %s", cp.cdp_port, exc)
+            if attempt == 0:
+                stale_key = pool._pool_key_for(cp)
+                if stale_key is not None:
+                    logger.warning(
+                        "Evicting dead pooled Chrome (seed_key=%s, port=%d) and retrying",
+                        stale_key, cp.cdp_port,
+                    )
+                    await pool._cleanup_process(stale_key)
+                continue
+            return web.json_response({"error": "CDP endpoint unreachable"}, status=502)
 
     # Rewrite webSocketDebuggerUrl to route through our multiplexer
     host = _external_host(request)
@@ -626,25 +677,37 @@ async def handle_json_list(request: web.Request) -> web.Response:
     pool: ChromePool = request.app["pool"]
     params = parse_connection_params(request.query_string)
 
-    cp = await pool.get_or_launch(
-        seed=params["seed"],
-        extra_args=params["extra_args"] or None,
-        timezone=params["timezone"],
-        locale=params["locale"],
-        proxy=params["proxy"],
-        geoip=params["geoip"],
-    )
+    data = None
+    for attempt in range(2):
+        cp = await pool.get_or_launch(
+            seed=params["seed"],
+            extra_args=params["extra_args"] or None,
+            timezone=params["timezone"],
+            locale=params["locale"],
+            proxy=params["proxy"],
+            geoip=params["geoip"],
+        )
 
-    try:
-        async with aiohttp.ClientSession() as session:
-            async with session.get(
-                f"http://127.0.0.1:{cp.cdp_port}/json/list",
-                timeout=aiohttp.ClientTimeout(total=5),
-            ) as resp:
-                data = await resp.json()
-    except Exception as exc:
-        logger.error("Failed to reach Chrome CDP (port %d): %s", cp.cdp_port, exc)
-        return web.json_response({"error": "CDP endpoint unreachable"}, status=502)
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"http://127.0.0.1:{cp.cdp_port}/json/list",
+                    timeout=aiohttp.ClientTimeout(total=5),
+                ) as resp:
+                    data = await resp.json()
+            break
+        except Exception as exc:
+            logger.error("Failed to reach Chrome CDP (port %d): %s", cp.cdp_port, exc)
+            if attempt == 0:
+                stale_key = pool._pool_key_for(cp)
+                if stale_key is not None:
+                    logger.warning(
+                        "Evicting dead pooled Chrome (seed_key=%s, port=%d) and retrying",
+                        stale_key, cp.cdp_port,
+                    )
+                    await pool._cleanup_process(stale_key)
+                continue
+            return web.json_response({"error": "CDP endpoint unreachable"}, status=502)
 
     host = _external_host(request)
     scheme = _ws_scheme(request)

--- a/tests/test_cloakserve.py
+++ b/tests/test_cloakserve.py
@@ -472,6 +472,7 @@ class TestConnectionTracking:
     def _track_live_process(self, pool, seed="seed1"):
         pool._processes[seed] = SimpleNamespace(
             process=SimpleNamespace(poll=lambda: None),
+            cdp_port=5100,
         )
 
     def test_connect_increments(self):
@@ -570,6 +571,13 @@ class TestConnectionTracking:
         async def run():
             pool = self._make_pool(idle_timeout=1.0)
             self._track_live_process(pool)
+
+            # The reuse fast-path now also probes the CDP port; the tracked
+            # process is deliberately live, so keep the probe positive.
+            async def _always_alive(_port):
+                return True
+
+            pool._cdp_port_alive = _always_alive
 
             pool.connect("seed1")
             pool.disconnect("seed1")
@@ -676,3 +684,352 @@ class TestSafeRmtree:
         pool._safe_rmtree(traversal)
 
         assert victim.exists(), "Traversal path must not be deleted"
+
+
+# ---------------------------------------------------------------------------
+# Dead-CDP-port corpse eviction
+#
+# process.poll() reports a Chrome alive until the OS reaps it, but Chrome drops
+# its DevTools/CDP socket seconds before it exits (and a wedged Chrome keeps the
+# process alive with a dead port indefinitely). Reusing such a corpse hands back
+# a browser whose CDP port refuses connections, so the /json handlers used to
+# 502 without evicting it — every retry hit the same corpse. The pool now probes
+# the CDP port before reuse, and the handlers evict-and-retry once.
+# ---------------------------------------------------------------------------
+
+
+class TestCdpPortAlive:
+    """_cdp_port_alive: a real local TCP probe, not a poll() guess."""
+
+    def _make_pool(self):
+        return ChromePool(
+            binary="/fake/chrome",
+            global_args=[],
+            headless=True,
+            data_dir="/tmp/test-cloakserve",
+        )
+
+    def test_true_for_a_listening_port(self):
+        import socket as _socket
+
+        async def run():
+            listener = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+            listener.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1)
+            listener.bind(("127.0.0.1", 0))
+            listener.listen(16)
+            port = listener.getsockname()[1]
+            try:
+                assert await self._make_pool()._cdp_port_alive(port) is True
+            finally:
+                listener.close()
+
+        asyncio.run(run())
+
+    def test_false_for_a_closed_port(self):
+        import socket as _socket
+
+        async def run():
+            # Bind then immediately release a port so nothing is listening on it.
+            s = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+            s.bind(("127.0.0.1", 0))
+            port = s.getsockname()[1]
+            s.close()
+
+            assert await self._make_pool()._cdp_port_alive(port, timeout=0.2) is False
+
+        asyncio.run(run())
+
+
+class TestPoolKeyForIdentity:
+    """_pool_key_for matches by object identity, never by re-deriving the seed key."""
+
+    def _make_pool(self):
+        return ChromePool(
+            binary="/fake/chrome",
+            global_args=[],
+            headless=True,
+            data_dir="/tmp/test-cloakserve",
+        )
+
+    def test_returns_key_of_the_pooled_object(self):
+        pool = self._make_pool()
+        cp = SimpleNamespace(cdp_port=5100)
+        pool._processes["seed1"] = cp
+        assert pool._pool_key_for(cp) == "seed1"
+
+    def test_returns_none_when_not_pooled(self):
+        pool = self._make_pool()
+        assert pool._pool_key_for(SimpleNamespace(cdp_port=5100)) is None
+
+    def test_ignores_an_equal_but_distinct_process_under_the_same_key(self):
+        # A concurrent relaunch on the same seed replaced the entry with a fresh
+        # object; the corpse is no longer pooled, so identity lookup finds
+        # nothing to evict — re-deriving "seed1" would have killed the fresh one.
+        pool = self._make_pool()
+        corpse = SimpleNamespace(cdp_port=5100)
+        fresh = SimpleNamespace(cdp_port=5101)
+        pool._processes["seed1"] = fresh
+        assert pool._pool_key_for(corpse) is None
+        assert pool._pool_key_for(fresh) == "seed1"
+
+
+class TestGetOrLaunchReuseGuard:
+    """get_or_launch reuses a pooled Chrome only when its CDP port is alive."""
+
+    def _make_pool(self):
+        return ChromePool(
+            binary="/fake/chrome",
+            global_args=[],
+            headless=True,
+            data_dir="/tmp/test-cloakserve",
+        )
+
+    def _stub_launch(self, pool, monkeypatch, cdp_port=6000):
+        """Neuter the real Chrome launch so a relaunch is observable, not spawned."""
+        state = {"launches": 0}
+
+        def _popen(*_args, **_kwargs):
+            state["launches"] += 1
+            return SimpleNamespace(poll=lambda: None, pid=4321, kill=lambda: None)
+
+        async def _wait_for_cdp(_port):
+            return True
+
+        monkeypatch.setattr(_mod.subprocess, "Popen", _popen)
+        monkeypatch.setattr(_mod.os, "makedirs", lambda *a, **k: None)
+        monkeypatch.setattr(_mod, "build_args", lambda **k: [])
+        monkeypatch.setattr(_mod, "_resolve_webrtc_args", lambda fp_extra, proxy: fp_extra)
+        monkeypatch.setattr(pool, "_allocate_port", lambda: cdp_port)
+        monkeypatch.setattr(pool, "_wait_for_cdp", _wait_for_cdp)
+        return state
+
+    def test_poll_alive_but_dead_port_is_evicted_and_relaunched(self, monkeypatch):
+        async def run():
+            pool = self._make_pool()
+            corpse = SimpleNamespace(
+                process=SimpleNamespace(poll=lambda: None),
+                cdp_port=5100,
+                user_data_dir="/tmp/test-cloakserve/seed1",
+            )
+            pool._processes["seed1"] = corpse
+
+            # poll() says alive, but the CDP port refuses connections.
+            async def _dead(_port):
+                return False
+
+            monkeypatch.setattr(pool, "_cdp_port_alive", _dead)
+
+            evicted = []
+
+            async def _cleanup(key):
+                evicted.append(key)
+                pool._processes.pop(key, None)
+
+            monkeypatch.setattr(pool, "_cleanup_process", _cleanup)
+            launch = self._stub_launch(pool, monkeypatch, cdp_port=6000)
+
+            cp = await pool.get_or_launch("seed1")
+
+            assert evicted == ["seed1"], "the corpse must be evicted"
+            assert cp is not corpse, "the corpse must not be reused"
+            assert cp.cdp_port == 6000, "a fresh browser must be launched"
+            assert launch["launches"] == 1
+            assert pool._processes["seed1"] is cp
+
+        asyncio.run(run())
+
+    def test_poll_alive_and_port_alive_is_reused_after_exactly_one_probe(self, monkeypatch):
+        async def run():
+            pool = self._make_pool()
+            live = SimpleNamespace(
+                process=SimpleNamespace(poll=lambda: None),
+                cdp_port=5100,
+            )
+            pool._processes["seed1"] = live
+
+            probes = []
+
+            async def _alive(port):
+                probes.append(port)
+                return True
+
+            monkeypatch.setattr(pool, "_cdp_port_alive", _alive)
+
+            def _no_launch(*_args, **_kwargs):
+                raise AssertionError("a live browser must be reused, never relaunched")
+
+            monkeypatch.setattr(_mod.subprocess, "Popen", _no_launch)
+
+            cp = await pool.get_or_launch("seed1")
+
+            assert cp is live, "the live browser must be reused"
+            assert probes == [5100], "the CDP port must be probed exactly once"
+
+        asyncio.run(run())
+
+
+class TestHandlerCorpseRecovery:
+    """handle_json_version / handle_json_list evict a dead corpse and retry once."""
+
+    def _make_request(self, pool, query_string="fingerprint=seed1"):
+        return SimpleNamespace(
+            app={"pool": pool, "port": 9222},
+            query_string=query_string,
+            headers={"Host": "cdp.example.com:9222"},
+            scheme="http",
+        )
+
+    class _FlakySession:
+        """aiohttp.ClientSession stand-in: fails the first ``fail_times`` fetches."""
+
+        def __init__(self, controller):
+            self._c = controller
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return None
+
+        def get(self, *_args, **_kwargs):
+            return TestHandlerCorpseRecovery._FlakyResponse(self._c)
+
+    class _FlakyResponse:
+        def __init__(self, controller):
+            self._c = controller
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return None
+
+        async def json(self):
+            self._c["calls"] += 1
+            if self._c["calls"] <= self._c["fail_times"]:
+                raise ConnectionRefusedError("CDP port refused")
+            return self._c["data"]
+
+    def _patch_session(self, monkeypatch, controller):
+        monkeypatch.setattr(
+            _mod.aiohttp,
+            "ClientSession",
+            lambda *_a, **_k: self._FlakySession(controller),
+        )
+
+    class _RecoveringPool:
+        """Hands back a fresh cp each launch; records evictions by identity."""
+
+        def __init__(self):
+            self.launches = 0
+            self.evicted = []
+            self._processes = {}
+
+        async def get_or_launch(self, **_kwargs):
+            self.launches += 1
+            cp = SimpleNamespace(cdp_port=5100 + self.launches)
+            self._processes["seed1"] = cp
+            return cp
+
+        def _pool_key_for(self, cp):
+            for key, pooled in self._processes.items():
+                if pooled is cp:
+                    return key
+            return None
+
+        async def _cleanup_process(self, key):
+            self.evicted.append(key)
+            self._processes.pop(key, None)
+
+    def test_json_version_recovers_from_a_dead_port_without_502(self, monkeypatch):
+        pool = self._RecoveringPool()
+        controller = {
+            "calls": 0,
+            "fail_times": 1,
+            "data": {"webSocketDebuggerUrl": "ws://127.0.0.1:5100/devtools/browser/guid"},
+        }
+        self._patch_session(monkeypatch, controller)
+
+        response = asyncio.run(_mod.handle_json_version(self._make_request(pool)))
+        payload = json.loads(response.text)
+
+        assert response.status == 200
+        assert pool.evicted == ["seed1"], "the dead corpse is evicted exactly once"
+        assert pool.launches == 2, "a fresh browser is launched for the retry"
+        assert payload["webSocketDebuggerUrl"] == (
+            "ws://cdp.example.com:9222/fingerprint/seed1/devtools/browser/guid"
+        )
+
+    def test_json_version_returns_502_only_after_both_attempts_fail(self, monkeypatch):
+        pool = self._RecoveringPool()
+        controller = {"calls": 0, "fail_times": 2, "data": {}}
+        self._patch_session(monkeypatch, controller)
+
+        response = asyncio.run(_mod.handle_json_version(self._make_request(pool)))
+
+        assert response.status == 502
+        assert json.loads(response.text) == {"error": "CDP endpoint unreachable"}
+        assert pool.evicted == ["seed1"], "eviction is attempted once, on the first failure"
+        assert pool.launches == 2, "both attempts run before giving up"
+
+    def test_json_list_recovers_from_a_dead_port_without_502(self, monkeypatch):
+        pool = self._RecoveringPool()
+        controller = {
+            "calls": 0,
+            "fail_times": 1,
+            "data": [{"webSocketDebuggerUrl": "ws://127.0.0.1:5100/devtools/page/guid"}],
+        }
+        self._patch_session(monkeypatch, controller)
+
+        response = asyncio.run(_mod.handle_json_list(self._make_request(pool)))
+        payload = json.loads(response.text)
+
+        assert response.status == 200
+        assert pool.evicted == ["seed1"]
+        assert pool.launches == 2
+        assert payload[0]["webSocketDebuggerUrl"] == (
+            "ws://cdp.example.com:9222/fingerprint/seed1/devtools/page/guid"
+        )
+
+    def test_eviction_by_identity_spares_a_concurrently_relaunched_process(self, monkeypatch):
+        # get_or_launch hands back a corpse on attempt 0, but by the time the
+        # handler goes to evict, a concurrent same-seed relaunch has already put
+        # a fresh process in the pool under "seed1". Identity-based lookup must
+        # find nothing to evict, so the fresh process survives and is reused.
+        corpse = SimpleNamespace(cdp_port=5100)
+        fresh = SimpleNamespace(cdp_port=5101)
+
+        class _RacePool:
+            def __init__(self):
+                self.launches = 0
+                self.evicted = []
+                # the concurrent relaunch already swapped the entry
+                self._processes = {"seed1": fresh}
+
+            async def get_or_launch(self, **_kwargs):
+                self.launches += 1
+                return corpse if self.launches == 1 else fresh
+
+            def _pool_key_for(self, cp):
+                for key, pooled in self._processes.items():
+                    if pooled is cp:
+                        return key
+                return None
+
+            async def _cleanup_process(self, key):
+                self.evicted.append(key)
+                self._processes.pop(key, None)
+
+        pool = _RacePool()
+        controller = {
+            "calls": 0,
+            "fail_times": 1,  # the corpse fetch fails, the fresh fetch succeeds
+            "data": {"webSocketDebuggerUrl": "ws://127.0.0.1:5101/devtools/browser/guid"},
+        }
+        self._patch_session(monkeypatch, controller)
+
+        response = asyncio.run(_mod.handle_json_version(self._make_request(pool)))
+
+        assert response.status == 200
+        assert pool.evicted == [], "the concurrently-relaunched process must not be evicted"
+        assert pool._processes["seed1"] is fresh, "the fresh process survives"


### PR DESCRIPTION
## Problem

`ChromePool.get_or_launch` decides whether to reuse a pooled Chrome for a seed with a single liveness check — `proc.process.poll() is None`. But `poll()` only reports whether the OS process has been reaped, which lags CDP availability in two common ways:

- **Graceful-shutdown window.** Chrome tears down its DevTools/CDP listening socket seconds before the process actually exits. A client that closes a browser and immediately requests the same fingerprint seed is handed the still-"alive" process whose CDP port already refuses connections.
- **Wedged browser.** A hung/unresponsive Chrome can keep its process alive indefinitely while its CDP port no longer answers.

In both cases the dead process is returned, and `handle_json_version` / `handle_json_list` then fail to reach `http://127.0.0.1:<port>/json/version` and return `502 {"error": "CDP endpoint unreachable"}`. Crucially, the 502 path **does not evict the dead pool entry**, so every retry for that seed hits the same corpse — the failure is **not self-healing** until the OS finally reaps the process (or the idle timeout fires).

This is easy to trigger under any workflow that reuses seeds across browser restarts, or when a browser crashes/OOMs and lingers mid-shutdown. Under load it presents as a burst of dead-port 502s against a seed whose process still `poll()`s as alive.

## Fix

1. `get_or_launch` reuses a `poll()`-alive process **only if its CDP port actually accepts a TCP connection** (`_cdp_port_alive`, a sub-millisecond local connect). `poll()` short-circuits the check, so an already-exited process skips the probe and takes the existing cleanup+relaunch path. A poll-alive-but-dead-port corpse now falls through to `_cleanup_process` + a fresh launch, under the existing per-seed lock.
2. `handle_json_version` and `handle_json_list` wrap the fetch in a 2-attempt loop: on the first connection failure they evict the stale entry and retry once, so a browser that dies in the narrow window between the probe and the fetch becomes a single cold relaunch instead of a persistent 502. Eviction matches the pooled process **by object identity**, never by recomputing the seed key, so a concurrent relaunch on the same seed is never killed.

The reuse fast-path stays fast (one cheap local connect) and behavior is unchanged for a genuinely-live browser.

## Tests

Added to `tests/test_cloakserve.py`:

- `TestCdpPortAlive` — the probe returns True for a listening port, False for a closed one.
- `TestPoolKeyForIdentity` — identity match; returns None when a concurrent relaunch has replaced the entry.
- `TestGetOrLaunchReuseGuard` — poll-alive-but-dead-port is evicted and relaunched; poll-alive-and-port-alive is reused after exactly one probe (no relaunch).
- `TestHandlerCorpseRecovery` — `json/version` and `json/list` recover without a 502 by evicting once and retrying; they return 502 only after both attempts fail; identity-based eviction spares a concurrently-relaunched process.

Two existing tests were adjusted for the new reuse probe. `pytest tests/test_cloakserve.py` → **113 passed**.
