### PR TITLE
tests: skip slow live detection tests by default

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared pytest fixtures."""
 
+import os
 import pytest
 
 
@@ -17,3 +18,20 @@ def isolated_cache_dir(tmp_path_factory, monkeypatch):
         "CLOAKBROWSER_CACHE_DIR",
         str(tmp_path_factory.mktemp("cloakbrowser-cache")),
     )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip tests marked 'slow' by default unless CLOAKBROWSER_RUN_SLOW=1.
+
+    Many stealth tests hit live detection services and are slow/flaky in local
+    environments (network/proxy differences). Running them locally is opt-in
+    via the CLOAKBROWSER_RUN_SLOW env var so the default developer run stays
+    fast and deterministic.
+    """
+    run_slow = os.getenv("CLOAKBROWSER_RUN_SLOW") == "1"
+    if run_slow:
+        return
+    skip_slow = pytest.mark.skip(reason="skipping slow live tests (set CLOAKBROWSER_RUN_SLOW=1 to run)")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)


### PR DESCRIPTION
Skip slow live network bot-detection tests by default to keep local runs fast and deterministic. Set CLOAKBROWSER_RUN_SLOW=1 to opt in when you want to run live/slow tests.\n\nWhat changed:\n- tests/conftest.py: added pytest_collection_modifyitems to skip tests marked @pytest.mark.slow unless CLOAKBROWSER_RUN_SLOW=1\n\nValidation:\n- Non-slow test run: 822 passed, 42 deselected (local).\n\nIf you want these tests run in CI, set CLOAKBROWSER_RUN_SLOW=1 in the workflow or create a separate slow job.