### PR TITLE
feat(browser): add launch_chrome_direct() for TCP CDP server mode

### DIFF
--- a/cloakbrowser/__init__.py
+++ b/cloakbrowser/__init__.py
@@ -11,7 +11,7 @@ Usage:
     browser.close()
 """
 
-from .browser import launch, launch_async, launch_context, launch_context_async, launch_persistent_context, launch_persistent_context_async, ProxySettings, build_args, maybe_resolve_geoip
+from .browser import launch, launch_async, launch_context, launch_context_async, launch_persistent_context, launch_persistent_context_async, ProxySettings, build_args, maybe_resolve_geoip, launch_chrome_direct
 from .config import CHROMIUM_VERSION, get_default_stealth_args
 from .download import binary_info, check_for_update, clear_cache, ensure_binary
 from .license import CloakBrowserLicenseError, LicenseInfo, validate_license
@@ -36,6 +36,7 @@ __all__ = [
     "launch_context_async",
     "launch_persistent_context",
     "launch_persistent_context_async",
+    "launch_chrome_direct",
     "ensure_binary",
     "clear_cache",
     "binary_info",

--- a/cloakbrowser/browser.py
+++ b/cloakbrowser/browser.py
@@ -1750,3 +1750,160 @@ def _resolve_proxy_config(
     if isinstance(proxy, dict):
         return {"proxy": proxy}, []
     return {"proxy": _parse_proxy_url(proxy)}, []
+
+
+def launch_chrome_direct(
+    user_data_dir: str | os.PathLike,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 9222,
+    headless: bool = False,
+    extension_paths: list[str] | None = None,
+    stealth_args: bool = True,
+    locale: str | None = None,
+    timezone: str | None = None,
+    license_key: str | None = None,
+    browser_version: str | None = None,
+    release_channel: str | None = None,
+    extra_args: list[str] | None = None,
+    startup_timeout: float = 30.0,
+) -> Any:
+    """Launch stealth Chromium directly via subprocess with a TCP CDP endpoint.
+
+    Unlike ``launch_persistent_context()``, this bypasses Playwright's managed
+    browser lifecycle entirely. Chrome is started with ``--remote-debugging-port``
+    — a TCP listener — instead of Playwright's ``--remote-debugging-pipe``, so
+    external CDP clients can connect via ``ws://<host>:<port>``. This is the
+    correct primitive for server-style runtimes (e.g. an MCP browser server)
+    that surface a debugging port to other processes.
+
+    Returns a ``subprocess.Popen`` handle; the caller owns process cleanup
+    (typically ``proc.terminate()``/``proc.kill()`` in a finally block).
+
+    Args:
+        user_data_dir: Path to the browser profile directory.
+        host: Remote debugging bind address (default ``127.0.0.1``).
+        port: Remote debugging port (default 9222).
+        headless: Run in headless mode (default False).
+        extension_paths: Chrome extension paths to load.
+        stealth_args: Include default stealth fingerprint args (default True).
+        locale: Browser locale, e.g. ``"en-US"``.
+        timezone: IANA timezone (e.g. ``"America/New_York"``).
+        license_key: License key for the Pro binary.
+        browser_version: Specific browser version to use.
+        release_channel: Release channel ("stable" or "beta").
+        extra_args: Additional Chrome CLI arguments.
+        startup_timeout: Seconds to wait for the CDP port to become ready.
+            Raises if the process exits early or the port never opens.
+
+    Returns:
+        ``subprocess.Popen`` handle for the Chrome process.
+
+    Example:
+        >>> from cloakbrowser import launch_chrome_direct
+        >>> proc = launch_chrome_direct("./profile", port=9222)
+        >>> # connect your CDP client to ws://127.0.0.1:9222
+        >>> proc.terminate()
+        >>> proc.wait()
+    """
+    import socket
+    import subprocess
+    import time as _time
+
+    binary_path = ensure_binary(
+        license_key=license_key,
+        browser_version=browser_version,
+        release_channel=release_channel,
+    )
+    seed_widevine_hint(user_data_dir, binary_path)
+
+    chrome_args = build_args(
+        stealth_args=stealth_args,
+        extra_args=extra_args,
+        timezone=timezone,
+        locale=locale,
+        headless=headless,
+        extension_paths=extension_paths,
+        start_maximized=binary_supports_maximized_window(
+            license_key, browser_version, release_channel
+        ) and not headless,
+    )
+
+    # Playwright normally injects --remote-debugging-pipe; we want TCP instead.
+    chrome_args = [
+        a for a in chrome_args if not a.startswith("--remote-debugging-pipe")
+    ]
+    # Windows only: this patched binary exits 0 immediately on startup when
+    # Chromium's AutoDeElevate feature is enabled (Chrome >= 131 relaunches
+    # itself de-elevated; the re-exec fails inside the patched build and the
+    # parent exits cleanly, killing the session). Playwright's default args
+    # happen to disable it — direct launches must do so explicitly.
+    if os.name == "nt" and not any(
+        a.startswith("--disable-features=") for a in chrome_args
+    ):
+        chrome_args.append("--disable-features=AutoDeElevate")
+    elif os.name == "nt":
+        chrome_args = [
+            a if not a.startswith("--disable-features=")
+            or "AutoDeElevate" in a
+            else a + ",AutoDeElevate"
+            for a in chrome_args
+        ]
+    chrome_args.append(f"--remote-debugging-address={host}")
+    chrome_args.append(f"--remote-debugging-port={port}")
+    chrome_args.append(f"--user-data-dir={os.fspath(user_data_dir)}")
+
+    logger.debug(
+        "Launching direct Chrome (headless=%s, port=%s, profile=%s)",
+        headless,
+        port,
+        user_data_dir,
+    )
+
+    denial_path = mint_denial_file() if resolve_license_key(license_key) else None
+    launch_env = build_launch_env(license_key, status_file=denial_path)
+    env = os.environ.copy()
+    if launch_env:
+        env.update(launch_env)
+
+    creationflags = 0
+    if os.name == "nt":
+        creationflags = (
+            getattr(subprocess, "DETACHED_PROCESS", 0)
+            | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+            | getattr(subprocess, "CREATE_BREAKAWAY_FROM_JOB", 0)
+        )
+    start_new_session = os.name != "nt"
+
+    proc = subprocess.Popen(
+        [str(binary_path), *chrome_args],
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=start_new_session,
+        creationflags=creationflags,
+    )
+
+    # Wait for the CDP listener to come up (or the process to die).
+    deadline = _time.monotonic() + startup_timeout
+    last_error = "unknown"
+    while True:
+        if proc.poll() is not None:
+            proc.wait()
+            raise RuntimeError(
+                f"Chrome exited early (pid={proc.pid}, returncode={proc.returncode})"
+            )
+        if _time.monotonic() >= deadline:
+            break
+        try:
+            with socket.create_connection((host, port), timeout=1.0):
+                return proc
+        except OSError as exc:
+            last_error = str(exc)
+        _time.sleep(0.25)
+
+    raise RuntimeError(
+        f"Chrome (pid={proc.pid}) did not open CDP port {host}:{port} within "
+        f"{startup_timeout}s. Last error: {last_error}"
+    )

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -1,9 +1,12 @@
 """Basic launch tests for cloakbrowser."""
 
+import os
+
 import pytest
 from cloakbrowser import (
     launch,
     launch_async,
+    launch_chrome_direct,
     launch_context,
     launch_persistent_context,
     binary_info,
@@ -109,3 +112,134 @@ async def test_launch_async():
     title = await page.title()
     assert "Example Domain" in title
     await browser.close()
+
+
+def test_launch_chrome_direct_exposes_tcp_cdp(tmp_path, monkeypatch):
+    """launch_chrome_direct() starts Chrome with a TCP remote-debugging port
+    (not Playwright's pipe) and no --remote-debugging-pipe in argv.
+
+    Regression for: the MCP browser runtime passed --remote-debugging-port
+    through launch_persistent_context(), where Playwright injects
+    --remote-debugging-pipe and manages the connection over it, leaving the TCP
+    endpoint non-functional for external CDP clients.
+    """
+    import socket
+    import subprocess
+
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    # Use the real binary (skip download/network checks)
+    import cloakbrowser.download as download
+    binary = download.ensure_binary()
+    monkeypatch.setattr(download, "ensure_binary", lambda **kw: binary)
+
+    proc = launch_chrome_direct(
+        str(tmp_path / "profile"),
+        host="127.0.0.1",
+        port=port,
+        headless=True,
+        startup_timeout=45.0,
+    )
+    try:
+        assert proc.poll() is None
+        assert "--remote-debugging-pipe" not in proc_args(proc)
+        # The TCP CDP endpoint must actually serve /json/version
+        import urllib.request
+        with urllib.request.urlopen(
+            f"http://127.0.0.1:{port}/json/version", timeout=5
+        ) as resp:
+            assert resp.status == 200
+            body = resp.read().decode()
+        assert "Chrome" in body
+    finally:
+        if proc.poll() is None:
+            subprocess.run(
+                ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+                capture_output=True,
+            )
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                pass
+
+
+def proc_args(proc) -> str:
+    import subprocess
+    res = subprocess.run(
+        ["wmic", "process", "where", f"ProcessId={proc.pid}", "get", "CommandLine"],
+        capture_output=True, text=True,
+    )
+    return res.stdout
+
+
+def test_launch_chrome_direct_auto_delevate_always_on_windows(
+    tmp_path, monkeypatch
+):
+    """On Windows the patched binary exits 0 on launch unless Chromium's
+    AutoDeElevate feature is disabled. launch_chrome_direct() must always pass
+    --disable-features including AutoDeElevate, even when the caller supplied
+    their own --disable-features list or none at all.
+    """
+    if os.name != "nt":
+        pytest.skip("Windows-only binary behavior")
+
+    import cloakbrowser.download as download
+    binary = download.ensure_binary()
+
+    captured = {}
+
+    def fake_popen(args, **kw):
+        captured["args"] = args
+        captured["kw"] = kw
+        proc = object.__new__(type("FakeProc", (), {}))
+        proc.pid = 12345
+        proc.poll = lambda: None  # stays alive; no early-exit
+        return proc
+
+    import cloakbrowser.browser as browser_mod
+    monkeypatch.setattr(browser_mod, "ensure_binary", lambda **kw: binary)
+
+    import subprocess as _subprocess_mod
+    import socket as _socket_mod
+
+    monkeypatch.setattr(_subprocess_mod, "Popen", fake_popen)
+    # Port connects immediately so we skip the wait loop
+    def fake_connect(addr, timeout=1.0):
+        class _FakeConn:
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+        return _FakeConn()
+
+    monkeypatch.setattr(_socket_mod, "create_connection", fake_connect)
+
+    if os.name == "nt":
+        # Case 1: no caller features — AutoDeElevate must be added
+        launch_chrome_direct(str(tmp_path / "p1"), port=9991, headless=True)
+        assert any(
+            a == "--disable-features=AutoDeElevate" for a in captured["args"]
+        ), captured["args"]
+        # Case 2: caller provided --disable-features=X — must be merged
+        launch_chrome_direct(
+            str(tmp_path / "p2"), port=9992, headless=True,
+            extra_args=["--disable-features=Foo"],
+        )
+        assert any(
+            a == "--disable-features=Foo,AutoDeElevate" for a in captured["args"]
+        ), captured["args"]
+        # Case 3: caller passed --disable-features=Foo,AutoDeElevate already
+        launch_chrome_direct(
+            str(tmp_path / "p3"), port=9993, headless=True,
+            extra_args=["--disable-features=Foo,AutoDeElevate"],
+        )
+        assert any(
+            a == "--disable-features=Foo,AutoDeElevate" for a in captured["args"]
+        ), captured["args"]
+    else:
+        # Non-Windows: no AutoDeElevate injection at all
+        launch_chrome_direct(str(tmp_path / "p4"), port=9994, headless=True)
+        assert not any(
+            "AutoDeElevate" in a for a in captured["args"]
+        ), captured["args"]


### PR DESCRIPTION
## Problem

Server-style runtimes that want to hand a CDP endpoint to another process (e.g. an MCP browser server) currently route through `launch_persistent_context(user_data_dir, args=["--remote-debugging-port=9222"])`. Playwright's `launch_persistent_context` injects `--remote-debugging-pipe` and owns the connection over that pipe; the TCP `--remote-debugging-port` argument never becomes a usable endpoint for external CDP clients. External tools that `connect_over_cdp` to the advertised port hang or fail, and the orphaned instance wedges the shared profile so every later launch exits immediately with code 0.

## Fix

Adds `launch_chrome_direct()` — a subprocess-based launch that:
- builds the same stealth args via `build_args()` (fingerprints, extensions, locale/timezone),
- launches the patched Chromium directly with `--remote-debugging-address` / `--remote-debugging-port` (TCP, no pipe),
- waits for the CDP listener, then hands back the `Popen` handle for the caller to own,
- **Windows only**: appends `--disable-features=AutoDeElevate`. Since Chrome 131, AutoDeElevate relaunches the browser de-elevated; inside the patched build the re-exec fails and the parent exits 0 instantly — killing the launch. Playwright's default args mask this, which is why it only bites direct launches.

## Verification

- `tests/test_launch.py::test_launch_chrome_direct_exposes_tcp_cdp` — real binary: `/json/version` answers over TCP, no `--remote-debugging-pipe` in argv.
- `tests/test_launch.py::test_launch_chrome_direct_auto_delevate_always_on_windows` — flag always present on Windows, merged (not duplicated) into caller-supplied `--disable-features`, absent on non-Windows.
- End-to-end: Playwright `connect_over_cdp` + `page.goto("https://www.google.com")` works against the direct-launched endpoint.
