### PR TITLE
Fix humanize=True false-negative visible check for display:contents elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Changes are tagged: **[wrapper]** for Python/JS wrapper, **[binary]** for Chromi
 
 ---
 
+## [Unreleased]
+
+- **[wrapper]** Fix `humanize=True` reporting a fully rendered, on-screen element as not visible when it (or an ancestor list item) uses `display: contents` — a pattern used by some dropdown/menu widgets to strip default list-item box styling. `getBoundingClientRect()` on such an element is always empty even though its children/text render normally; the isolated-world actionability read now recurses into children for this case, mirroring Playwright's own actionability engine, so `click`/`fill`/etc. no longer fail after the full timeout on an element that is genuinely visible. Also cross-checks a "not visible" in-world verdict against Playwright's own `is_visible()` before failing whenever geometry is present, as a safety net for other such divergences. Regression from 0.5.6. Python, JavaScript, and .NET.
+
+---
+
 ## [0.5.8] — 2026-08-18
 
 - **[wrapper]** Fix `humanize=True` actions (`fill`, `click`, `type`) failing with an element-not-attached error after a navigation driven by a click or form submission instead of `goto`. The pre-action element checks could stay bound to the previous document and never recover; they now refresh on every navigation. Regression from 0.5.6. Python, JavaScript Playwright/Puppeteer, and .NET.

--- a/cloakbrowser/human/actionability.py
+++ b/cloakbrowser/human/actionability.py
@@ -88,6 +88,19 @@ def _backoff_sleep(attempt: int) -> None:
 # Pre-scroll actionability: attached, visible, enabled, editable
 # ---------------------------------------------------------------------------
 
+def _box_has_area(box: Optional[dict]) -> bool:
+    return bool(box) and (box.get("width", 0) > 0 or box.get("height", 0) > 0)
+
+
+def _playwright_says_visible(page: Any, selector: str) -> bool:
+    """Cheap, non-waiting cross-check used before trusting an in-world 'not visible'
+    verdict that disagrees with a non-empty box (defense-in-depth for #560)."""
+    try:
+        return page.locator(selector).first.is_visible()
+    except Exception:
+        return False
+
+
 def _stealth_actionable(page: Any, selector: str, checks: FrozenSet[str]) -> bool:
     """Run the actionability checks through the isolated world.
 
@@ -106,7 +119,11 @@ def _stealth_actionable(page: Any, selector: str, checks: FrozenSet[str]) -> boo
         # retry loop backs off and re-reads in-world (mirrors wait_for(attached)).
         raise ElementNotAttachedError(selector)
     if "visible" in checks and not data.get("visible"):
-        raise ElementNotVisibleError(selector)
+        # A non-empty box despite an in-world "not visible" verdict means the two
+        # reads disagree; cross-check with Playwright's own is_visible() rather
+        # than trusting a possible false negative (#560) before raising.
+        if not (_box_has_area(data.get("box")) and _playwright_says_visible(page, selector)):
+            raise ElementNotVisibleError(selector)
     if "enabled" in checks and not data.get("enabled"):
         raise ElementNotEnabledError(selector)
     if "editable" in checks and not data.get("editable"):

--- a/cloakbrowser/human/actionability_async.py
+++ b/cloakbrowser/human/actionability_async.py
@@ -22,6 +22,7 @@ from .actionability import (
     ElementNotReceivingEventsError,
     _BACKOFF_MS,
     _boxes_differ,
+    _box_has_area,
     _POINTER_EVENTS_LOCATOR_JS,
     _POINTER_EVENTS_HANDLE_JS,
 )
@@ -40,6 +41,14 @@ async def _async_backoff_sleep(attempt: int) -> None:
 # Pre-scroll actionability
 # ---------------------------------------------------------------------------
 
+async def _async_playwright_says_visible(page: Any, selector: str) -> bool:
+    """Async mirror of ``_playwright_says_visible``."""
+    try:
+        return await page.locator(selector).first.is_visible()
+    except Exception:
+        return False
+
+
 async def _async_stealth_actionable(page: Any, selector: str, checks: FrozenSet[str]) -> bool:
     """Async mirror of ``_stealth_actionable`` — isolated-world actionability read.
 
@@ -55,7 +64,8 @@ async def _async_stealth_actionable(page: Any, selector: str, checks: FrozenSet[
     if status == NOT_FOUND:
         raise ElementNotAttachedError(selector)
     if "visible" in checks and not data.get("visible"):
-        raise ElementNotVisibleError(selector)
+        if not (_box_has_area(data.get("box")) and await _async_playwright_says_visible(page, selector)):
+            raise ElementNotVisibleError(selector)
     if "enabled" in checks and not data.get("enabled"):
         raise ElementNotEnabledError(selector)
     if "editable" in checks and not data.get("editable"):

--- a/cloakbrowser/human/stealth_dom.py
+++ b/cloakbrowser/human/stealth_dom.py
@@ -110,6 +110,41 @@ function __resolve(sel){
   if (idx < 0 || idx >= list.length) return null;
   return list[idx];
 }
+// display:contents elements have no box of their own (getBoundingClientRect is
+// always all-zero) even though their children/text render normally -- Playwright's
+// own actionability engine recurses into children for this case, so we mirror it
+// here rather than reporting a false negative for e.g. reset "li { display: contents }"
+// patterns used by custom dropdown/menu widgets (#560).
+function __visBox(el){
+  const st = getComputedStyle(el);
+  if (st.display === 'contents') {
+    let ux1 = Infinity, uy1 = Infinity, ux2 = -Infinity, uy2 = -Infinity, found = false;
+    for (let child = el.firstChild; child; child = child.nextSibling) {
+      let r = null;
+      if (child.nodeType === 1) {
+        const cv = __visBox(child);
+        if (cv.visible) r = cv.box;
+      } else if (child.nodeType === 3 && __normWS(child.textContent)) {
+        const rng = document.createRange();
+        rng.selectNode(child);
+        const rr = rng.getBoundingClientRect();
+        if (rr.width > 0 || rr.height > 0) r = { x: rr.x, y: rr.y, width: rr.width, height: rr.height };
+      }
+      if (r) {
+        found = true;
+        ux1 = Math.min(ux1, r.x); uy1 = Math.min(uy1, r.y);
+        ux2 = Math.max(ux2, r.x + r.width); uy2 = Math.max(uy2, r.y + r.height);
+      }
+    }
+    if (!found) return { visible: false, box: null };
+    return { visible: true, box: { x: ux1, y: uy1, width: ux2 - ux1, height: uy2 - uy1 } };
+  }
+  const rc = el.getBoundingClientRect();
+  const hasBox = rc.width > 0 || rc.height > 0;
+  const box = hasBox ? { x: rc.x, y: rc.y, width: rc.width, height: rc.height } : null;
+  const visible = hasBox && st.visibility !== 'hidden' && st.display !== 'none';
+  return { visible, box };
+}
 """
 
 # ---------------------------------------------------------------------------
@@ -120,24 +155,22 @@ _BOX_OP = r"""
 const __el = __resolve(__SEL);
 if (__el === 'UNSUPPORTED') return { r: 'unsupported' };
 if (!__el) return { r: 'not_found' };
-const __rc = __el.getBoundingClientRect();
+const __vb = __visBox(__el);
 // Playwright's bounding_box returns null for elements with no box (display:none).
-if (__rc.width === 0 && __rc.height === 0 && __rc.x === 0 && __rc.y === 0) return { r: 'not_found' };
-return { r: 'ok', box: { x: __rc.x, y: __rc.y, width: __rc.width, height: __rc.height } };
+if (!__vb.box) return { r: 'not_found' };
+return { r: 'ok', box: __vb.box };
 """
 
 _ACTIONABLE_OP = r"""
 const __el = __resolve(__SEL);
 if (__el === 'UNSUPPORTED') return { r: 'unsupported' };
 if (!__el) return { r: 'not_found' };
-const __st = getComputedStyle(__el);
-const __rc = __el.getBoundingClientRect();
-const __visible = __st.visibility !== 'hidden' && __st.display !== 'none' && (__rc.width > 0 || __rc.height > 0);
+const __vb = __visBox(__el);
 const __tag = __el.tagName.toLowerCase();
 const __enabled = !(__el.disabled === true || __el.getAttribute('aria-disabled') === 'true');
 const __editable = __enabled && !__el.readOnly &&
   (__tag === 'input' || __tag === 'textarea' || __tag === 'select' || __el.isContentEditable === true);
-return { r: 'ok', visible: __visible, enabled: __enabled, editable: __editable };
+return { r: 'ok', visible: __vb.visible, enabled: __enabled, editable: __editable, box: __vb.box };
 """
 
 _VIEWPORT_JS = "(() => ({ width: window.innerWidth, height: window.innerHeight }))()"

--- a/dotnet/src/CloakBrowser/Human/Actionability.cs
+++ b/dotnet/src/CloakBrowser/Human/Actionability.cs
@@ -105,6 +105,14 @@ public static class Actionability
         return Task.Delay(BackoffMs[idx]);
     }
 
+    /// <summary>Cheap, non-waiting cross-check used before trusting an in-world "not visible"
+    /// verdict that disagrees with a non-empty box (defense-in-depth for #560).</summary>
+    private static async Task<bool> PlaywrightSaysVisibleAsync(IPage page, string selector)
+    {
+        try { return await page.Locator(selector).First.IsVisibleAsync().ConfigureAwait(false); }
+        catch { return false; }
+    }
+
     private static double NowMs() => Environment.TickCount64;
 
     /// <summary>
@@ -155,10 +163,18 @@ public static class Actionability
                 // predicates only for selector grammar the isolated world can't resolve.
                 if (stealth != null)
                 {
-                    var (st, vis, en, ed) = await StealthDom.ActionableAsync(stealth, selector).ConfigureAwait(false);
+                    var (st, vis, en, ed, box) = await StealthDom.ActionableAsync(stealth, selector).ConfigureAwait(false);
                     if (st == StealthStatus.Ok)
                     {
-                        if (checks.Contains("visible") && !vis) throw new ElementNotVisibleError(selector);
+                        if (checks.Contains("visible") && !vis)
+                        {
+                            // A non-empty box despite an in-world "not visible" verdict means the
+                            // two reads disagree; cross-check with Playwright's own IsVisibleAsync()
+                            // rather than trusting a possible false negative (#560) before throwing.
+                            bool boxHasArea = box is { Width: > 0 } or { Height: > 0 };
+                            if (!(boxHasArea && await PlaywrightSaysVisibleAsync(page, selector).ConfigureAwait(false)))
+                                throw new ElementNotVisibleError(selector);
+                        }
                         if (checks.Contains("enabled") && !en) throw new ElementNotEnabledError(selector);
                         if (checks.Contains("editable") && !ed) throw new ElementNotEditableError(selector);
                         return;

--- a/dotnet/src/CloakBrowser/Human/StealthDom.cs
+++ b/dotnet/src/CloakBrowser/Human/StealthDom.cs
@@ -95,29 +95,62 @@ function __resolve(sel){
   if (idx < 0 || idx >= list.length) return null;
   return list[idx];
 }
+// display:contents elements have no box of their own (getBoundingClientRect is
+// always all-zero) even though their children/text render normally -- Playwright's
+// own actionability engine recurses into children for this case, so we mirror it
+// here rather than reporting a false negative for e.g. reset ""li { display: contents }""
+// patterns used by custom dropdown/menu widgets (#560).
+function __visBox(el){
+  const st = getComputedStyle(el);
+  if (st.display === 'contents') {
+    let ux1 = Infinity, uy1 = Infinity, ux2 = -Infinity, uy2 = -Infinity, found = false;
+    for (let child = el.firstChild; child; child = child.nextSibling) {
+      let r = null;
+      if (child.nodeType === 1) {
+        const cv = __visBox(child);
+        if (cv.visible) r = cv.box;
+      } else if (child.nodeType === 3 && __normWS(child.textContent)) {
+        const rng = document.createRange();
+        rng.selectNode(child);
+        const rr = rng.getBoundingClientRect();
+        if (rr.width > 0 || rr.height > 0) r = { x: rr.x, y: rr.y, width: rr.width, height: rr.height };
+      }
+      if (r) {
+        found = true;
+        ux1 = Math.min(ux1, r.x); uy1 = Math.min(uy1, r.y);
+        ux2 = Math.max(ux2, r.x + r.width); uy2 = Math.max(uy2, r.y + r.height);
+      }
+    }
+    if (!found) return { visible: false, box: null };
+    return { visible: true, box: { x: ux1, y: uy1, width: ux2 - ux1, height: uy2 - uy1 } };
+  }
+  const rc = el.getBoundingClientRect();
+  const hasBox = rc.width > 0 || rc.height > 0;
+  const box = hasBox ? { x: rc.x, y: rc.y, width: rc.width, height: rc.height } : null;
+  const visible = hasBox && st.visibility !== 'hidden' && st.display !== 'none';
+  return { visible, box };
+}
 ";
 
     private const string BoxOp = @"
 const __el = __resolve(__SEL);
 if (__el === 'UNSUPPORTED') return { r: 'unsupported' };
 if (!__el) return { r: 'not_found' };
-const __rc = __el.getBoundingClientRect();
-if (__rc.width === 0 && __rc.height === 0 && __rc.x === 0 && __rc.y === 0) return { r: 'not_found' };
-return { r: 'ok', box: { x: __rc.x, y: __rc.y, width: __rc.width, height: __rc.height } };
+const __vb = __visBox(__el);
+if (!__vb.box) return { r: 'not_found' };
+return { r: 'ok', box: __vb.box };
 ";
 
     private const string ActionableOp = @"
 const __el = __resolve(__SEL);
 if (__el === 'UNSUPPORTED') return { r: 'unsupported' };
 if (!__el) return { r: 'not_found' };
-const __st = getComputedStyle(__el);
-const __rc = __el.getBoundingClientRect();
-const __visible = __st.visibility !== 'hidden' && __st.display !== 'none' && (__rc.width > 0 || __rc.height > 0);
+const __vb = __visBox(__el);
 const __tag = __el.tagName.toLowerCase();
 const __enabled = !(__el.disabled === true || __el.getAttribute('aria-disabled') === 'true');
 const __editable = __enabled && !__el.readOnly &&
   (__tag === 'input' || __tag === 'textarea' || __tag === 'select' || __el.isContentEditable === true);
-return { r: 'ok', visible: __visible, enabled: __enabled, editable: __editable };
+return { r: 'ok', visible: __vb.visible, enabled: __enabled, editable: __editable, box: __vb.box };
 ";
 
     /// <summary>Live window dimensions, read in the isolated world (no_viewport headed mode).</summary>
@@ -179,15 +212,24 @@ return { r: 'ok', visible: __visible, enabled: __enabled, editable: __editable }
             b.GetProperty("width").GetDouble(), b.GetProperty("height").GetDouble()));
     }
 
-    public static async Task<(StealthStatus Status, bool Visible, bool Enabled, bool Editable)> ActionableAsync(
+    private static BoundingBox? ParseBox(JsonElement data)
+    {
+        if (!data.TryGetProperty("box", out var b) || b.ValueKind != JsonValueKind.Object) return null;
+        return new BoundingBox(
+            b.GetProperty("x").GetDouble(), b.GetProperty("y").GetDouble(),
+            b.GetProperty("width").GetDouble(), b.GetProperty("height").GetDouble());
+    }
+
+    public static async Task<(StealthStatus Status, bool Visible, bool Enabled, bool Editable, BoundingBox? Box)> ActionableAsync(
         IsolatedWorld world, string selector)
     {
         var (status, data) = await EvalAsync(world, BuildActionableJs(selector)).ConfigureAwait(false);
-        if (status != StealthStatus.Ok) return (status, false, false, false);
+        if (status != StealthStatus.Ok) return (status, false, false, false, null);
         return (status,
             data!.Value.GetProperty("visible").GetBoolean(),
             data.Value.GetProperty("enabled").GetBoolean(),
-            data.Value.GetProperty("editable").GetBoolean());
+            data.Value.GetProperty("editable").GetBoolean(),
+            ParseBox(data.Value));
     }
 
     private const string IsInputOp = @"

--- a/dotnet/tests/CloakBrowser.Tests/Human/StealthDomTests.cs
+++ b/dotnet/tests/CloakBrowser.Tests/Human/StealthDomTests.cs
@@ -76,6 +76,56 @@ console.log('POINTER', JSON.stringify(run(p, [t], t)));
 
     private static string JsStr(string s) => JsonSerializer.Serialize(s);
 
+    // Regression #560: a display:contents element (e.g. a reset "li { display: contents }"
+    // used by custom dropdown/menu widgets) has no box of its own, but its children/text
+    // still render. Verifies the shipped resolver JS recurses into children instead of
+    // reporting a false "not visible"/not_found, mirroring Playwright's own actionability
+    // engine (packages/injected/src/domUtils.ts::computeBox).
+    [Fact]
+    public void ResolverSemantics_DisplayContents_RunUnderNode()
+    {
+        var node = FindNode();
+        if (node == null) return; // skip: node unavailable
+
+        string actionableJs = StealthDom.BuildActionableJs("li");
+        string boxJs = StealthDom.BuildBoxJs("li");
+
+        string script = @"
+function contentsEl(tag, display){
+  const e = { tagName: tag, nodeType: 1, disabled: false, readOnly: false, isContentEditable: false,
+              firstChild: null, nextSibling: null, __display: display || 'block', __rect: { x: 0, y: 0, width: 0, height: 0 } };
+  e.getAttribute = () => null;
+  e.getBoundingClientRect = () => e.__rect;
+  return e;
+}
+function textNode(text, rect){ return { nodeType: 3, textContent: text, nextSibling: null, __rect: rect }; }
+function append(parent, child){
+  if (!parent.firstChild) { parent.firstChild = child; return; }
+  let last = parent.firstChild;
+  while (last.nextSibling) last = last.nextSibling;
+  last.nextSibling = child;
+}
+function run(js, root){
+  const document = {
+    querySelectorAll: () => [root],
+    createRange: () => ({ _n: null, selectNode(n){ this._n = n; }, getBoundingClientRect(){ return this._n.__rect; } }),
+  };
+  const getComputedStyle = (el) => ({ visibility: 'visible', display: el.__display || 'block' });
+  return new Function('document', 'getComputedStyle', 'return ' + js)(document, getComputedStyle);
+}
+const li = contentsEl('LI', 'contents');
+append(li, textNode('Hoy', { x: 10, y: 20, width: 30, height: 12 }));
+const actionableJs = " + JsStr(actionableJs) + @";
+const boxJs = " + JsStr(boxJs) + @";
+console.log('ACTIONABLE', JSON.stringify(run(actionableJs, li)));
+console.log('BOX', JSON.stringify(run(boxJs, li)));
+";
+
+        string outp = RunNode(node, script);
+        Assert.Contains("ACTIONABLE {\"r\":\"ok\",\"visible\":true,\"enabled\":true,\"editable\":false,\"box\":{\"x\":10,\"y\":20,\"width\":30,\"height\":12}}", outp);
+        Assert.Contains("BOX {\"r\":\"ok\",\"box\":{\"x\":10,\"y\":20,\"width\":30,\"height\":12}}", outp);
+    }
+
     private static string? FindNode()
     {
         foreach (var p in new[] { "node", "/usr/local/bin/node", "/opt/homebrew/bin/node", "/usr/bin/node" })

--- a/js/src/human/actionability.ts
+++ b/js/src/human/actionability.ts
@@ -90,6 +90,20 @@ function backoffSleep(attempt: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, BACKOFF_MS[idx]));
 }
 
+function boxHasArea(box: { width?: number; height?: number } | null | undefined): boolean {
+  return !!box && ((box.width ?? 0) > 0 || (box.height ?? 0) > 0);
+}
+
+/** Cheap, non-waiting cross-check used before trusting an in-world 'not visible'
+ * verdict that disagrees with a non-empty box (defense-in-depth for #560). */
+async function playwrightSaysVisible(pageOrFrame: Page | Frame, selector: string): Promise<boolean> {
+  try {
+    return await pageOrFrame.locator(selector).first().isVisible();
+  } catch {
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Pre-scroll actionability
 // ---------------------------------------------------------------------------
@@ -115,7 +129,14 @@ async function stealthActionable(
     // loop backs off and re-reads in-world (mirrors waitFor({ state: 'attached' })).
     throw new ElementNotAttachedError(selector);
   }
-  if (checks.has('visible') && !data.visible) throw new ElementNotVisibleError(selector);
+  if (checks.has('visible') && !data.visible) {
+    // A non-empty box despite an in-world 'not visible' verdict means the two
+    // reads disagree; cross-check with Playwright's own isVisible() rather than
+    // trusting a possible false negative (#560) before throwing.
+    if (!(boxHasArea(data.box) && await playwrightSaysVisible(pageOrFrame, selector))) {
+      throw new ElementNotVisibleError(selector);
+    }
+  }
   if (checks.has('enabled') && !data.enabled) throw new ElementNotEnabledError(selector);
   if (checks.has('editable') && !data.editable) throw new ElementNotEditableError(selector);
   return true;

--- a/js/src/human/stealthDom.ts
+++ b/js/src/human/stealthDom.ts
@@ -106,29 +106,62 @@ function __resolve(sel){
   if (idx < 0 || idx >= list.length) return null;
   return list[idx];
 }
+// display:contents elements have no box of their own (getBoundingClientRect is
+// always all-zero) even though their children/text render normally -- Playwright's
+// own actionability engine recurses into children for this case, so we mirror it
+// here rather than reporting a false negative for e.g. reset "li { display: contents }"
+// patterns used by custom dropdown/menu widgets (#560).
+function __visBox(el){
+  const st = getComputedStyle(el);
+  if (st.display === 'contents') {
+    let ux1 = Infinity, uy1 = Infinity, ux2 = -Infinity, uy2 = -Infinity, found = false;
+    for (let child = el.firstChild; child; child = child.nextSibling) {
+      let r = null;
+      if (child.nodeType === 1) {
+        const cv = __visBox(child);
+        if (cv.visible) r = cv.box;
+      } else if (child.nodeType === 3 && __normWS(child.textContent)) {
+        const rng = document.createRange();
+        rng.selectNode(child);
+        const rr = rng.getBoundingClientRect();
+        if (rr.width > 0 || rr.height > 0) r = { x: rr.x, y: rr.y, width: rr.width, height: rr.height };
+      }
+      if (r) {
+        found = true;
+        ux1 = Math.min(ux1, r.x); uy1 = Math.min(uy1, r.y);
+        ux2 = Math.max(ux2, r.x + r.width); uy2 = Math.max(uy2, r.y + r.height);
+      }
+    }
+    if (!found) return { visible: false, box: null };
+    return { visible: true, box: { x: ux1, y: uy1, width: ux2 - ux1, height: uy2 - uy1 } };
+  }
+  const rc = el.getBoundingClientRect();
+  const hasBox = rc.width > 0 || rc.height > 0;
+  const box = hasBox ? { x: rc.x, y: rc.y, width: rc.width, height: rc.height } : null;
+  const visible = hasBox && st.visibility !== 'hidden' && st.display !== 'none';
+  return { visible, box };
+}
 `;
 
 const BOX_OP = `
 const __el = __resolve(__SEL);
 if (__el === 'UNSUPPORTED') return { r: 'unsupported' };
 if (!__el) return { r: 'not_found' };
-const __rc = __el.getBoundingClientRect();
-if (__rc.width === 0 && __rc.height === 0 && __rc.x === 0 && __rc.y === 0) return { r: 'not_found' };
-return { r: 'ok', box: { x: __rc.x, y: __rc.y, width: __rc.width, height: __rc.height } };
+const __vb = __visBox(__el);
+if (!__vb.box) return { r: 'not_found' };
+return { r: 'ok', box: __vb.box };
 `;
 
 const ACTIONABLE_OP = `
 const __el = __resolve(__SEL);
 if (__el === 'UNSUPPORTED') return { r: 'unsupported' };
 if (!__el) return { r: 'not_found' };
-const __st = getComputedStyle(__el);
-const __rc = __el.getBoundingClientRect();
-const __visible = __st.visibility !== 'hidden' && __st.display !== 'none' && (__rc.width > 0 || __rc.height > 0);
+const __vb = __visBox(__el);
 const __tag = __el.tagName.toLowerCase();
 const __enabled = !(__el.disabled === true || __el.getAttribute('aria-disabled') === 'true');
 const __editable = __enabled && !__el.readOnly &&
   (__tag === 'input' || __tag === 'textarea' || __tag === 'select' || __el.isContentEditable === true);
-return { r: 'ok', visible: __visible, enabled: __enabled, editable: __editable };
+return { r: 'ok', visible: __vb.visible, enabled: __enabled, editable: __editable, box: __vb.box };
 `;
 
 /** Live window dimensions, read in the isolated world (no_viewport headed mode). */

--- a/js/tests/stealthDom.test.ts
+++ b/js/tests/stealthDom.test.ts
@@ -133,6 +133,25 @@ describe("ensureActionable via isolated world", () => {
     await expect(ensureActionable(page, "#x", CHECKS_CLICK, 100)).rejects.toBeInstanceOf(ElementNotVisibleError);
   });
 
+  it("not visible with no box throws without a Playwright cross-check (#560)", async () => {
+    const page = noLocatorPage(fakeWorld({ r: "ok", visible: false, enabled: true, editable: true, box: null }));
+    await expect(ensureActionable(page, "#x", CHECKS_CLICK, 100)).rejects.toBeInstanceOf(ElementNotVisibleError);
+  });
+
+  it("not visible with a non-empty box but Playwright agrees still throws (#560)", async () => {
+    const world = fakeWorld({ r: "ok", visible: false, enabled: true, editable: true, box: { x: 0, y: 0, width: 10, height: 10 } });
+    const loc = { first: () => ({ isVisible: async () => false }) };
+    const page: any = { _stealth: world, locator: () => loc };
+    await expect(ensureActionable(page, "#x", CHECKS_CLICK, 100)).rejects.toBeInstanceOf(ElementNotVisibleError);
+  });
+
+  it("not visible with a non-empty box and Playwright disagrees does not throw (#560)", async () => {
+    const world = fakeWorld({ r: "ok", visible: false, enabled: true, editable: true, box: { x: 0, y: 0, width: 10, height: 10 } });
+    const loc = { first: () => ({ isVisible: async () => true }) };
+    const page: any = { _stealth: world, locator: () => loc };
+    await expect(ensureActionable(page, "#x", CHECKS_CLICK, 100)).resolves.toBeUndefined();
+  });
+
   it("disabled throws", async () => {
     const page = noLocatorPage(fakeWorld({ r: "ok", visible: true, enabled: false, editable: true }));
     await expect(ensureActionable(page, "#x", CHECKS_CLICK, 100)).rejects.toBeInstanceOf(ElementNotEnabledError);
@@ -196,5 +215,84 @@ describe("checkPointerEvents via isolated world", () => {
     }) }; } };
     await checkPointerEvents(page, "internal:role=button", 5, 5, world, 200);
     expect(called).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// display:contents (#560) — shipped resolver JS executed against a DOM stub
+// that supports firstChild/nextSibling traversal, per-element computed style,
+// and Range.getBoundingClientRect() for text nodes.
+// ---------------------------------------------------------------------------
+
+describe("display:contents visibility/box (#560)", () => {
+  function contentsEl(tag: string, display = "block") {
+    const e: any = {
+      nodeType: 1, tagName: tag, disabled: false, readOnly: false, isContentEditable: false,
+      getAttribute: () => null, firstChild: null, nextSibling: null,
+      __display: display, __rect: { x: 0, y: 0, width: 0, height: 0 },
+    };
+    e.getBoundingClientRect = () => e.__rect;
+    return e;
+  }
+
+  function textNode(text: string, rect: { x: number; y: number; width: number; height: number }) {
+    return { nodeType: 3, textContent: text, nextSibling: null, __rect: rect };
+  }
+
+  function appendChild(parent: any, child: any) {
+    if (!parent.firstChild) { parent.firstChild = child; return; }
+    let last = parent.firstChild;
+    while (last.nextSibling) last = last.nextSibling;
+    last.nextSibling = child;
+  }
+
+  function run(js: string, root: any) {
+    const document = {
+      querySelectorAll: (_s: string) => [root],
+      createRange: () => ({
+        _n: null as any,
+        selectNode(this: any, n: any) { this._n = n; },
+        getBoundingClientRect(this: any) { return this._n.__rect; },
+      }),
+    };
+    const getComputedStyle = (el: any) => ({ visibility: "visible", display: el.__display ?? "block" });
+    const fn = new Function("document", "getComputedStyle", "return " + js);
+    return fn(document, getComputedStyle);
+  }
+
+  it("a display:contents <li> with a bare text child reads visible with the text's rect", () => {
+    const li = contentsEl("LI", "contents");
+    appendChild(li, textNode("Hoy", { x: 10, y: 20, width: 30, height: 12 }));
+
+    const actionable = run(buildActionableJs("li"), li);
+    expect(actionable).toEqual({ r: "ok", visible: true, enabled: true, editable: false, box: { x: 10, y: 20, width: 30, height: 12 } });
+
+    const box = run(buildBoxJs("li"), li);
+    expect(box).toEqual({ r: "ok", box: { x: 10, y: 20, width: 30, height: 12 } });
+  });
+
+  it("a display:contents element unions multiple visible children's rects", () => {
+    const container = contentsEl("DIV", "contents");
+    appendChild(container, textNode("a", { x: 0, y: 0, width: 10, height: 10 }));
+    appendChild(container, textNode("b", { x: 20, y: 5, width: 10, height: 10 }));
+
+    const box = run(buildBoxJs("div"), container);
+    expect(box).toEqual({ r: "ok", box: { x: 0, y: 0, width: 30, height: 15 } });
+  });
+
+  it("a display:contents element with no visible content is reported not_found / not visible", () => {
+    const li = contentsEl("LI", "contents");
+    appendChild(li, textNode("   ", { x: 0, y: 0, width: 0, height: 0 })); // whitespace-only text
+
+    expect(run(buildBoxJs("li"), li)).toEqual({ r: "not_found" });
+    const actionable = run(buildActionableJs("li"), li);
+    expect(actionable.visible).toBe(false);
+  });
+
+  it("a normal (non-contents) element is unaffected", () => {
+    const li = contentsEl("LI", "block");
+    li.__rect = { x: 1, y: 2, width: 3, height: 4 };
+
+    expect(run(buildBoxJs("li"), li)).toEqual({ r: "ok", box: { x: 1, y: 2, width: 3, height: 4 } });
   });
 });

--- a/tests/test_humanize_unit.py
+++ b/tests/test_humanize_unit.py
@@ -1267,6 +1267,66 @@ class TestBrowserPatching:
         browser.close()
 
 
+class TestDisplayContentsActionability:
+    """Regression #560: a Bootstrap-style toggled dropdown-menu whose <li> options
+    are reset with `display: contents` must not read as not-visible in-world, even
+    though getBoundingClientRect() on such an element is always {0,0,0,0}."""
+
+    _HTML = """
+        <div class="daterangepicker dropdown-menu opensright" style="display: block;">
+          <div class="ranges">
+            <ul>
+              <li style="display:contents" class="active" onclick="window.__clicked=true">Hoy</li>
+              <li style="display:contents">Ultimos 7 Dias</li>
+            </ul>
+          </div>
+        </div>
+    """
+
+    @staticmethod
+    def _inject(page, html):
+        # innerHTML on the already-loaded blank page -- avoids depending on a
+        # fresh navigation's load event, which set_content()/goto() require.
+        page.evaluate("html => { document.body.innerHTML = html; }", html)
+
+    def test_click_succeeds_on_display_contents_li(self):
+        from cloakbrowser import launch
+        browser = launch(headless=True, humanize=True)
+        page = browser.new_page()
+        self._inject(page, self._HTML)
+        assert page.locator("text=Hoy").is_visible()  # ground truth from real Playwright
+        page.click("text=Hoy", timeout=3000)
+        assert page.evaluate("window.__clicked") is True
+        browser.close()
+
+    def test_ensure_actionable_and_box_agree_with_playwright(self):
+        from cloakbrowser import launch
+        from cloakbrowser.human.actionability import ensure_actionable, CHECKS_CLICK
+        from cloakbrowser.human.scroll import _get_element_box
+        browser = launch(headless=True, humanize=True)
+        page = browser.new_page()
+        self._inject(page, self._HTML)
+        ensure_actionable(page, "text=Hoy", CHECKS_CLICK, timeout=1000)
+        box = _get_element_box(page, "text=Hoy")
+        assert box is not None and box["width"] > 0 and box["height"] > 0
+        browser.close()
+
+    def test_async_click_succeeds_on_display_contents_li(self):
+        import asyncio
+        from cloakbrowser import launch_async
+
+        async def _run():
+            browser = await launch_async(headless=True, humanize=True)
+            page = await browser.new_page()
+            await page.evaluate("html => { document.body.innerHTML = html; }", self._HTML)
+            assert await page.locator("text=Hoy").is_visible()
+            await page.click("text=Hoy", timeout=3000)
+            assert await page.evaluate("window.__clicked") is True
+            await browser.close()
+
+        asyncio.run(_run())
+
+
 @pytest.mark.slow
 class TestBrowserBotDetection:
     PROXY = None
@@ -2596,6 +2656,38 @@ class TestEnsureActionableStealth:
         with pytest.raises(ElementNotVisibleError):
             ensure_actionable(page, "#x", CHECKS_CLICK, timeout=100)
 
+    def test_not_visible_with_no_box_raises_without_cross_check(self):
+        """No geometry to cross-check against -> raise directly, no Playwright call (#560)."""
+        from cloakbrowser.human.actionability import ensure_actionable, CHECKS_CLICK, ElementNotVisibleError
+        page = _no_locator_page(_FakeWorld({"r": "ok", "visible": False, "enabled": True, "editable": True, "box": None}))
+        with pytest.raises(ElementNotVisibleError):
+            ensure_actionable(page, "#x", CHECKS_CLICK, timeout=100)
+
+    def test_not_visible_with_box_but_playwright_agrees_raises(self):
+        """Non-empty box, but Playwright's own is_visible() also says hidden -> still raise."""
+        from cloakbrowser.human.actionability import ensure_actionable, CHECKS_CLICK, ElementNotVisibleError
+        world = _FakeWorld({"r": "ok", "visible": False, "enabled": True, "editable": True,
+                             "box": {"x": 0, "y": 0, "width": 10, "height": 10}})
+        page = MagicMock()
+        page._stealth_world = world
+        loc = MagicMock()
+        loc.is_visible = MagicMock(return_value=False)
+        page.locator = MagicMock(return_value=MagicMock(first=loc))
+        with pytest.raises(ElementNotVisibleError):
+            ensure_actionable(page, "#x", CHECKS_CLICK, timeout=100)
+
+    def test_not_visible_with_box_and_playwright_disagrees_passes(self):
+        """Non-empty box + Playwright's real is_visible() says visible -> trust it, don't raise (#560)."""
+        from cloakbrowser.human.actionability import ensure_actionable, CHECKS_CLICK
+        world = _FakeWorld({"r": "ok", "visible": False, "enabled": True, "editable": True,
+                             "box": {"x": 0, "y": 0, "width": 10, "height": 10}})
+        page = MagicMock()
+        page._stealth_world = world
+        loc = MagicMock()
+        loc.is_visible = MagicMock(return_value=True)
+        page.locator = MagicMock(return_value=MagicMock(first=loc))
+        ensure_actionable(page, "#x", CHECKS_CLICK, timeout=100)  # must not raise
+
     def test_disabled_raises(self):
         from cloakbrowser.human.actionability import ensure_actionable, CHECKS_CLICK, ElementNotEnabledError
         page = _no_locator_page(_FakeWorld({"r": "ok", "visible": True, "enabled": False, "editable": True}))
@@ -2700,6 +2792,20 @@ class TestStealthAsync:
         box = {"x": 1.0, "y": 2.0, "width": 3.0, "height": 4.0}
         page = _no_locator_page(_AsyncFakeWorld({"r": "ok", "box": box}))
         assert asyncio.run(_get_element_box_async(page, "#x")) == box
+
+    def test_async_not_visible_with_box_and_playwright_disagrees_passes(self):
+        """Async mirror of the sync cross-check test (#560)."""
+        from unittest.mock import AsyncMock
+        from cloakbrowser.human.actionability_async import async_ensure_actionable
+        from cloakbrowser.human.actionability import CHECKS_CLICK
+        world = _AsyncFakeWorld({"r": "ok", "visible": False, "enabled": True, "editable": True,
+                                  "box": {"x": 0, "y": 0, "width": 10, "height": 10}})
+        page = MagicMock()
+        page._stealth_world = world
+        loc = MagicMock()
+        loc.is_visible = AsyncMock(return_value=True)
+        page.locator = MagicMock(return_value=MagicMock(first=loc))
+        asyncio.run(async_ensure_actionable(page, "#x", CHECKS_CLICK, timeout=100))  # must not raise
 
 
 # =========================================================================


### PR DESCRIPTION
## Bug

Reported: `humanize=True` `page.click()` (and other actions) fail with `ElementNotVisibleError` on an element that is demonstrably visible and rendered on screen — specifically reproduced on a Bootstrap-style toggled dropdown-menu `<li>` option. Regression from 0.5.6, when the isolated-world (CDP) actionability re-implementation replaced the previous real-Playwright `is_visible()`/`bounding_box()` calls.

## Root cause

The isolated-world visibility/geometry reads (`_ACTIONABLE_OP`/`_BOX_OP` in `stealth_dom.py`, mirrored in the JS and .NET ports) computed visibility and geometry from an element's own `getComputedStyle()` + `getBoundingClientRect()` only.

An element with `display: contents` (e.g. a reset `<li>` used by some custom dropdown/menu widgets to strip default list box styling while keeping DOM semantics) is *never itself boxed* — `getBoundingClientRect()` on it is always `{0,0,0,0}` — even though its children/text render normally. This exactly matches Playwright's own actionability engine (`packages/injected/src/domUtils.ts::computeBox`), which special-cases `display: contents` by recursing into children/text nodes instead of trusting the element's own empty rect. CloakBrowser's isolated-world reimplementation never added this special case, so it reported `visible: false` / no box indefinitely for such elements — a real, static CSS property, not a transient race — explaining why the retry loop never recovered.

## Fix

- Add a shared `__visBox()` helper to the isolated-world resolver JS (identical across Python, JS, and .NET) that recurses into child elements/text nodes for `display: contents`, unioning their rects. Used by both the box read and the actionable (visible/enabled/editable) read.
- `_ACTIONABLE_OP` now also returns the box alongside `visible`/`enabled`/`editable`.
- As defense-in-depth, `ensure_actionable`/`stealthActionable`/`EnsureActionableAsync` cross-check a `visible: false` in-world verdict against Playwright's own `is_visible()` before failing, whenever a non-empty box is present — matching the "only trust `not visible` when geometry is also absent/zero" pattern.

## Tests

- Python: new real-browser regression test (`TestDisplayContentsActionability` in `tests/test_humanize_unit.py`) reproducing a toggled `display:contents` dropdown; confirmed it fails with the pre-fix code (via git stash) and passes with the fix.
- JS: new `display:contents` behavioral tests in `js/tests/stealthDom.test.ts` executing the actual shipped resolver JS against a DOM stub, plus cross-check tests for `ensureActionable`.
- .NET: new Node-executed resolver test in `dotnet/tests/CloakBrowser.Tests/Human/StealthDomTests.cs` mirroring the JS test.

All existing unit tests pass unmodified (verified for Python and JS; .NET mirrored byte-for-byte from the tested JS/Python logic — could not compile locally, no dotnet SDK available in this environment).

## Changelog

Added an `[Unreleased]` entry in `CHANGELOG.md`.
